### PR TITLE
baro-plan-refinement

### DIFF
--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -138,6 +138,11 @@ pub struct App {
     // Resume mode
     pub is_resume: bool,
 
+    // Refinement
+    #[allow(dead_code)]
+    pub refine_input: Option<String>,
+    pub refining: bool,
+
     // Config
     pub parallel_limit: u32,
     pub timeout_secs: u64,
@@ -183,6 +188,8 @@ impl App {
             finalize_in_progress: false,
             pr_url: None,
             is_resume: false,
+            refine_input: None,
+            refining: false,
             parallel_limit: 0,
             timeout_secs: 600,
             global_tab: GlobalTab::Dashboard,

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -139,7 +139,6 @@ pub struct App {
     pub is_resume: bool,
 
     // Refinement
-    #[allow(dead_code)]
     pub refine_input: Option<String>,
     pub refining: bool,
 

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -284,7 +284,21 @@ async fn run_app(
                         }
                         _ => {}
                     },
-                    Screen::Review => match key.code {
+                    Screen::Review => if app.refine_input.is_some() {
+                        // Overlay is open — handle overlay keys only
+                        match key.code {
+                            KeyCode::Esc => { app.refine_input = None; }
+                            KeyCode::Char(c) => { app.refine_input.as_mut().unwrap().push(c); }
+                            KeyCode::Backspace => { app.refine_input.as_mut().unwrap().pop(); }
+                            _ => {}
+                        }
+                    } else {
+                        match key.code {
+                        KeyCode::Char('r') => {
+                            if !app.refining {
+                                app.refine_input = Some(String::new());
+                            }
+                        }
                         KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
                         KeyCode::Enter => {
                             if app.is_resume {
@@ -345,7 +359,7 @@ async fn run_app(
                         KeyCode::Up | KeyCode::Char('k') => app.review_prev(),
                         KeyCode::Down | KeyCode::Char('j') => app.review_next(),
                         _ => {}
-                    },
+                    }},
                     Screen::Execute => match key.code {
                         KeyCode::Char('q') => return Ok(()),
                         KeyCode::Char('1') => app.global_tab = app::GlobalTab::Dashboard,

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -59,9 +59,7 @@ enum AppEvent {
     Key(crossterm::event::KeyEvent),
     PlanReady(Vec<ReviewStory>, String, String, String),
     PlanError(String),
-    #[allow(dead_code)]
     RefineReady(Vec<ReviewStory>, String, String, String),
-    #[allow(dead_code)]
     RefineError(String),
     Tick,
 }
@@ -288,6 +286,14 @@ async fn run_app(
                         // Overlay is open — handle overlay keys only
                         match key.code {
                             KeyCode::Esc => { app.refine_input = None; }
+                            KeyCode::Enter => {
+                                let feedback = app.refine_input.as_ref().unwrap().clone();
+                                if !feedback.is_empty() {
+                                    app.refining = true;
+                                    app.refine_input = None;
+                                    spawn_refiner(&app, &feedback, &cwd, tx.clone());
+                                }
+                            }
                             KeyCode::Char(c) => { app.refine_input.as_mut().unwrap().push(c); }
                             KeyCode::Backspace => { app.refine_input.as_mut().unwrap().pop(); }
                             _ => {}
@@ -402,6 +408,92 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
             }
             Err(e) => {
                 let _ = tx.send(AppEvent::PlanError(e.to_string())).await;
+            }
+        }
+    });
+}
+
+fn spawn_refiner(app: &App, feedback: &str, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
+    let feedback = feedback.to_string();
+    let cwd = cwd.to_path_buf();
+
+    // Build current plan JSON from app state
+    let stories_json: Vec<serde_json::Value> = app.review_stories.iter().map(|s| {
+        serde_json::json!({
+            "id": s.id,
+            "title": s.title,
+            "description": s.description,
+            "dependsOn": s.depends_on,
+        })
+    }).collect();
+    let plan_json = serde_json::json!({
+        "project": app.project,
+        "branchName": app.branch_name,
+        "description": app.description,
+        "userStories": stories_json,
+    });
+    let plan_str = serde_json::to_string_pretty(&plan_json).unwrap_or_default();
+
+    tokio::spawn(async move {
+        let prompt = format!(
+            "Here is the current plan:\n{}\nThe user wants these changes: {}\nGenerate an updated plan with the same JSON schema. Keep stories the user did not mention unchanged. Output ONLY valid JSON, no markdown, no explanation.",
+            plan_str, feedback
+        );
+
+        let result = async {
+            let output = Command::new("claude")
+                .args([
+                    "--dangerously-skip-permissions",
+                    "--output-format", "json",
+                    "-p",
+                    &prompt,
+                ])
+                .current_dir(&cwd)
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()?
+                .wait_with_output()
+                .await?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                return Err(format!("Claude exited with {}: {}", output.status, stderr).into());
+            }
+
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let claude_output: serde_json::Value = serde_json::from_str(&stdout)
+                .map_err(|e| format!("Failed to parse Claude JSON wrapper: {}", e))?;
+
+            let plan_text = claude_output
+                .get("result")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&stdout);
+
+            let json_str = extract_json(plan_text);
+
+            let prd: PrdOutput = serde_json::from_str(&json_str)
+                .map_err(|e| format!("Failed to parse refined PRD JSON: {}\nRaw: {}", e, &json_str[..json_str.len().min(500)]))?;
+
+            let stories: Vec<ReviewStory> = prd.user_stories
+                .into_iter()
+                .map(|s| ReviewStory {
+                    id: s.id,
+                    title: s.title,
+                    description: s.description,
+                    depends_on: s.depends_on,
+                    completed: false,
+                })
+                .collect();
+
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>((stories, prd.project, prd.branch_name, prd.description))
+        }.await;
+
+        match result {
+            Ok((stories, project, branch, description)) => {
+                let _ = tx.send(AppEvent::RefineReady(stories, project, branch, description)).await;
+            }
+            Err(e) => {
+                let _ = tx.send(AppEvent::RefineError(e.to_string())).await;
             }
         }
     });

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -59,6 +59,10 @@ enum AppEvent {
     Key(crossterm::event::KeyEvent),
     PlanReady(Vec<ReviewStory>, String, String, String),
     PlanError(String),
+    #[allow(dead_code)]
+    RefineReady(Vec<ReviewStory>, String, String, String),
+    #[allow(dead_code)]
+    RefineError(String),
     Tick,
 }
 
@@ -236,6 +240,17 @@ async fn run_app(
                 app.show_review(stories);
             }
             Some(AppEvent::PlanError(err)) => {
+                app.planning_error = Some(err);
+            }
+            Some(AppEvent::RefineReady(stories, project, branch, description)) => {
+                app.refining = false;
+                app.project = project;
+                app.branch_name = branch;
+                app.description = description;
+                app.show_review(stories);
+            }
+            Some(AppEvent::RefineError(err)) => {
+                app.refining = false;
                 app.planning_error = Some(err);
             }
             Some(AppEvent::Key(key)) => {

--- a/crates/baro-tui/src/screens/review.rs
+++ b/crates/baro-tui/src/screens/review.rs
@@ -1,10 +1,8 @@
 use ratatui::{
-    layout::{Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{
-        Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap,
-    },
+    widgets::{Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap},
     Frame,
 };
 
@@ -218,4 +216,73 @@ pub fn render(f: &mut Frame, app: &App) {
         Span::styled(":quit", Style::default().fg(theme::MUTED)),
     ]));
     f.render_widget(footer, chunks[2]);
+
+    // Refine input overlay
+    if let Some(ref input) = app.refine_input {
+        let overlay_area = centered_rect(60, 5, area);
+
+        f.render_widget(Clear, overlay_area);
+
+        let cursor_char = if app.tick_count % 10 < 5 { "\u{2588}" } else { " " };
+        let input_line = Line::from(vec![
+            Span::styled(input.as_str(), Style::default().fg(theme::TEXT)),
+            Span::styled(cursor_char, Style::default().fg(theme::ACCENT)),
+        ]);
+        let hint_line = Line::from(Span::styled(
+            "Enter:send  Esc:cancel",
+            Style::default().fg(theme::MUTED),
+        ));
+
+        let paragraph = Paragraph::new(vec![input_line, Line::from(""), hint_line])
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(theme::ACCENT))
+                    .title(Span::styled(
+                        " Refine Plan ",
+                        Style::default()
+                            .fg(theme::ACCENT)
+                            .add_modifier(Modifier::BOLD),
+                    )),
+            )
+            .wrap(Wrap { trim: false });
+        f.render_widget(paragraph, overlay_area);
+    } else if app.refining {
+        let overlay_area = centered_rect(30, 3, area);
+
+        f.render_widget(Clear, overlay_area);
+
+        let paragraph = Paragraph::new(Line::from(Span::styled(
+            "Refining...",
+            Style::default()
+                .fg(theme::ACCENT)
+                .add_modifier(Modifier::BOLD),
+        )))
+        .alignment(Alignment::Center)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(theme::ACCENT)),
+        );
+        f.render_widget(paragraph, overlay_area);
+    }
+}
+
+fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length((area.height.saturating_sub(height)) / 2),
+            Constraint::Length(height),
+            Constraint::Min(0),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Min(0),
+        ])
+        .split(vertical[1])[1]
 }

--- a/prd.json
+++ b/prd.json
@@ -1,65 +1,66 @@
 {
-  "branchName": "feat/parallel-limit-and-story-timeout",
-  "description": "Add configurable parallelism (--parallel N) and story timeout (--timeout SECONDS) CLI flags with TUI display",
-  "project": "baro-parallelism-timeout",
+  "branchName": "feat/plan-refinement-overlay",
+  "description": "Add plan refinement overlay to review screen with Claude-powered plan editing",
+  "project": "baro-plan-refinement",
   "userStories": [
     {
       "acceptance": [],
-      "completedAt": "2026-03-26T17:54:27.441990+00:00",
+      "completedAt": "2026-03-26T18:09:40.165561+00:00",
       "dependsOn": [],
-      "description": "In main.rs, add two new fields to the Cli struct: `parallel` (u32, long flag, default 0 meaning unlimited) and `timeout` (u64, long flag, default 600). Pass both values through spawn_executor to run_executor. Update run_executor signature to accept parallel: u32 and timeout_secs: u64 parameters. In spawn_executor, accept and forward these values. Do NOT yet implement semaphore or timeout logic - just thread the values through. Update both call sites of spawn_executor (line 281 and 312 in main.rs) to pass the CLI values.",
-      "durationSecs": 784,
+      "description": "Add `refine_input: Option<String>` field to the App struct in app.rs, initialized to None in App::new(). Add `refining: bool` field to track when a refinement request is in-flight. Add a `RefineReady` variant to the AppEvent enum in main.rs: `RefineReady(Vec<ReviewStory>, String, String, String)` (same shape as PlanReady) and a `RefineError(String)` variant. Ensure `cargo build` passes with zero warnings — all new fields and variants must be used or prefixed with _ if temporarily unused.",
+      "durationSecs": 83,
       "id": "S1",
       "passes": true,
       "priority": 1,
       "retries": 2,
       "tests": [],
-      "title": "Add --parallel and --timeout CLI flags"
+      "title": "Add refine_input field and RefineReady event to App"
     },
     {
       "acceptance": [],
-      "completedAt": "2026-03-26T17:55:45.270633+00:00",
+      "completedAt": null,
       "dependsOn": [
         "S1"
       ],
-      "description": "In executor.rs run_executor, implement configurable parallelism using tokio::sync::Semaphore. If parallel > 0, create an Arc<Semaphore> with parallel permits. In the level execution loop (around line 891-904), instead of spawning all stories immediately, acquire a semaphore permit before spawning each story's execute_story call. If parallel is 0, use no semaphore (current unlimited behavior). The semaphore should be created once before the level loop. Each story task should acquire a permit at the start and hold it until execute_story completes. Make sure to clone the Arc<Semaphore> for each spawned task.",
-      "durationSecs": 53,
+      "description": "In the main event loop in main.rs, in the Screen::Review key handler: when 'r' is pressed and app.refine_input is None and app.refining is false, set app.refine_input = Some(String::new()) to open the overlay. When app.refine_input is Some (overlay is open), handle: KeyCode::Esc sets app.refine_input = None (cancel), KeyCode::Char(c) pushes to the string, KeyCode::Backspace pops from the string. The overlay input handling must come BEFORE the existing review key handling so it takes priority when the overlay is open. When overlay is open, do NOT process other review keys (scroll, quit, accept). Ensure cargo build passes with zero warnings.",
+      "durationSecs": null,
       "id": "S2",
-      "passes": true,
+      "passes": false,
       "priority": 2,
       "retries": 2,
       "tests": [],
-      "title": "Implement semaphore-based parallelism limiting in executor"
+      "title": "Wire up 'r' key to open refine overlay and Esc to close it"
     },
     {
       "acceptance": [],
-      "completedAt": "2026-03-26T17:58:14.710856+00:00",
+      "completedAt": null,
       "dependsOn": [
         "S1"
       ],
-      "description": "In executor.rs run_claude_for_story, wrap the entire claude process execution (spawn, stdout/stderr reading, wait) in a tokio::time::timeout of timeout_secs duration. Add timeout_secs: u64 parameter to run_claude_for_story. Thread it from execute_story (which also needs the parameter added) and from run_executor. If the timeout expires: (1) kill the child process with child.kill(), (2) log a timeout message via tx.send(BaroEvent::StoryLog) with format '[timeout] Story {story_id} killed after {timeout_secs}s', (3) return Err(format!('Story timed out after {timeout_secs}s')). The story will then retry per normal retry logic in execute_story. Also update the call to run_claude_for_story in execute_story to pass timeout_secs. Update any other callers of execute_story to pass timeout_secs as well (e.g., review fix story execution around line 700+).",
-      "durationSecs": 202,
+      "description": "In screens/review.rs, after the main review render, if app.refine_input is Some, render a centered overlay box on top of the review screen. The overlay should be a Block with title ' Refine Plan ' and borders, containing: a Paragraph showing the current input text with a blinking cursor (use app.tick_count % 10 < 5 for blink). The overlay should be roughly 60% width and 5 lines tall, centered in the screen area using ratatui Layout. Show a hint line below the input: 'Enter:send  Esc:cancel'. Use Clear widget or render a background block to make the overlay stand out. Use theme::ACCENT for the border color. Also render a 'Refining...' indicator if app.refining is true and refine_input is None. Ensure cargo build passes with zero warnings.",
+      "durationSecs": null,
       "id": "S3",
-      "passes": true,
+      "passes": false,
       "priority": 3,
       "retries": 2,
       "tests": [],
-      "title": "Implement story timeout in run_claude_for_story"
+      "title": "Render refine input overlay on review screen"
     },
     {
       "acceptance": [],
-      "completedAt": "2026-03-26T17:55:55.523193+00:00",
+      "completedAt": null,
       "dependsOn": [
-        "S1"
+        "S2",
+        "S3"
       ],
-      "description": "Show the parallelism limit and timeout in the TUI execute screen header. In app.rs, add two fields to the App struct: parallel_limit: u32 and timeout_secs: u64, with defaults 0 and 600. Set these values in main.rs when creating the App (pass from CLI args). In screens/execute.rs render_header function, add two new spans to the info_line after the completed/total span: (1) 'parallel: N' or 'parallel: ∞' if 0, styled with theme::MUTED, (2) 'timeout: Ns' styled with theme::MUTED. Use the same separator pattern (│) as existing spans. Make sure to widen the header min constraint if needed to accommodate the new text.",
-      "durationSecs": 65,
+      "description": "In main.rs: (1) Add a `spawn_refiner` function similar to `spawn_planner` that takes the current plan JSON and user feedback, constructs a refinement prompt, spawns `claude --dangerously-skip-permissions --output-format json -p <prompt>`, parses the response using the existing PrdOutput struct and extract_json function, and sends RefineReady or RefineError via the channel. The refinement prompt should be: 'Here is the current plan:\\n<plan JSON>\\nThe user wants these changes: <feedback>\\nGenerate an updated plan with the same JSON schema. Keep stories the user did not mention unchanged. Output ONLY valid JSON, no markdown, no explanation.' To build the current plan JSON, serialize a PrdOutput-compatible struct from app.project, app.branch_name, app.description, and app.review_stories. (2) In the event loop, when Enter is pressed while refine_input is Some and the input is non-empty: take the feedback string, set app.refining = true, set app.refine_input = None, and call spawn_refiner. (3) Handle RefineReady: set app.refining = false, call app.show_review(stories), update app.project/branch_name/description. (4) Handle RefineError: set app.refining = false, set app.planning_error = Some(err). Ensure cargo build passes with zero warnings.",
+      "durationSecs": null,
       "id": "S4",
-      "passes": true,
+      "passes": false,
       "priority": 4,
       "retries": 2,
       "tests": [],
-      "title": "Display parallelism and timeout in TUI header"
+      "title": "Implement refinement Claude call and response handling"
     }
   ]
 }

--- a/prd.json
+++ b/prd.json
@@ -18,14 +18,14 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T18:10:50.935925+00:00",
       "dependsOn": [
         "S1"
       ],
       "description": "In the main event loop in main.rs, in the Screen::Review key handler: when 'r' is pressed and app.refine_input is None and app.refining is false, set app.refine_input = Some(String::new()) to open the overlay. When app.refine_input is Some (overlay is open), handle: KeyCode::Esc sets app.refine_input = None (cancel), KeyCode::Char(c) pushes to the string, KeyCode::Backspace pops from the string. The overlay input handling must come BEFORE the existing review key handling so it takes priority when the overlay is open. When overlay is open, do NOT process other review keys (scroll, quit, accept). Ensure cargo build passes with zero warnings.",
-      "durationSecs": null,
+      "durationSecs": 58,
       "id": "S2",
-      "passes": false,
+      "passes": true,
       "priority": 2,
       "retries": 2,
       "tests": [],

--- a/prd.json
+++ b/prd.json
@@ -48,15 +48,15 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T18:12:59.283657+00:00",
       "dependsOn": [
         "S2",
         "S3"
       ],
       "description": "In main.rs: (1) Add a `spawn_refiner` function similar to `spawn_planner` that takes the current plan JSON and user feedback, constructs a refinement prompt, spawns `claude --dangerously-skip-permissions --output-format json -p <prompt>`, parses the response using the existing PrdOutput struct and extract_json function, and sends RefineReady or RefineError via the channel. The refinement prompt should be: 'Here is the current plan:\\n<plan JSON>\\nThe user wants these changes: <feedback>\\nGenerate an updated plan with the same JSON schema. Keep stories the user did not mention unchanged. Output ONLY valid JSON, no markdown, no explanation.' To build the current plan JSON, serialize a PrdOutput-compatible struct from app.project, app.branch_name, app.description, and app.review_stories. (2) In the event loop, when Enter is pressed while refine_input is Some and the input is non-empty: take the feedback string, set app.refining = true, set app.refine_input = None, and call spawn_refiner. (3) Handle RefineReady: set app.refining = false, call app.show_review(stories), update app.project/branch_name/description. (4) Handle RefineError: set app.refining = false, set app.planning_error = Some(err). Ensure cargo build passes with zero warnings.",
-      "durationSecs": null,
+      "durationSecs": 76,
       "id": "S4",
-      "passes": false,
+      "passes": true,
       "priority": 4,
       "retries": 2,
       "tests": [],

--- a/prd.json
+++ b/prd.json
@@ -33,14 +33,14 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T18:11:22.785694+00:00",
       "dependsOn": [
         "S1"
       ],
       "description": "In screens/review.rs, after the main review render, if app.refine_input is Some, render a centered overlay box on top of the review screen. The overlay should be a Block with title ' Refine Plan ' and borders, containing: a Paragraph showing the current input text with a blinking cursor (use app.tick_count % 10 < 5 for blink). The overlay should be roughly 60% width and 5 lines tall, centered in the screen area using ratatui Layout. Show a hint line below the input: 'Enter:send  Esc:cancel'. Use Clear widget or render a background block to make the overlay stand out. Use theme::ACCENT for the border color. Also render a 'Refining...' indicator if app.refining is true and refine_input is None. Ensure cargo build passes with zero warnings.",
-      "durationSecs": null,
+      "durationSecs": 91,
       "id": "S3",
-      "passes": false,
+      "passes": true,
       "priority": 3,
       "retries": 2,
       "tests": [],


### PR DESCRIPTION
## baro-plan-refinement

Add plan refinement overlay to review screen with Claude-powered plan editing

### Completed Stories

- **S1**: Add refine_input field and RefineReady event to App (83s)
- **S2**: Wire up 'r' key to open refine overlay and Esc to close it (58s)
- **S3**: Render refine input overlay on review screen (91s)
- **S4**: Implement refinement Claude call and response handling (76s)

### Stats

- Files created: 0
- Files modified: 9
- Total time: 299s
- Completed: 4
- Skipped: 0
