### PR TITLE
fix-speedup-calculation

### DIFF
--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -1172,29 +1172,37 @@ pub async fn run_executor(
         } else {
             format!("{}s", total_time_secs)
         };
-        let time_saved = sequential_time.saturating_sub(total_time_secs);
-        let time_saved_str = if time_saved >= 60 {
-            format!("{}m {}s", time_saved / 60, time_saved % 60)
-        } else {
-            format!("{}s", time_saved)
-        };
-        let speedup = if total_time_secs > 0 {
-            format!("{:.1}x", sequential_time as f64 / total_time_secs as f64)
-        } else {
-            "–".to_string()
-        };
         let total_stories = current_prd.user_stories.len();
+        let parallelism_stats = if total_stories > 1 {
+            let time_saved = sequential_time.saturating_sub(total_time_secs);
+            let time_saved_str = if time_saved >= 60 {
+                format!("{}m {}s", time_saved / 60, time_saved % 60)
+            } else {
+                format!("{}s", time_saved)
+            };
+            let raw_speedup = if total_time_secs > 0 {
+                sequential_time as f64 / total_time_secs as f64
+            } else {
+                1.0
+            };
+            let clamped_speedup = if raw_speedup < 1.0 { 1.0 } else { raw_speedup };
+            format!(
+                "- **Time saved:** {} (parallelism)\n\
+                 - **Speedup:** {:.1}x\n",
+                time_saved_str, clamped_speedup
+            )
+        } else {
+            String::new()
+        };
         body.push_str(&format!(
             "\n## Stats\n\n\
              - **Wall time:** {}\n\
-             - **Time saved:** {} (parallelism)\n\
-             - **Speedup:** {}\n\
+             {}\
              - **Files created:** {}\n\
              - **Files modified:** {}\n\
              - **Stories:** {}/{} completed, {} skipped\n",
             wall_time_str,
-            time_saved_str,
-            speedup,
+            parallelism_stats,
             total_files_created,
             total_files_modified,
             completed,

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -491,6 +491,7 @@ struct ReviewFix {
     description: String,
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_review_for_level(
     saved_hash: &str,
     cwd: &Path,

--- a/crates/baro-tui/src/screens/execute_completion.rs
+++ b/crates/baro-tui/src/screens/execute_completion.rs
@@ -37,11 +37,15 @@ pub fn render_completion(f: &mut Frame, app: &App) {
         .filter_map(|s| s.duration_secs)
         .sum();
     let wall_time = app.total_time_secs;
-    let saved_secs = sequential_time.saturating_sub(wall_time);
     let multiplier = if wall_time > 0 {
-        sequential_time as f64 / wall_time as f64
+        (sequential_time as f64 / wall_time as f64).max(1.0)
     } else {
         1.0
+    };
+    let saved_secs = if multiplier > 1.0 {
+        sequential_time.saturating_sub(wall_time)
+    } else {
+        0
     };
 
     let mut lines = vec![
@@ -91,9 +95,12 @@ pub fn render_completion(f: &mut Frame, app: &App) {
                     .add_modifier(Modifier::BOLD),
             ),
         ]),
-        Line::from(vec![
+    ];
+
+    if app.total > 1 {
+        lines.push(Line::from(vec![
             Span::styled("  Time saved:     ", Style::default().fg(theme::MUTED)),
-            if app.total > 1 && multiplier > 1.0 {
+            if multiplier > 1.0 {
                 Span::styled(
                     format!(
                         "{}:{:02} with parallel execution ({:.1}x speedup)",
@@ -108,7 +115,10 @@ pub fn render_completion(f: &mut Frame, app: &App) {
             } else {
                 Span::styled("Parallelism: 1.0x", Style::default().fg(theme::MUTED))
             },
-        ]),
+        ]));
+    }
+
+    lines.extend(vec![
         Line::from(vec![
             Span::styled("  Files created:  ", Style::default().fg(theme::MUTED)),
             Span::styled(
@@ -141,7 +151,7 @@ pub fn render_completion(f: &mut Frame, app: &App) {
                 ),
             ),
         ]),
-    ];
+    ]);
 
     if let Some(ref url) = app.pr_url {
         lines.push(Line::from(vec![

--- a/crates/baro-tui/src/screens/execute_stats.rs
+++ b/crates/baro-tui/src/screens/execute_stats.rs
@@ -146,42 +146,34 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
         ]),
     ];
 
-    // Third line: time saved
+    // Third line: time saved (only shown for multiple stories)
     let completed_count = completed_stories.len();
-    let multiplier = if wall_time > 0 {
-        sequential_time as f64 / wall_time as f64
-    } else {
-        1.0
-    };
-    if completed_count >= 2 && multiplier > 1.0 {
-        let saved_time = sequential_time.saturating_sub(wall_time);
-        summary_lines.push(Line::from(vec![
-            Span::styled("  Saved: ", Style::default().fg(theme::MUTED)),
-            Span::styled(
-                format!("{}:{:02}", saved_time / 60, saved_time % 60),
-                Style::default()
-                    .fg(theme::SUCCESS)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" (", Style::default().fg(theme::MUTED)),
-            Span::styled(
-                format!("{:.1}x", multiplier),
-                Style::default()
-                    .fg(theme::ACCENT)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" faster)", Style::default().fg(theme::MUTED)),
-        ]));
-    } else {
-        summary_lines.push(Line::from(vec![
-            Span::styled("  Saved: ", Style::default().fg(theme::MUTED)),
-            Span::styled(
-                "1.0x",
-                Style::default()
-                    .fg(theme::ACCENT)
-                    .add_modifier(Modifier::BOLD),
-            ),
-        ]));
+    if completed_count > 1 {
+        let multiplier = if wall_time > 0 {
+            (sequential_time as f64 / wall_time as f64).max(1.0)
+        } else {
+            1.0
+        };
+        if multiplier > 1.0 {
+            let saved_time = sequential_time.saturating_sub(wall_time);
+            summary_lines.push(Line::from(vec![
+                Span::styled("  Saved: ", Style::default().fg(theme::MUTED)),
+                Span::styled(
+                    format!("{}:{:02}", saved_time / 60, saved_time % 60),
+                    Style::default()
+                        .fg(theme::SUCCESS)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" (", Style::default().fg(theme::MUTED)),
+                Span::styled(
+                    format!("{:.1}x", multiplier),
+                    Style::default()
+                        .fg(theme::ACCENT)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" faster)", Style::default().fg(theme::MUTED)),
+            ]));
+        }
     }
 
     let summary = Paragraph::new(summary_lines).block(

--- a/prd.json
+++ b/prd.json
@@ -1,20 +1,63 @@
 {
-  "branchName": "feat/completion-notification",
-  "description": "Send OS notification and terminal bell when all stories complete",
-  "project": "baro-completion-notification",
+  "branchName": "fix/speedup-floor-and-single-story",
+  "description": "Floor speedup to 1.0x minimum and hide time-saved for single-story runs",
+  "project": "fix-speedup-calculation",
   "userStories": [
     {
       "acceptance": [],
-      "completedAt": "2026-03-26T18:42:30.848047+00:00",
+      "completedAt": "2026-03-26T19:02:20.140597+00:00",
       "dependsOn": [],
-      "description": "In crates/baro-tui/src/executor.rs, right after the Done event is sent (around line 1074), add a notification block: (1) print terminal bell with print!(\"\\x07\"), (2) detect OS at runtime using std::env::consts::OS, (3) on \"macos\" run osascript -e 'display notification \"baro: all stories complete\" with title \"baro\"' via std::process::Command (not tokio, to keep it simple), (4) on \"linux\" run notify-send \"baro\" \"all stories complete\" via std::process::Command. All notification calls must be best-effort: ignore any errors from Command spawning or execution (use .ok() or let _ =). Do NOT add any new modules or files — keep all code inline in executor.rs. Ensure cargo build completes with zero warnings (no unused imports, no dead code).",
-      "durationSecs": 29,
+      "description": "In crates/baro-tui/src/executor.rs lines 1181-1203: 1) Clamp the speedup to a minimum of 1.0 — if sequential_time/total_time_secs < 1.0, display '1.0x' instead. 2) If there is only 1 story (total_stories == 1), skip the 'Time saved' and 'Speedup' lines entirely from the PR body stats section. Keep the rest of the stats (wall time, files, stories). Ensure no unused variable warnings — remove time_saved_str and speedup variables when they are not emitted, or gate their computation behind the same condition.",
+      "durationSecs": 110,
       "id": "S1",
       "passes": true,
       "priority": 1,
       "retries": 2,
       "tests": [],
-      "title": "Add completion notification after Done event"
+      "title": "Fix speedup in executor.rs PR body"
+    },
+    {
+      "acceptance": [],
+      "completedAt": "2026-03-26T19:01:19.813291+00:00",
+      "dependsOn": [],
+      "description": "In crates/baro-tui/src/screens/execute_stats.rs lines 149-185: 1) After computing multiplier, clamp it: if multiplier < 1.0, set it to 1.0. 2) If completed_count <= 1, skip the 'Saved:' line entirely (do not push any summary_line for saved time). Currently the else branch on line 175-185 shows '1.0x' — for single story, remove that line too so nothing about savings is shown. Ensure no unused variable warnings.",
+      "durationSecs": 49,
+      "id": "S2",
+      "passes": true,
+      "priority": 2,
+      "retries": 2,
+      "tests": [],
+      "title": "Fix speedup in execute_stats.rs stats tab"
+    },
+    {
+      "acceptance": [],
+      "completedAt": "2026-03-26T19:01:45.813571+00:00",
+      "dependsOn": [],
+      "description": "In crates/baro-tui/src/screens/execute_completion.rs lines 34-111: 1) Clamp multiplier to minimum 1.0 — if sequential_time/wall_time < 1.0, use 1.0. 2) If app.total == 1 (single story), skip the 'Time saved:' line entirely from the completion overlay. Currently lines 94-111 conditionally show either the time saved or 'Parallelism: 1.0x' — for single story, omit the entire Line::from block. Ensure no unused variable warnings (saved_secs may become unused when single story).",
+      "durationSecs": 77,
+      "id": "S3",
+      "passes": true,
+      "priority": 3,
+      "retries": 2,
+      "tests": [],
+      "title": "Fix speedup in execute_completion.rs overlay"
+    },
+    {
+      "acceptance": [],
+      "completedAt": null,
+      "dependsOn": [
+        "S1",
+        "S2",
+        "S3"
+      ],
+      "description": "Run cargo build (and cargo clippy if available) across the entire workspace to verify there are zero warnings and zero errors after the changes from S1, S2, and S3. Fix any remaining warnings (unused variables, dead code, etc.) that may have been introduced.",
+      "durationSecs": null,
+      "id": "S4",
+      "passes": false,
+      "priority": 4,
+      "retries": 2,
+      "tests": [],
+      "title": "Final cargo build zero-warnings check"
     }
   ]
 }

--- a/prd.json
+++ b/prd.json
@@ -44,16 +44,16 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T19:03:14.437069+00:00",
       "dependsOn": [
         "S1",
         "S2",
         "S3"
       ],
       "description": "Run cargo build (and cargo clippy if available) across the entire workspace to verify there are zero warnings and zero errors after the changes from S1, S2, and S3. Fix any remaining warnings (unused variables, dead code, etc.) that may have been introduced.",
-      "durationSecs": null,
+      "durationSecs": 33,
       "id": "S4",
-      "passes": false,
+      "passes": true,
       "priority": 4,
       "retries": 2,
       "tests": [],


### PR DESCRIPTION
Floor speedup to 1

## Stories

| ID | Title | Duration | Status |
|:---|:------|:---------|:-------|
| S1 | Fix speedup in executor.rs PR body | 1m 50s | Done |
| S2 | Fix speedup in execute_stats.rs stats tab | 49s | Done |
| S3 | Fix speedup in execute_completion.rs overlay | 1m 17s | Done |
| S4 | Final cargo build zero-warnings check | 33s | Done |

## Stats

- **Wall time:** 2m 59s
- **Time saved:** 1m 30s (parallelism)
- **Speedup:** 1.5x
- **Files created:** 0
- **Files modified:** 5
- **Stories:** 4/4 completed, 0 skipped

## Review

- **Review cycles:** 2
- **Fixes auto-applied:** 0

---

Built with [baro](https://www.npmjs.com/package/baro-ai) — Background Agent Runtime Orchestrator
