### PR TITLE
baro-model-routing

### DIFF
--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -89,6 +89,7 @@ pub struct ReviewStory {
     pub description: String,
     pub depends_on: Vec<String>,
     pub completed: bool,
+    pub model: Option<String>,
 }
 
 pub struct App {

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -146,6 +146,10 @@ pub struct App {
     pub parallel_limit: u32,
     pub timeout_secs: u64,
 
+    // Model routing
+    pub model_routing: bool,
+    pub override_model: Option<String>,
+
     // UI state
     pub global_tab: GlobalTab,
     pub selected_log_index: usize,
@@ -191,6 +195,8 @@ impl App {
             refining: false,
             parallel_limit: 0,
             timeout_secs: 600,
+            model_routing: true,
+            override_model: None,
             global_tab: GlobalTab::Dashboard,
             selected_log_index: 0,
             tick_count: 0,
@@ -453,5 +459,21 @@ impl App {
         } else {
             self.start_time.elapsed().as_secs()
         }
+    }
+
+    #[allow(dead_code)]
+    pub fn model_for_phase(&self, phase: &str) -> Option<String> {
+        if let Some(ref model) = self.override_model {
+            return Some(model.clone());
+        }
+        if self.model_routing {
+            return match phase {
+                "planning" => Some("opus".to_string()),
+                "execution" => Some("sonnet".to_string()),
+                "review" => Some("haiku".to_string()),
+                _ => None,
+            };
+        }
+        None
     }
 }

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -461,7 +461,6 @@ impl App {
         }
     }
 
-    #[allow(dead_code)]
     pub fn model_for_phase(&self, phase: &str) -> Option<String> {
         if let Some(ref model) = self.override_model {
             return Some(model.clone());

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -169,6 +169,32 @@ fn parse_claude_stream_line(line: &str, _story_id: &str) -> Vec<String> {
     logs
 }
 
+// ─── Model resolution helper ────────────────────────────────
+
+fn resolve_model(
+    override_model: &Option<String>,
+    story_model: &Option<String>,
+    model_routing: bool,
+    phase: &str, // "execute" or "review"
+) -> Option<String> {
+    if let Some(ref m) = override_model {
+        return Some(m.clone());
+    }
+    if let Some(ref m) = story_model {
+        return Some(m.clone());
+    }
+    if model_routing {
+        return Some(
+            match phase {
+                "review" => "haiku",
+                _ => "sonnet",
+            }
+            .to_string(),
+        );
+    }
+    None
+}
+
 // ─── Execute a single story ─────────────────────────────────
 
 async fn execute_story(
@@ -178,6 +204,7 @@ async fn execute_story(
     tx: &mpsc::Sender<BaroEvent>,
     git_mutex: &Mutex<()>,
     timeout_secs: u64,
+    model: Option<String>,
 ) -> Result<(u64, u32, u32), String> {
     let max_attempts = story.retries + 1;
 

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -45,6 +45,8 @@ pub struct PrdStory {
     pub completed_at: Option<String>,
     #[serde(rename = "durationSecs", default)]
     pub duration_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 fn default_retries() -> u32 {
@@ -781,6 +783,7 @@ async fn run_review_for_level(
                 passes: false,
                 completed_at: None,
                 duration_secs: None,
+                model: None,
             };
 
             match execute_story(&fix_story, cwd, prd_path, tx, git_mutex, timeout_secs).await {
@@ -1295,6 +1298,7 @@ pub fn prd_from_review(
                 passes: false,
                 completed_at: None,
                 duration_secs: None,
+                model: None,
             })
             .collect(),
     }

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -1377,7 +1377,7 @@ pub fn prd_from_review(
                 passes: false,
                 completed_at: None,
                 duration_secs: None,
-                model: None,
+                model: s.model.clone(),
             })
             .collect(),
     }

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -216,6 +216,16 @@ async fn execute_story(
             })
             .await;
 
+        let model_label = model
+            .as_deref()
+            .unwrap_or("default");
+        let _ = tx
+            .send(BaroEvent::StoryLog {
+                id: story.id.clone(),
+                line: format!("[model] using {}", model_label),
+            })
+            .await;
+
         // Git pull --rebase before running claude (best-effort, never fatal)
         {
             let _git_lock = git_mutex.lock().await;
@@ -225,7 +235,8 @@ async fn execute_story(
         let start = Instant::now();
         let prompt = build_prompt(story, cwd);
 
-        let result = run_claude_for_story(&story.id, &prompt, cwd, tx, timeout_secs).await;
+        let result =
+            run_claude_for_story(&story.id, &prompt, cwd, tx, timeout_secs, &model).await;
 
         let duration_secs = start.elapsed().as_secs();
 
@@ -292,16 +303,24 @@ async fn run_claude_for_story(
     cwd: &Path,
     tx: &mpsc::Sender<BaroEvent>,
     timeout_secs: u64,
+    model: &Option<String>,
 ) -> Result<(), String> {
+    let mut args = vec![
+        "--dangerously-skip-permissions",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "-p",
+        prompt,
+    ];
+    let model_owned;
+    if let Some(ref m) = model {
+        model_owned = m.clone();
+        args.push("--model");
+        args.push(&model_owned);
+    }
     let mut child = Command::new("claude")
-        .args([
-            "--dangerously-skip-permissions",
-            "--output-format",
-            "stream-json",
-            "--verbose",
-            "-p",
-            prompt,
-        ])
+        .args(&args)
         .current_dir(cwd)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
@@ -530,6 +549,8 @@ async fn run_review_for_level(
     prd_path: &Path,
     level_index: usize,
     timeout_secs: u64,
+    model_routing: bool,
+    override_model: &Option<String>,
 ) -> (u32, u32) {
     let mut cycles_run: u32 = 0;
     let mut total_fixes_applied: u32 = 0;
@@ -667,6 +688,14 @@ async fn run_review_for_level(
             }
         );
 
+        let review_model = resolve_model(override_model, &None, model_routing, "review");
+        let review_model_label = review_model.as_deref().unwrap_or("default");
+        let _ = tx
+            .send(BaroEvent::ReviewLog {
+                line: format!("[model] review using {}", review_model_label),
+            })
+            .await;
+
         let _ = tx
             .send(BaroEvent::ReviewLog {
                 line: "Spawning Claude for review...".to_string(),
@@ -674,14 +703,19 @@ async fn run_review_for_level(
             .await;
 
         // Spawn claude for review
+        let mut review_args = vec![
+            "--dangerously-skip-permissions".to_string(),
+            "--output-format".to_string(),
+            "json".to_string(),
+            "-p".to_string(),
+            prompt.clone(),
+        ];
+        if let Some(ref m) = review_model {
+            review_args.push("--model".to_string());
+            review_args.push(m.clone());
+        }
         let child_result = Command::new("claude")
-            .args([
-                "--dangerously-skip-permissions",
-                "--output-format",
-                "json",
-                "-p",
-                &prompt,
-            ])
+            .args(&review_args)
             .current_dir(cwd)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
@@ -813,7 +847,10 @@ async fn run_review_for_level(
                 model: None,
             };
 
-            match execute_story(&fix_story, cwd, prd_path, tx, git_mutex, timeout_secs).await {
+            let fix_model = resolve_model(override_model, &None, model_routing, "execute");
+            match execute_story(&fix_story, cwd, prd_path, tx, git_mutex, timeout_secs, fix_model)
+                .await
+            {
                 Ok(_) => {
                     let _ = tx
                         .send(BaroEvent::ReviewLog {
@@ -864,6 +901,8 @@ pub async fn run_executor(
     tx: mpsc::Sender<BaroEvent>,
     parallel: u32,
     timeout_secs: u64,
+    model_routing: bool,
+    override_model: Option<String>,
 ) {
     let prd_path = cwd.join("prd.json");
     let stories = &prd.user_stories;
@@ -972,13 +1011,24 @@ pub async fn run_executor(
             let git_mutex = Arc::clone(&git_mutex);
 
             let semaphore = semaphore.clone();
+            let story_model =
+                resolve_model(&override_model, &story.model, model_routing, "execute");
             let handle = tokio::spawn(async move {
                 let _permit = if let Some(ref sem) = semaphore {
                     Some(sem.acquire().await.expect("semaphore closed"))
                 } else {
                     None
                 };
-                execute_story(&story, &cwd, &prd_path, &tx, &git_mutex, timeout_secs).await
+                execute_story(
+                    &story,
+                    &cwd,
+                    &prd_path,
+                    &tx,
+                    &git_mutex,
+                    timeout_secs,
+                    story_model,
+                )
+                .await
             });
             handles.push((story_id.clone(), handle));
         }
@@ -1047,6 +1097,8 @@ pub async fn run_executor(
                 &prd_path,
                 level_index,
                 timeout_secs,
+                model_routing,
+                &override_model,
             )
             .await;
             review_cycles += cycles;

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -133,6 +133,8 @@ struct PrdStoryOutput {
     #[serde(default)]
     #[serde(rename = "dependsOn")]
     depends_on: Vec<String>,
+    #[serde(default)]
+    model: Option<String>,
 }
 
 #[tokio::main]
@@ -205,6 +207,7 @@ async fn run_app(
                         description: s.description.clone(),
                         depends_on: s.depends_on.clone(),
                         completed: s.passes,
+                        model: s.model.clone(),
                     }).collect();
                     app.show_review(stories);
                     entered_resume = true;
@@ -512,6 +515,7 @@ fn spawn_refiner(app: &App, feedback: &str, cwd: &Path, tx: mpsc::Sender<AppEven
                     description: s.description,
                     depends_on: s.depends_on,
                     completed: false,
+                    model: s.model,
                 })
                 .collect();
 
@@ -610,6 +614,7 @@ async fn run_claude_planner(goal: &str, cwd: &Path, model: Option<&str>) -> Resu
             description: s.description,
             depends_on: s.depends_on,
             completed: false,
+            model: s.model,
         })
         .collect();
 
@@ -667,6 +672,7 @@ async fn run_openai_planner(goal: &str, cwd: &Path) -> Result<(Vec<ReviewStory>,
             description: s.description,
             depends_on: s.depends_on,
             completed: false,
+            model: s.model,
         })
         .collect();
 

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -340,11 +340,13 @@ async fn run_app(
                                         app.start_execution();
                                         let exec_cwd = cwd.clone();
                                         let branch_tx = tx.clone();
+                                        let mr = app.model_routing;
+                                        let om = app.override_model.clone();
                                         tokio::spawn(async move {
                                             if let Err(e) = git::create_or_checkout_branch(&branch_cwd, &branch_name_clone).await {
                                                 eprintln!("[baro] branch checkout failed: {}", e);
                                             }
-                                            spawn_executor(prd, exec_cwd, branch_tx, parallel, timeout_secs);
+                                            spawn_executor(prd, exec_cwd, branch_tx, parallel, timeout_secs, mr, om);
                                         });
                                     }
                                     Err(e) => {
@@ -371,11 +373,13 @@ async fn run_app(
                                     let exec_prd = prd;
                                     let exec_cwd = cwd.clone();
                                     let branch_tx = tx.clone();
+                                    let mr = app.model_routing;
+                                    let om = app.override_model.clone();
                                     tokio::spawn(async move {
                                         if let Err(e) = git::create_or_checkout_branch(&branch_cwd, &branch_name_clone).await {
                                             eprintln!("[baro] branch creation failed: {}", e);
                                         }
-                                        spawn_executor(exec_prd, exec_cwd, branch_tx, parallel, timeout_secs);
+                                        spawn_executor(exec_prd, exec_cwd, branch_tx, parallel, timeout_secs, mr, om);
                                     });
                                 }
                             }
@@ -525,7 +529,15 @@ fn spawn_refiner(app: &App, feedback: &str, cwd: &Path, tx: mpsc::Sender<AppEven
     });
 }
 
-fn spawn_executor(prd: executor::PrdFile, cwd: PathBuf, tx: mpsc::Sender<AppEvent>, parallel: u32, timeout_secs: u64) {
+fn spawn_executor(
+    prd: executor::PrdFile,
+    cwd: PathBuf,
+    tx: mpsc::Sender<AppEvent>,
+    parallel: u32,
+    timeout_secs: u64,
+    model_routing: bool,
+    override_model: Option<String>,
+) {
     // Create a channel bridge: executor sends BaroEvent, we wrap them as AppEvent::Baro
     let (exec_tx, mut exec_rx) = mpsc::channel::<BaroEvent>(256);
 
@@ -541,7 +553,7 @@ fn spawn_executor(prd: executor::PrdFile, cwd: PathBuf, tx: mpsc::Sender<AppEven
 
     // Run executor
     tokio::spawn(async move {
-        executor::run_executor(prd, cwd, exec_tx, parallel, timeout_secs).await;
+        executor::run_executor(prd, cwd, exec_tx, parallel, timeout_secs, model_routing, override_model).await;
     });
 }
 

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -413,10 +413,11 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
     let goal = app.goal_input.clone();
     let planner = app.planner;
     let cwd = cwd.to_path_buf();
+    let model = app.model_for_phase("planning");
 
     tokio::spawn(async move {
         let result = match planner {
-            Planner::Claude => run_claude_planner(&goal, &cwd).await,
+            Planner::Claude => run_claude_planner(&goal, &cwd, model.as_deref()).await,
             Planner::OpenAI => run_openai_planner(&goal, &cwd).await,
         };
 
@@ -434,6 +435,7 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
 fn spawn_refiner(app: &App, feedback: &str, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
     let feedback = feedback.to_string();
     let cwd = cwd.to_path_buf();
+    let model = app.model_for_phase("planning");
 
     // Build current plan JSON from app state
     let stories_json: Vec<serde_json::Value> = app.review_stories.iter().map(|s| {
@@ -459,13 +461,19 @@ fn spawn_refiner(app: &App, feedback: &str, cwd: &Path, tx: mpsc::Sender<AppEven
         );
 
         let result = async {
+            let mut args = vec![
+                "--dangerously-skip-permissions".to_string(),
+                "--output-format".to_string(), "json".to_string(),
+            ];
+            if let Some(ref model_name) = model {
+                args.push("--model".to_string());
+                args.push(model_name.clone());
+            }
+            args.push("-p".to_string());
+            args.push(prompt.clone());
+
             let output = Command::new("claude")
-                .args([
-                    "--dangerously-skip-permissions",
-                    "--output-format", "json",
-                    "-p",
-                    &prompt,
-                ])
+                .args(&args)
                 .current_dir(&cwd)
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
@@ -537,16 +545,22 @@ fn spawn_executor(prd: executor::PrdFile, cwd: PathBuf, tx: mpsc::Sender<AppEven
     });
 }
 
-async fn run_claude_planner(goal: &str, cwd: &Path) -> Result<(Vec<ReviewStory>, String, String, String), Box<dyn std::error::Error + Send + Sync>> {
+async fn run_claude_planner(goal: &str, cwd: &Path, model: Option<&str>) -> Result<(Vec<ReviewStory>, String, String, String), Box<dyn std::error::Error + Send + Sync>> {
     let prompt = format!("{}\n\nUser goal: {}", CLAUDE_PLANNER_PROMPT, goal);
 
+    let mut args = vec![
+        "--dangerously-skip-permissions",
+        "--output-format", "json",
+    ];
+    if let Some(model_name) = model {
+        args.push("--model");
+        args.push(model_name);
+    }
+    args.push("-p");
+    args.push(&prompt);
+
     let output = Command::new("claude")
-        .args([
-            "--dangerously-skip-permissions",
-            "--output-format", "json",
-            "-p",
-            &prompt,
-        ])
+        .args(&args)
         .current_dir(cwd)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -52,6 +52,14 @@ struct Cli {
     /// Per-story timeout in seconds
     #[arg(long, default_value = "600")]
     timeout: u64,
+
+    /// Override model for all phases (valid: opus, sonnet, haiku)
+    #[arg(long = "model", value_parser = ["opus", "sonnet", "haiku"])]
+    model: Option<String>,
+
+    /// Disable model routing (equivalent to --model opus)
+    #[arg(long = "no-model-routing")]
+    no_model_routing: bool,
 }
 
 enum AppEvent {
@@ -86,13 +94,15 @@ Output ONLY valid JSON matching this exact schema (no markdown, no explanation, 
       "dependsOn": [],
       "retries": 2,
       "acceptance": ["testable criterion"],
-      "tests": ["npm test"]
+      "tests": ["npm test"],
+      "model": "opus"
     }
   ]
 }
 
 Rules:
 - Each story: single focused unit of work for one AI agent
+- If a story is complex enough to require the most capable model (opus with 1M context) for implementation, set its "model" field to "opus". Otherwise omit the field entirely (defaults to the routing default, typically sonnet)
 - Use dependsOn for dependencies; same-priority stories with no deps run IN PARALLEL
 - Keep stories small (15-60 min of work each)
 - Include testable acceptance criteria and test commands
@@ -166,6 +176,14 @@ async fn run_app(
         "openai" => Planner::OpenAI,
         _ => Planner::Claude,
     };
+
+    if let Some(ref model) = cli.model {
+        app.override_model = Some(model.clone());
+        app.model_routing = false;
+    } else if cli.no_model_routing {
+        app.override_model = Some("opus".to_string());
+        app.model_routing = false;
+    }
 
     let (tx, mut rx) = mpsc::channel::<AppEvent>(256);
 

--- a/crates/baro-tui/src/screens/execute.rs
+++ b/crates/baro-tui/src/screens/execute.rs
@@ -99,6 +99,25 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
             format!("timeout: {}s", app.timeout_secs),
             Style::default().fg(theme::MUTED),
         ),
+        Span::styled(" │ ", Style::default().fg(theme::BORDER)),
+        Span::styled(
+            if let Some(ref name) = app.override_model {
+                format!("model: {}", name)
+            } else if app.model_routing {
+                "model: routed".to_string()
+            } else {
+                "model: default".to_string()
+            },
+            Style::default().fg(
+                if app.override_model.is_some() {
+                    theme::WARNING
+                } else if app.model_routing {
+                    theme::ACCENT
+                } else {
+                    theme::MUTED
+                },
+            ),
+        ),
     ]);
 
     let info = Paragraph::new(info_line).block(

--- a/crates/baro-tui/src/screens/execute_completion.rs
+++ b/crates/baro-tui/src/screens/execute_completion.rs
@@ -157,7 +157,7 @@ pub fn render_completion(f: &mut Frame, app: &App) {
         Span::styled("  Model:          ", Style::default().fg(theme::MUTED)),
         Span::styled(
             if let Some(ref name) = app.override_model {
-                format!("{}", name)
+                name.to_string()
             } else if app.model_routing {
                 "routed".to_string()
             } else {

--- a/crates/baro-tui/src/screens/execute_completion.rs
+++ b/crates/baro-tui/src/screens/execute_completion.rs
@@ -153,6 +153,28 @@ pub fn render_completion(f: &mut Frame, app: &App) {
         ]),
     ]);
 
+    lines.push(Line::from(vec![
+        Span::styled("  Model:          ", Style::default().fg(theme::MUTED)),
+        Span::styled(
+            if let Some(ref name) = app.override_model {
+                format!("{}", name)
+            } else if app.model_routing {
+                "routed".to_string()
+            } else {
+                "default".to_string()
+            },
+            Style::default().fg(
+                if app.override_model.is_some() {
+                    theme::WARNING
+                } else if app.model_routing {
+                    theme::ACCENT
+                } else {
+                    theme::MUTED
+                },
+            ),
+        ),
+    ]));
+
     if let Some(ref url) = app.pr_url {
         lines.push(Line::from(vec![
             Span::styled("  PR: ", Style::default().fg(theme::MUTED)),

--- a/prd.json
+++ b/prd.json
@@ -33,14 +33,14 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T19:28:15.848501+00:00",
       "dependsOn": [
         "S1"
       ],
       "description": "In crates/baro-tui/src/main.rs, modify spawn_executor() to accept the model config (model_routing: bool, override_model: Option<String>). Pass it through to executor::run_executor(). In crates/baro-tui/src/executor.rs, update run_executor() signature to accept model_routing: bool and override_model: Option<String>. Add a local helper function (or inline logic) to resolve the model for a given story: (1) if override_model is Some, always use it (CLI override wins); (2) if the story's PrdStory struct has a non-None `model` field (see S3a), use that (planner-selected override); (3) if model_routing is true, use \"sonnet\" for story execution and \"haiku\" for review; (4) else None (default). Pass the resolved execution model to run_claude_for_story() — update its signature to accept model: Option<String>, and when Some, add \"--model\" and the name to the claude args array. Similarly, in run_review_for_level(), resolve the review model and add \"--model\" flag to the review claude spawn args. Also pass the execution model to execute_story() so fix stories spawned during review also get the correct model. Log the model being used: at the start of each story, emit a StoryLog with line \"[model] using <model_name>\" (or \"[model] using default\" if None). Ensure cargo build passes with zero warnings.",
-      "durationSecs": null,
+      "durationSecs": 310,
       "id": "S3",
-      "passes": false,
+      "passes": true,
       "priority": 3,
       "retries": 2,
       "tests": [],

--- a/prd.json
+++ b/prd.json
@@ -1,96 +1,96 @@
 {
-  "project": "baro-model-routing",
   "branchName": "feat-model-routing",
   "description": "Add model routing to baro: opus for planning, sonnet for execution, haiku for review, with CLI override flags. The planner can escalate complex stories to opus for implementation.",
+  "project": "baro-model-routing",
   "userStories": [
     {
-      "id": "S1",
-      "priority": 1,
-      "title": "Add model config to App struct and CLI flags",
+      "acceptance": [],
+      "completedAt": null,
+      "dependsOn": [],
       "description": "In crates/baro-tui/src/app.rs, add two new fields to the App struct: `model_routing: bool` (default true) and `override_model: Option<String>` (default None). Initialize them in App::new(). In crates/baro-tui/src/main.rs, add two new CLI flags to the Cli struct: `--model <name>` (optional, valid values: opus, sonnet, haiku) which sets override_model and disables routing, and `--no-model-routing` (bool flag) which is equivalent to --model opus. In run_app(), wire the CLI values into the App struct: if --model is set, set app.override_model = Some(value) and app.model_routing = false; if --no-model-routing is set, set app.override_model = Some(\"opus\") and app.model_routing = false. Also add a helper method on App like `fn model_for_phase(&self, phase: &str) -> Option<String>` that returns: if override_model is set, return that; if model_routing is true, return opus for \"planning\", sonnet for \"execution\", haiku for \"review\"; if model_routing is false and no override, return None (use default). Ensure cargo build passes with zero warnings.",
-      "dependsOn": [],
-      "retries": 2,
-      "acceptance": [],
-      "tests": [],
+      "durationSecs": null,
+      "id": "S1",
       "passes": false,
-      "completedAt": null,
-      "durationSecs": null
+      "priority": 1,
+      "retries": 2,
+      "tests": [],
+      "title": "Add model config to App struct and CLI flags"
     },
     {
-      "id": "S2",
-      "priority": 2,
-      "title": "Pass model config to planner spawn and add --model flag to claude args",
+      "acceptance": [],
+      "completedAt": null,
+      "dependsOn": [
+        "S1"
+      ],
       "description": "In crates/baro-tui/src/main.rs, modify spawn_planner() to accept model config. Use app.model_for_phase(\"planning\") to get the model. Modify run_claude_planner() to accept an optional model parameter (Option<String>). When the model is Some(name), add \"--model\" and the name to the args array passed to Command::new(\"claude\"). The claude CLI accepts `--model <name>` flag. Do the same for spawn_refiner() / its claude call — use the planning model for refinement too. Ensure cargo build passes with zero warnings.",
+      "durationSecs": null,
+      "id": "S2",
+      "passes": false,
+      "priority": 2,
+      "retries": 2,
+      "tests": [],
+      "title": "Pass model config to planner spawn and add --model flag to claude args"
+    },
+    {
+      "acceptance": [],
+      "completedAt": null,
       "dependsOn": [
         "S1"
       ],
-      "retries": 2,
-      "acceptance": [],
-      "tests": [],
-      "passes": false,
-      "completedAt": null,
-      "durationSecs": null
-    },
-    {
-      "id": "S3",
-      "priority": 3,
-      "title": "Pass model config to executor and add --model flag to story execution and review agent",
       "description": "In crates/baro-tui/src/main.rs, modify spawn_executor() to accept the model config (model_routing: bool, override_model: Option<String>). Pass it through to executor::run_executor(). In crates/baro-tui/src/executor.rs, update run_executor() signature to accept model_routing: bool and override_model: Option<String>. Add a local helper function (or inline logic) to resolve the model for a given story: (1) if override_model is Some, always use it (CLI override wins); (2) if the story's PrdStory struct has a non-None `model` field (see S3a), use that (planner-selected override); (3) if model_routing is true, use \"sonnet\" for story execution and \"haiku\" for review; (4) else None (default). Pass the resolved execution model to run_claude_for_story() — update its signature to accept model: Option<String>, and when Some, add \"--model\" and the name to the claude args array. Similarly, in run_review_for_level(), resolve the review model and add \"--model\" flag to the review claude spawn args. Also pass the execution model to execute_story() so fix stories spawned during review also get the correct model. Log the model being used: at the start of each story, emit a StoryLog with line \"[model] using <model_name>\" (or \"[model] using default\" if None). Ensure cargo build passes with zero warnings.",
-      "dependsOn": [
-        "S1"
-      ],
-      "retries": 2,
-      "acceptance": [],
-      "tests": [],
+      "durationSecs": null,
+      "id": "S3",
       "passes": false,
-      "completedAt": null,
-      "durationSecs": null
+      "priority": 3,
+      "retries": 2,
+      "tests": [],
+      "title": "Pass model config to executor and add --model flag to story execution and review agent"
     },
     {
-      "id": "S3a",
-      "priority": 4,
-      "title": "Add per-story model field to PrdStory and update planner prompt to allow opus escalation",
-      "description": "Add an optional `model` field (Option<String>) to the PrdStory struct in the PRD data model (likely in crates/baro-tui/src/prd.rs or wherever PrdStory is defined). This field allows the planner to specify a per-story model override — for example, setting model to \"opus\" for a complex story that needs the full 1M-context model for implementation. The field defaults to None (meaning use the routing default). Update the planner prompt template to instruct the planner: \"If a story is complex enough to require the most capable model (opus with 1M context) for implementation, set its `model` field to `opus`. Otherwise leave it null/omit it.\" This way the intelligent planner (which itself runs on opus) can decide at planning time which stories need opus-level implementation versus which can use sonnet. Ensure the JSON deserialization handles the optional field gracefully (serde skip_serializing_if = Option::is_none, default). Ensure cargo build passes with zero warnings.",
+      "acceptance": [],
+      "completedAt": "2026-03-26T19:22:20.980081+00:00",
       "dependsOn": [],
+      "description": "Add an optional `model` field (Option<String>) to the PrdStory struct in the PRD data model (likely in crates/baro-tui/src/prd.rs or wherever PrdStory is defined). This field allows the planner to specify a per-story model override — for example, setting model to \"opus\" for a complex story that needs the full 1M-context model for implementation. The field defaults to None (meaning use the routing default). Update the planner prompt template to instruct the planner: \"If a story is complex enough to require the most capable model (opus with 1M context) for implementation, set its `model` field to `opus`. Otherwise leave it null/omit it.\" This way the intelligent planner (which itself runs on opus) can decide at planning time which stories need opus-level implementation versus which can use sonnet. Ensure the JSON deserialization handles the optional field gracefully (serde skip_serializing_if = Option::is_none, default). Ensure cargo build passes with zero warnings.",
+      "durationSecs": 93,
+      "id": "S3a",
+      "passes": true,
+      "priority": 4,
       "retries": 2,
-      "acceptance": [],
       "tests": [],
-      "passes": false,
-      "completedAt": null,
-      "durationSecs": null
+      "title": "Add per-story model field to PrdStory and update planner prompt to allow opus escalation"
     },
     {
-      "id": "S4",
-      "priority": 5,
-      "title": "Show active model in TUI header and completion screen",
-      "description": "In crates/baro-tui/src/screens/execute.rs, modify render_header() to add a model indicator span in the header info line after the existing spans. If app.model_routing is true and app.override_model is None, show \"model: routed\" in ACCENT color. If app.override_model is Some(name), show \"model: <name>\" in WARNING color. If model_routing is false and override_model is None, show \"model: default\" in MUTED color. Add it with a separator like the existing spans. Also check screens/execute_completion.rs — if there's a summary section, add the model info there too. Ensure cargo build passes with zero warnings.",
+      "acceptance": [],
+      "completedAt": null,
       "dependsOn": [
         "S1"
       ],
-      "retries": 2,
-      "acceptance": [],
-      "tests": [],
+      "description": "In crates/baro-tui/src/screens/execute.rs, modify render_header() to add a model indicator span in the header info line after the existing spans. If app.model_routing is true and app.override_model is None, show \"model: routed\" in ACCENT color. If app.override_model is Some(name), show \"model: <name>\" in WARNING color. If model_routing is false and override_model is None, show \"model: default\" in MUTED color. Add it with a separator like the existing spans. Also check screens/execute_completion.rs — if there's a summary section, add the model info there too. Ensure cargo build passes with zero warnings.",
+      "durationSecs": null,
+      "id": "S4",
       "passes": false,
-      "completedAt": null,
-      "durationSecs": null
+      "priority": 5,
+      "retries": 2,
+      "tests": [],
+      "title": "Show active model in TUI header and completion screen"
     },
     {
-      "id": "S5",
-      "priority": 6,
-      "title": "Final cargo build zero-warnings check and integration validation",
-      "description": "Run cargo build on the entire workspace and fix any remaining warnings or errors. Check that all the pieces connect: CLI flags parsed -> App struct populated -> planner gets model -> planner can set per-story model field -> executor reads per-story model -> executor falls back to routing default -> review agent gets model -> TUI shows model. Verify that a story with model: \"opus\" in the PRD would cause the executor to spawn claude with --model opus for that story, overriding the default sonnet routing. Read through main.rs, app.rs, executor.rs, prd.rs, and the execute screen files to verify the full data flow is correct. Fix any unused imports, unused variables, or type mismatches. Ensure cargo build passes with zero warnings. Also verify that cargo clippy (if available) passes cleanly.",
+      "acceptance": [],
+      "completedAt": null,
       "dependsOn": [
         "S2",
         "S3",
         "S3a",
         "S4"
       ],
-      "retries": 2,
-      "acceptance": [],
-      "tests": [],
+      "description": "Run cargo build on the entire workspace and fix any remaining warnings or errors. Check that all the pieces connect: CLI flags parsed -> App struct populated -> planner gets model -> planner can set per-story model field -> executor reads per-story model -> executor falls back to routing default -> review agent gets model -> TUI shows model. Verify that a story with model: \"opus\" in the PRD would cause the executor to spawn claude with --model opus for that story, overriding the default sonnet routing. Read through main.rs, app.rs, executor.rs, prd.rs, and the execute screen files to verify the full data flow is correct. Fix any unused imports, unused variables, or type mismatches. Ensure cargo build passes with zero warnings. Also verify that cargo clippy (if available) passes cleanly.",
+      "durationSecs": null,
+      "id": "S5",
       "passes": false,
-      "completedAt": null,
-      "durationSecs": null
+      "priority": 6,
+      "retries": 2,
+      "tests": [],
+      "title": "Final cargo build zero-warnings check and integration validation"
     }
   ]
 }

--- a/prd.json
+++ b/prd.json
@@ -76,7 +76,7 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T19:32:46.340097+00:00",
       "dependsOn": [
         "S2",
         "S3",
@@ -84,9 +84,9 @@
         "S4"
       ],
       "description": "Run cargo build on the entire workspace and fix any remaining warnings or errors. Check that all the pieces connect: CLI flags parsed -> App struct populated -> planner gets model -> planner can set per-story model field -> executor reads per-story model -> executor falls back to routing default -> review agent gets model -> TUI shows model. Verify that a story with model: \"opus\" in the PRD would cause the executor to spawn claude with --model opus for that story, overriding the default sonnet routing. Read through main.rs, app.rs, executor.rs, prd.rs, and the execute screen files to verify the full data flow is correct. Fix any unused imports, unused variables, or type mismatches. Ensure cargo build passes with zero warnings. Also verify that cargo clippy (if available) passes cleanly.",
-      "durationSecs": null,
+      "durationSecs": 245,
       "id": "S5",
-      "passes": false,
+      "passes": true,
       "priority": 6,
       "retries": 2,
       "tests": [],

--- a/prd.json
+++ b/prd.json
@@ -1,63 +1,96 @@
 {
-  "branchName": "fix/speedup-floor-and-single-story",
-  "description": "Floor speedup to 1.0x minimum and hide time-saved for single-story runs",
-  "project": "fix-speedup-calculation",
+  "project": "baro-model-routing",
+  "branchName": "feat-model-routing",
+  "description": "Add model routing to baro: opus for planning, sonnet for execution, haiku for review, with CLI override flags. The planner can escalate complex stories to opus for implementation.",
   "userStories": [
     {
-      "acceptance": [],
-      "completedAt": "2026-03-26T19:02:20.140597+00:00",
-      "dependsOn": [],
-      "description": "In crates/baro-tui/src/executor.rs lines 1181-1203: 1) Clamp the speedup to a minimum of 1.0 — if sequential_time/total_time_secs < 1.0, display '1.0x' instead. 2) If there is only 1 story (total_stories == 1), skip the 'Time saved' and 'Speedup' lines entirely from the PR body stats section. Keep the rest of the stats (wall time, files, stories). Ensure no unused variable warnings — remove time_saved_str and speedup variables when they are not emitted, or gate their computation behind the same condition.",
-      "durationSecs": 110,
       "id": "S1",
-      "passes": true,
       "priority": 1,
+      "title": "Add model config to App struct and CLI flags",
+      "description": "In crates/baro-tui/src/app.rs, add two new fields to the App struct: `model_routing: bool` (default true) and `override_model: Option<String>` (default None). Initialize them in App::new(). In crates/baro-tui/src/main.rs, add two new CLI flags to the Cli struct: `--model <name>` (optional, valid values: opus, sonnet, haiku) which sets override_model and disables routing, and `--no-model-routing` (bool flag) which is equivalent to --model opus. In run_app(), wire the CLI values into the App struct: if --model is set, set app.override_model = Some(value) and app.model_routing = false; if --no-model-routing is set, set app.override_model = Some(\"opus\") and app.model_routing = false. Also add a helper method on App like `fn model_for_phase(&self, phase: &str) -> Option<String>` that returns: if override_model is set, return that; if model_routing is true, return opus for \"planning\", sonnet for \"execution\", haiku for \"review\"; if model_routing is false and no override, return None (use default). Ensure cargo build passes with zero warnings.",
+      "dependsOn": [],
       "retries": 2,
+      "acceptance": [],
       "tests": [],
-      "title": "Fix speedup in executor.rs PR body"
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null
     },
     {
-      "acceptance": [],
-      "completedAt": "2026-03-26T19:01:19.813291+00:00",
-      "dependsOn": [],
-      "description": "In crates/baro-tui/src/screens/execute_stats.rs lines 149-185: 1) After computing multiplier, clamp it: if multiplier < 1.0, set it to 1.0. 2) If completed_count <= 1, skip the 'Saved:' line entirely (do not push any summary_line for saved time). Currently the else branch on line 175-185 shows '1.0x' — for single story, remove that line too so nothing about savings is shown. Ensure no unused variable warnings.",
-      "durationSecs": 49,
       "id": "S2",
-      "passes": true,
       "priority": 2,
-      "retries": 2,
-      "tests": [],
-      "title": "Fix speedup in execute_stats.rs stats tab"
-    },
-    {
-      "acceptance": [],
-      "completedAt": "2026-03-26T19:01:45.813571+00:00",
-      "dependsOn": [],
-      "description": "In crates/baro-tui/src/screens/execute_completion.rs lines 34-111: 1) Clamp multiplier to minimum 1.0 — if sequential_time/wall_time < 1.0, use 1.0. 2) If app.total == 1 (single story), skip the 'Time saved:' line entirely from the completion overlay. Currently lines 94-111 conditionally show either the time saved or 'Parallelism: 1.0x' — for single story, omit the entire Line::from block. Ensure no unused variable warnings (saved_secs may become unused when single story).",
-      "durationSecs": 77,
-      "id": "S3",
-      "passes": true,
-      "priority": 3,
-      "retries": 2,
-      "tests": [],
-      "title": "Fix speedup in execute_completion.rs overlay"
-    },
-    {
-      "acceptance": [],
-      "completedAt": "2026-03-26T19:03:14.437069+00:00",
+      "title": "Pass model config to planner spawn and add --model flag to claude args",
+      "description": "In crates/baro-tui/src/main.rs, modify spawn_planner() to accept model config. Use app.model_for_phase(\"planning\") to get the model. Modify run_claude_planner() to accept an optional model parameter (Option<String>). When the model is Some(name), add \"--model\" and the name to the args array passed to Command::new(\"claude\"). The claude CLI accepts `--model <name>` flag. Do the same for spawn_refiner() / its claude call — use the planning model for refinement too. Ensure cargo build passes with zero warnings.",
       "dependsOn": [
-        "S1",
-        "S2",
-        "S3"
+        "S1"
       ],
-      "description": "Run cargo build (and cargo clippy if available) across the entire workspace to verify there are zero warnings and zero errors after the changes from S1, S2, and S3. Fix any remaining warnings (unused variables, dead code, etc.) that may have been introduced.",
-      "durationSecs": 33,
-      "id": "S4",
-      "passes": true,
-      "priority": 4,
       "retries": 2,
+      "acceptance": [],
       "tests": [],
-      "title": "Final cargo build zero-warnings check"
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null
+    },
+    {
+      "id": "S3",
+      "priority": 3,
+      "title": "Pass model config to executor and add --model flag to story execution and review agent",
+      "description": "In crates/baro-tui/src/main.rs, modify spawn_executor() to accept the model config (model_routing: bool, override_model: Option<String>). Pass it through to executor::run_executor(). In crates/baro-tui/src/executor.rs, update run_executor() signature to accept model_routing: bool and override_model: Option<String>. Add a local helper function (or inline logic) to resolve the model for a given story: (1) if override_model is Some, always use it (CLI override wins); (2) if the story's PrdStory struct has a non-None `model` field (see S3a), use that (planner-selected override); (3) if model_routing is true, use \"sonnet\" for story execution and \"haiku\" for review; (4) else None (default). Pass the resolved execution model to run_claude_for_story() — update its signature to accept model: Option<String>, and when Some, add \"--model\" and the name to the claude args array. Similarly, in run_review_for_level(), resolve the review model and add \"--model\" flag to the review claude spawn args. Also pass the execution model to execute_story() so fix stories spawned during review also get the correct model. Log the model being used: at the start of each story, emit a StoryLog with line \"[model] using <model_name>\" (or \"[model] using default\" if None). Ensure cargo build passes with zero warnings.",
+      "dependsOn": [
+        "S1"
+      ],
+      "retries": 2,
+      "acceptance": [],
+      "tests": [],
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null
+    },
+    {
+      "id": "S3a",
+      "priority": 4,
+      "title": "Add per-story model field to PrdStory and update planner prompt to allow opus escalation",
+      "description": "Add an optional `model` field (Option<String>) to the PrdStory struct in the PRD data model (likely in crates/baro-tui/src/prd.rs or wherever PrdStory is defined). This field allows the planner to specify a per-story model override — for example, setting model to \"opus\" for a complex story that needs the full 1M-context model for implementation. The field defaults to None (meaning use the routing default). Update the planner prompt template to instruct the planner: \"If a story is complex enough to require the most capable model (opus with 1M context) for implementation, set its `model` field to `opus`. Otherwise leave it null/omit it.\" This way the intelligent planner (which itself runs on opus) can decide at planning time which stories need opus-level implementation versus which can use sonnet. Ensure the JSON deserialization handles the optional field gracefully (serde skip_serializing_if = Option::is_none, default). Ensure cargo build passes with zero warnings.",
+      "dependsOn": [],
+      "retries": 2,
+      "acceptance": [],
+      "tests": [],
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null
+    },
+    {
+      "id": "S4",
+      "priority": 5,
+      "title": "Show active model in TUI header and completion screen",
+      "description": "In crates/baro-tui/src/screens/execute.rs, modify render_header() to add a model indicator span in the header info line after the existing spans. If app.model_routing is true and app.override_model is None, show \"model: routed\" in ACCENT color. If app.override_model is Some(name), show \"model: <name>\" in WARNING color. If model_routing is false and override_model is None, show \"model: default\" in MUTED color. Add it with a separator like the existing spans. Also check screens/execute_completion.rs — if there's a summary section, add the model info there too. Ensure cargo build passes with zero warnings.",
+      "dependsOn": [
+        "S1"
+      ],
+      "retries": 2,
+      "acceptance": [],
+      "tests": [],
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null
+    },
+    {
+      "id": "S5",
+      "priority": 6,
+      "title": "Final cargo build zero-warnings check and integration validation",
+      "description": "Run cargo build on the entire workspace and fix any remaining warnings or errors. Check that all the pieces connect: CLI flags parsed -> App struct populated -> planner gets model -> planner can set per-story model field -> executor reads per-story model -> executor falls back to routing default -> review agent gets model -> TUI shows model. Verify that a story with model: \"opus\" in the PRD would cause the executor to spawn claude with --model opus for that story, overriding the default sonnet routing. Read through main.rs, app.rs, executor.rs, prd.rs, and the execute screen files to verify the full data flow is correct. Fix any unused imports, unused variables, or type mismatches. Ensure cargo build passes with zero warnings. Also verify that cargo clippy (if available) passes cleanly.",
+      "dependsOn": [
+        "S2",
+        "S3",
+        "S3a",
+        "S4"
+      ],
+      "retries": 2,
+      "acceptance": [],
+      "tests": [],
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null
     }
   ]
 }

--- a/prd.json
+++ b/prd.json
@@ -18,14 +18,14 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T19:24:19.089417+00:00",
       "dependsOn": [
         "S1"
       ],
       "description": "In crates/baro-tui/src/main.rs, modify spawn_planner() to accept model config. Use app.model_for_phase(\"planning\") to get the model. Modify run_claude_planner() to accept an optional model parameter (Option<String>). When the model is Some(name), add \"--model\" and the name to the args array passed to Command::new(\"claude\"). The claude CLI accepts `--model <name>` flag. Do the same for spawn_refiner() / its claude call — use the planning model for refinement too. Ensure cargo build passes with zero warnings.",
-      "durationSecs": null,
+      "durationSecs": 74,
       "id": "S2",
-      "passes": false,
+      "passes": true,
       "priority": 2,
       "retries": 2,
       "tests": [],
@@ -61,14 +61,14 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T19:24:46.835410+00:00",
       "dependsOn": [
         "S1"
       ],
       "description": "In crates/baro-tui/src/screens/execute.rs, modify render_header() to add a model indicator span in the header info line after the existing spans. If app.model_routing is true and app.override_model is None, show \"model: routed\" in ACCENT color. If app.override_model is Some(name), show \"model: <name>\" in WARNING color. If model_routing is false and override_model is None, show \"model: default\" in MUTED color. Add it with a separator like the existing spans. Also check screens/execute_completion.rs — if there's a summary section, add the model info there too. Ensure cargo build passes with zero warnings.",
-      "durationSecs": null,
+      "durationSecs": 103,
       "id": "S4",
-      "passes": false,
+      "passes": true,
       "priority": 5,
       "retries": 2,
       "tests": [],

--- a/prd.json
+++ b/prd.json
@@ -5,12 +5,12 @@
   "userStories": [
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T19:22:50.084844+00:00",
       "dependsOn": [],
       "description": "In crates/baro-tui/src/app.rs, add two new fields to the App struct: `model_routing: bool` (default true) and `override_model: Option<String>` (default None). Initialize them in App::new(). In crates/baro-tui/src/main.rs, add two new CLI flags to the Cli struct: `--model <name>` (optional, valid values: opus, sonnet, haiku) which sets override_model and disables routing, and `--no-model-routing` (bool flag) which is equivalent to --model opus. In run_app(), wire the CLI values into the App struct: if --model is set, set app.override_model = Some(value) and app.model_routing = false; if --no-model-routing is set, set app.override_model = Some(\"opus\") and app.model_routing = false. Also add a helper method on App like `fn model_for_phase(&self, phase: &str) -> Option<String>` that returns: if override_model is set, return that; if model_routing is true, return opus for \"planning\", sonnet for \"execution\", haiku for \"review\"; if model_routing is false and no override, return None (use default). Ensure cargo build passes with zero warnings.",
-      "durationSecs": null,
+      "durationSecs": 121,
       "id": "S1",
-      "passes": false,
+      "passes": true,
       "priority": 1,
       "retries": 2,
       "tests": [],


### PR DESCRIPTION
Add model routing to baro: opus for planning, sonnet for execution, haiku for review, with CLI override flags

## Stories

| ID | Title | Duration | Status |
|:---|:------|:---------|:-------|
| S1 | Add model config to App struct and CLI flags | 2m 1s | Done |
| S2 | Pass model config to planner spawn and add --model flag to claude args | 1m 14s | Done |
| S3 | Pass model config to executor and add --model flag to story execution and review agent | 5m 10s | Done |
| S3a | Add per-story model field to PrdStory and update planner prompt to allow opus escalation | 1m 33s | Done |
| S4 | Show active model in TUI header and completion screen | 1m 43s | Done |
| S5 | Final cargo build zero-warnings check and integration validation | 4m 5s | Done |

## Stats

- **Wall time:** 12m 11s
- **Time saved:** 3m 35s (parallelism)
- **Speedup:** 1.3x
- **Files created:** 0
- **Files modified:** 25
- **Stories:** 6/6 completed, 0 skipped

## Review

- **Review cycles:** 3
- **Fixes auto-applied:** 0

---

Built with [baro](https://www.npmjs.com/package/baro-ai) — Background Agent Runtime Orchestrator
