### PR TITLE
baro-notification-and-tokens

### DIFF
--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -151,6 +151,11 @@ pub struct App {
     pub model_routing: bool,
     pub override_model: Option<String>,
 
+    // Token usage tracking
+    pub token_usage: HashMap<String, (u64, u64)>,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+
     // UI state
     pub global_tab: GlobalTab,
     pub selected_log_index: usize,
@@ -198,6 +203,9 @@ impl App {
             timeout_secs: 600,
             model_routing: true,
             override_model: None,
+            token_usage: HashMap::new(),
+            total_input_tokens: 0,
+            total_output_tokens: 0,
             global_tab: GlobalTab::Dashboard,
             selected_log_index: 0,
             tick_count: 0,
@@ -454,7 +462,13 @@ impl App {
 
             BaroEvent::NotificationReady { .. } => {}
 
-            BaroEvent::TokenUsage { .. } => {}
+            BaroEvent::TokenUsage { id, input_tokens, output_tokens } => {
+                let entry = self.token_usage.entry(id).or_insert((0, 0));
+                entry.0 += input_tokens;
+                entry.1 += output_tokens;
+                self.total_input_tokens += input_tokens;
+                self.total_output_tokens += output_tokens;
+            }
         }
     }
 

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -464,7 +464,7 @@ impl App {
                 self.final_stats = Some(stats);
             }
 
-            BaroEvent::NotificationReady { .. } => {
+            BaroEvent::NotificationReady => {
                 self.notification_ready = true;
             }
 

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -451,6 +451,10 @@ impl App {
                 self.total_time_secs = total_time_secs;
                 self.final_stats = Some(stats);
             }
+
+            BaroEvent::NotificationReady { .. } => {}
+
+            BaroEvent::TokenUsage { .. } => {}
         }
     }
 

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -151,6 +151,9 @@ pub struct App {
     pub model_routing: bool,
     pub override_model: Option<String>,
 
+    // Notification flag
+    pub notification_ready: bool,
+
     // Token usage tracking
     pub token_usage: HashMap<String, (u64, u64)>,
     pub total_input_tokens: u64,
@@ -201,6 +204,7 @@ impl App {
             refining: false,
             parallel_limit: 0,
             timeout_secs: 600,
+            notification_ready: false,
             model_routing: true,
             override_model: None,
             token_usage: HashMap::new(),
@@ -460,7 +464,9 @@ impl App {
                 self.final_stats = Some(stats);
             }
 
-            BaroEvent::NotificationReady { .. } => {}
+            BaroEvent::NotificationReady { .. } => {
+                self.notification_ready = true;
+            }
 
             BaroEvent::TokenUsage { id, input_tokens, output_tokens } => {
                 let entry = self.token_usage.entry(id).or_insert((0, 0));

--- a/crates/baro-tui/src/events.rs
+++ b/crates/baro-tui/src/events.rs
@@ -114,4 +114,14 @@ pub enum BaroEvent {
         total_time_secs: u64,
         stats: DoneStats,
     },
+
+    #[serde(rename = "notification_ready")]
+    NotificationReady,
+
+    #[serde(rename = "token_usage")]
+    TokenUsage {
+        id: String,
+        input_tokens: u64,
+        output_tokens: u64,
+    },
 }

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -1156,24 +1156,8 @@ pub async fn run_executor(
         })
         .await;
 
-    // ─── Completion notification (best-effort) ───────────────────
-    print!("\x07"); // terminal bell
-    match std::env::consts::OS {
-        "macos" => {
-            let _ = std::process::Command::new("osascript")
-                .args([
-                    "-e",
-                    "display notification \"baro: all stories complete\" with title \"baro\"",
-                ])
-                .spawn();
-        }
-        "linux" => {
-            let _ = std::process::Command::new("notify-send")
-                .args(["baro", "all stories complete"])
-                .spawn();
-        }
-        _ => {}
-    }
+    // Signal that notifications should fire after TUI cleanup
+    let _ = tx.send(BaroEvent::NotificationReady).await;
 
     // ─── Finalize phase ─────────────────────────────────────────
     let _ = tx.send(BaroEvent::FinalizeStart).await;

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -96,6 +96,18 @@ fn build_prompt(story: &PrdStory, cwd: &Path) -> String {
 
 // ─── Claude stream-json parser ──────────────────────────────
 
+fn format_with_commas(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
 fn parse_claude_stream_line(line: &str, _story_id: &str) -> (Vec<String>, Option<(u64, u64)>) {
     let mut logs = Vec::new();
 
@@ -210,7 +222,7 @@ async fn execute_story(
     git_mutex: &Mutex<()>,
     timeout_secs: u64,
     model: Option<String>,
-) -> Result<(u64, u32, u32), String> {
+) -> Result<(u64, u32, u32, u64, u64), String> {
     let max_attempts = story.retries + 1;
 
     for attempt in 1..=max_attempts {
@@ -246,7 +258,7 @@ async fn execute_story(
         let duration_secs = start.elapsed().as_secs();
 
         match result {
-            Ok(()) => {
+            Ok((story_input_tokens, story_output_tokens)) => {
                 // Acquire git mutex for prd update and git stats
                 let (files_created, files_modified) = {
                     let _git_lock = git_mutex.lock().await;
@@ -273,7 +285,7 @@ async fn execute_story(
                     })
                     .await;
 
-                return Ok((duration_secs, files_created, files_modified));
+                return Ok((duration_secs, files_created, files_modified, story_input_tokens, story_output_tokens));
             }
             Err(err) => {
                 let _ = tx
@@ -309,7 +321,7 @@ async fn run_claude_for_story(
     tx: &mpsc::Sender<BaroEvent>,
     timeout_secs: u64,
     model: &Option<String>,
-) -> Result<(), String> {
+) -> Result<(u64, u64), String> {
     let mut args = vec![
         "--dangerously-skip-permissions",
         "--output-format",
@@ -345,6 +357,8 @@ async fn run_claude_for_story(
         let stdout_task = tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
+            let mut acc_input: u64 = 0;
+            let mut acc_output: u64 = 0;
             while let Ok(Some(line)) = lines.next_line().await {
                 let (logs, token_usage) = parse_claude_stream_line(&line, &story_id_out);
                 for log in logs {
@@ -356,6 +370,8 @@ async fn run_claude_for_story(
                         .await;
                 }
                 if let Some((input_tokens, output_tokens)) = token_usage {
+                    acc_input += input_tokens;
+                    acc_output += output_tokens;
                     let _ = tx_out
                         .send(BaroEvent::TokenUsage {
                             id: story_id_out.clone(),
@@ -365,6 +381,7 @@ async fn run_claude_for_story(
                         .await;
                 }
             }
+            (acc_input, acc_output)
         });
 
         let story_id_err = story_id_owned.clone();
@@ -385,21 +402,22 @@ async fn run_claude_for_story(
             }
         });
 
-        let _ = stdout_task.await;
+        let token_totals = stdout_task.await.unwrap_or((0, 0));
         let _ = stderr_task.await;
 
-        child
+        let status = child
             .wait()
             .await
-            .map_err(|e| format!("Failed to wait for claude: {}", e))
+            .map_err(|e| format!("Failed to wait for claude: {}", e))?;
+        Ok::<_, String>((status, token_totals))
     })
     .await;
 
     match result {
         Ok(wait_result) => {
-            let status = wait_result?;
+            let (status, token_totals) = wait_result?;
             if status.success() {
-                Ok(())
+                Ok(token_totals)
             } else {
                 Err(format!("claude exited with code {}", status.code().unwrap_or(-1)))
             }
@@ -982,6 +1000,8 @@ pub async fn run_executor(
     let mut total_commits = 0u32;
     let mut review_cycles = 0u32;
     let mut review_fixes_applied = 0u32;
+    let mut total_input_tokens = 0u64;
+    let mut total_output_tokens = 0u64;
 
     // Create semaphore for parallelism limiting (0 = unlimited)
     let semaphore = if parallel > 0 {
@@ -1051,11 +1071,13 @@ pub async fn run_executor(
 
         for (story_id, handle) in handles {
             match handle.await {
-                Ok(Ok((duration_secs, files_created, files_modified))) => {
+                Ok(Ok((duration_secs, files_created, files_modified, story_input, story_output))) => {
                     completed += 1;
                     total_files_created += files_created;
                     total_files_modified += files_modified;
                     total_commits += 1;
+                    total_input_tokens += story_input;
+                    total_output_tokens += story_output;
                     level_completed_ids.push(story_id.clone());
 
                     let _ = tx
@@ -1281,11 +1303,14 @@ pub async fn run_executor(
              {}\
              - **Files created:** {}\n\
              - **Files modified:** {}\n\
+             - **Tokens:** {} input / {} output\n\
              - **Stories:** {}/{} completed, {} skipped\n",
             wall_time_str,
             parallelism_stats,
             total_files_created,
             total_files_modified,
+            format_with_commas(total_input_tokens),
+            format_with_commas(total_output_tokens),
             completed,
             total_stories,
             skipped

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -96,7 +96,7 @@ fn build_prompt(story: &PrdStory, cwd: &Path) -> String {
 
 // ─── Claude stream-json parser ──────────────────────────────
 
-fn parse_claude_stream_line(line: &str, _story_id: &str) -> Vec<String> {
+fn parse_claude_stream_line(line: &str, _story_id: &str) -> (Vec<String>, Option<(u64, u64)>) {
     let mut logs = Vec::new();
 
     let Ok(ev) = serde_json::from_str::<serde_json::Value>(line) else {
@@ -105,7 +105,7 @@ fn parse_claude_stream_line(line: &str, _story_id: &str) -> Vec<String> {
         if !trimmed.is_empty() {
             logs.push(trimmed.to_string());
         }
-        return logs;
+        return (logs, None);
     };
 
     let ev_type = ev.get("type").and_then(|t| t.as_str()).unwrap_or("");
@@ -162,11 +162,16 @@ fn parse_claude_stream_line(line: &str, _story_id: &str) -> Vec<String> {
                     }
                 }
             }
+            if let Some(usage) = ev.get("usage") {
+                let input_tokens = usage.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                let output_tokens = usage.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                return (logs, Some((input_tokens, output_tokens)));
+            }
         }
         _ => {}
     }
 
-    logs
+    (logs, None)
 }
 
 // ─── Model resolution helper ────────────────────────────────
@@ -341,12 +346,21 @@ async fn run_claude_for_story(
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                let logs = parse_claude_stream_line(&line, &story_id_out);
+                let (logs, token_usage) = parse_claude_stream_line(&line, &story_id_out);
                 for log in logs {
                     let _ = tx_out
                         .send(BaroEvent::StoryLog {
                             id: story_id_out.clone(),
                             line: log,
+                        })
+                        .await;
+                }
+                if let Some((input_tokens, output_tokens)) = token_usage {
+                    let _ = tx_out
+                        .send(BaroEvent::TokenUsage {
+                            id: story_id_out.clone(),
+                            input_tokens,
+                            output_tokens,
                         })
                         .await;
                 }

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -155,17 +155,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     terminal.show_cursor()?;
     terminal.backend_mut().flush()?;
 
-    if let Err(err) = result {
-        eprintln!("Error: {}", err);
-        std::process::exit(1);
+    match result {
+        Ok(notify) => {
+            if notify {
+                // Fire notification outside the alternate screen so it actually works
+                print!("\x07"); // terminal bell
+                match std::env::consts::OS {
+                    "macos" => {
+                        let _ = std::process::Command::new("osascript")
+                            .args([
+                                "-e",
+                                "display notification \"baro: all stories complete\" with title \"baro\"",
+                            ])
+                            .spawn();
+                    }
+                    "linux" => {
+                        let _ = std::process::Command::new("notify-send")
+                            .args(["baro", "all stories complete"])
+                            .spawn();
+                    }
+                    _ => {}
+                }
+            }
+            Ok(())
+        }
+        Err(err) => {
+            eprintln!("Error: {}", err);
+            std::process::exit(1);
+        }
     }
-    Ok(())
 }
 
 async fn run_app(
     terminal: &mut Terminal<CrosstermBackend<std::fs::File>>,
     cli: Cli,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<bool, Box<dyn std::error::Error>> {
     let mut app = App::new();
     let cwd = std::fs::canonicalize(&cli.cwd)?;
     let parallel = cli.parallel;
@@ -280,7 +304,7 @@ async fn run_app(
 
                 match app.screen {
                     Screen::Welcome => match key.code {
-                        KeyCode::Esc => return Ok(()),
+                        KeyCode::Esc => return Ok(false),
                         KeyCode::Enter => {
                             if !app.goal_input.is_empty() {
                                 app.start_planning();
@@ -293,7 +317,7 @@ async fn run_app(
                         _ => {}
                     },
                     Screen::Planning => match key.code {
-                        KeyCode::Esc | KeyCode::Char('q') => return Ok(()),
+                        KeyCode::Esc | KeyCode::Char('q') => return Ok(false),
                         KeyCode::Char('r') => {
                             if app.planning_error.is_some() {
                                 app.planning_error = None;
@@ -326,7 +350,7 @@ async fn run_app(
                                 app.refine_input = Some(String::new());
                             }
                         }
-                        KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                        KeyCode::Char('q') | KeyCode::Esc => return Ok(false),
                         KeyCode::Enter => {
                             if app.is_resume {
                                 // Resume mode: read existing prd.json (has full acceptance/tests data)
@@ -392,7 +416,7 @@ async fn run_app(
                         _ => {}
                     }},
                     Screen::Execute => match key.code {
-                        KeyCode::Char('q') => return Ok(()),
+                        KeyCode::Char('q') => return Ok(false),
                         KeyCode::Char('1') => app.global_tab = app::GlobalTab::Dashboard,
                         KeyCode::Char('2') => app.global_tab = app::GlobalTab::Dag,
                         KeyCode::Char('3') => app.global_tab = app::GlobalTab::Stats,
@@ -413,7 +437,7 @@ async fn run_app(
             None => break,
         }
     }
-    Ok(())
+    Ok(app.notification_ready)
 }
 
 fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {

--- a/crates/baro-tui/src/screens/execute_completion.rs
+++ b/crates/baro-tui/src/screens/execute_completion.rs
@@ -13,7 +13,7 @@ pub fn render_completion(f: &mut Frame, app: &App) {
     let area = f.area();
     let box_width = 50u16.min(area.width.saturating_sub(4));
     let pr_extra: u16 = if app.pr_url.is_some() { 1 } else { 0 };
-    let box_height = (16u16 + pr_extra).min(area.height.saturating_sub(2));
+    let box_height = (17u16 + pr_extra).min(area.height.saturating_sub(2));
     let x = (area.width.saturating_sub(box_width)) / 2;
     let y = (area.height.saturating_sub(box_height)) / 2;
     let popup_area = Rect::new(x, y, box_width, box_height);
@@ -172,6 +172,30 @@ pub fn render_completion(f: &mut Frame, app: &App) {
                     theme::MUTED
                 },
             ),
+        ),
+    ]));
+
+    let format_commas = |n: u64| -> String {
+        let s = n.to_string();
+        let mut result = String::new();
+        for (i, c) in s.chars().rev().enumerate() {
+            if i > 0 && i % 3 == 0 {
+                result.push(',');
+            }
+            result.push(c);
+        }
+        result.chars().rev().collect()
+    };
+
+    lines.push(Line::from(vec![
+        Span::styled("  Tokens:         ", Style::default().fg(theme::MUTED)),
+        Span::styled(
+            format!(
+                "{} in / {} out",
+                format_commas(app.total_input_tokens),
+                format_commas(app.total_output_tokens)
+            ),
+            Style::default().fg(theme::ACCENT),
         ),
     ]));
 

--- a/crates/baro-tui/src/screens/execute_stats.rs
+++ b/crates/baro-tui/src/screens/execute_stats.rs
@@ -11,7 +11,7 @@ use crate::theme;
 
 pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
     let has_bar_data = app.stories.iter().any(|s| s.duration_secs.is_some());
-    let mut constraints = vec![Constraint::Length(7)]; // Summary
+    let mut constraints = vec![Constraint::Length(8)]; // Summary
     if has_bar_data {
         constraints.push(Constraint::Length(10)); // Bar chart
     }
@@ -47,6 +47,18 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
     let total_files_created: u32 = app.stories.iter().map(|s| s.files_created).sum();
     let total_files_modified: u32 = app.stories.iter().map(|s| s.files_modified).sum();
     let final_stats = app.final_stats.as_ref();
+
+    let format_commas = |n: u64| -> String {
+        let s = n.to_string();
+        let mut result = String::new();
+        for (i, c) in s.chars().rev().enumerate() {
+            if i > 0 && i % 3 == 0 {
+                result.push(',');
+            }
+            result.push(c);
+        }
+        result.chars().rev().collect()
+    };
 
     // -- Time saved calculation --
     let sequential_time: u64 = completed_stories
@@ -146,6 +158,26 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
         ]),
     ];
 
+    // Tokens line
+    if app.total_input_tokens > 0 || app.total_output_tokens > 0 {
+        summary_lines.push(Line::from(vec![
+            Span::styled("  Tokens: ", Style::default().fg(theme::MUTED)),
+            Span::styled(
+                format!("{} in", format_commas(app.total_input_tokens)),
+                Style::default()
+                    .fg(theme::ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" / ", Style::default().fg(theme::MUTED)),
+            Span::styled(
+                format!("{} out", format_commas(app.total_output_tokens)),
+                Style::default()
+                    .fg(theme::ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+    }
+
     // Third line: time saved (only shown for multiple stories)
     let completed_count = completed_stories.len();
     if completed_count > 1 {
@@ -232,7 +264,7 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
     let table_chunk_idx = next_chunk;
 
     // -- Story table --
-    let header = Row::new(vec!["  ID", "Title", "Status", "Time", "Files", "Deps"]).style(
+    let header = Row::new(vec!["  ID", "Title", "Status", "Time", "Files", "Tokens", "Deps"]).style(
         Style::default()
             .fg(theme::ACCENT)
             .add_modifier(Modifier::BOLD),
@@ -280,6 +312,12 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
                 Cell::from("-")
             };
 
+            let tokens_cell = if let Some(&(inp, out)) = app.token_usage.get(&s.id) {
+                Cell::from(format!("{}/ {}", format_commas(inp), format_commas(out)))
+            } else {
+                Cell::from("-")
+            };
+
             let deps = if s.depends_on.is_empty() {
                 "-".to_string()
             } else {
@@ -292,6 +330,7 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
                 Cell::from(status_str.to_string()),
                 Cell::from(time),
                 files_cell,
+                tokens_cell,
                 Cell::from(deps),
             ])
             .style(Style::default().fg(color))
@@ -304,6 +343,7 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
         Constraint::Length(8),
         Constraint::Length(8),
         Constraint::Length(8),
+        Constraint::Length(16),
         Constraint::Length(10),
     ];
 

--- a/prd.json
+++ b/prd.json
@@ -81,15 +81,15 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T19:54:44.141476+00:00",
       "dependsOn": [
         "S2",
         "S5"
       ],
       "description": "Run 'cargo build 2>&1' and 'cargo clippy 2>&1' on the workspace. Fix ANY warnings (unused imports, unused variables, dead code, clippy lints). Verify all changes integrate correctly: events.rs has both new variants, executor.rs emits both events and no longer has notification code, main.rs handles notification after TUI exit, app.rs tracks tokens, stats/completion screens display tokens, PR body includes tokens. If any warnings remain, fix them. This is the final quality gate.",
-      "durationSecs": null,
+      "durationSecs": 26,
       "id": "S6",
-      "passes": false,
+      "passes": true,
       "priority": 6,
       "retries": 2,
       "tests": [],

--- a/prd.json
+++ b/prd.json
@@ -1,99 +1,99 @@
 {
-  "project": "baro-notification-and-tokens",
   "branchName": "fix-notification-add-token-tracking",
   "description": "Fix completion notification (runs outside TUI) and add token cost tracking with per-story and total display",
+  "project": "baro-notification-and-tokens",
   "userStories": [
     {
-      "id": "S1",
-      "priority": 1,
-      "title": "Add NotificationReady and TokenUsage events",
-      "description": "In crates/baro-tui/src/events.rs, add two new variants to the BaroEvent enum: (1) NotificationReady - a simple variant with no fields, serde-renamed to 'notification_ready'. (2) TokenUsage { id: String, input_tokens: u64, output_tokens: u64 } - serde-renamed to 'token_usage'. These are the foundation events that other stories will emit and handle.",
+      "acceptance": [],
+      "completedAt": "2026-03-26T19:43:21.656133+00:00",
       "dependsOn": [],
+      "description": "In crates/baro-tui/src/events.rs, add two new variants to the BaroEvent enum: (1) NotificationReady - a simple variant with no fields, serde-renamed to 'notification_ready'. (2) TokenUsage { id: String, input_tokens: u64, output_tokens: u64 } - serde-renamed to 'token_usage'. These are the foundation events that other stories will emit and handle.",
+      "durationSecs": 16,
+      "id": "S1",
+      "passes": true,
+      "priority": 1,
       "retries": 2,
-      "acceptance": [],
       "tests": [],
-      "passes": false,
-      "completedAt": null,
-      "durationSecs": null
+      "title": "Add NotificationReady and TokenUsage events"
     },
     {
-      "id": "S2",
-      "priority": 2,
-      "title": "Fix notification to run outside TUI alternate screen",
+      "acceptance": [],
+      "completedAt": null,
+      "dependsOn": [
+        "S1"
+      ],
       "description": "Two changes: (1) In crates/baro-tui/src/executor.rs, replace the notification code block (terminal bell print!('\\x07') and osascript/notify-send spawn at lines ~1159-1176) with emitting BaroEvent::NotificationReady via the tx channel. Keep it after the Done event send. Remove the old print!/osascript/notify-send code entirely from executor.rs. (2) In crates/baro-tui/src/main.rs, after the terminal cleanup (after disable_raw_mode and LeaveAlternateScreen at ~line 153-156), and after the run_app result check, but before Ok(()), add notification code: print terminal bell, then run osascript on macos or notify-send on linux. This runs AFTER leaving the alternate screen so the notification actually fires. Also in main.rs handle_event or the event loop, add a match arm for BaroEvent::NotificationReady that sets a flag on App (add a field notification_ready: bool to App in app.rs), and after run_app returns in main(), check that flag to decide whether to notify. Pass the app out of run_app or use a shared flag.",
-      "dependsOn": [
-        "S1"
-      ],
-      "retries": 2,
-      "acceptance": [],
-      "tests": [],
-      "passes": false,
-      "completedAt": null,
       "durationSecs": null,
-      "model": "opus"
+      "id": "S2",
+      "model": "opus",
+      "passes": false,
+      "priority": 2,
+      "retries": 2,
+      "tests": [],
+      "title": "Fix notification to run outside TUI alternate screen"
     },
     {
-      "id": "S3",
-      "priority": 3,
-      "title": "Parse token usage from Claude stream and emit TokenUsage",
+      "acceptance": [],
+      "completedAt": null,
+      "dependsOn": [
+        "S1"
+      ],
       "description": "In crates/baro-tui/src/executor.rs, modify the parse_claude_stream_line function. In the 'result' match arm (line ~156), after the existing result text parsing, check if the JSON event object has a 'usage' field. If ev.get('usage') exists, extract input_tokens and output_tokens as u64 from it. Return these values alongside the log lines. Change the return type to include optional token usage data, or add a second function. Then in the caller of parse_claude_stream_line (in run_claude_for_story or wherever stdout lines are processed), when token usage data is found, send a BaroEvent::TokenUsage { id: story_id, input_tokens, output_tokens } via the tx channel. The story_id parameter is already available as _story_id (rename it to story_id).",
+      "durationSecs": null,
+      "id": "S3",
+      "passes": false,
+      "priority": 3,
+      "retries": 2,
+      "tests": [],
+      "title": "Parse token usage from Claude stream and emit TokenUsage"
+    },
+    {
+      "acceptance": [],
+      "completedAt": null,
       "dependsOn": [
         "S1"
       ],
-      "retries": 2,
-      "acceptance": [],
-      "tests": [],
-      "passes": false,
-      "completedAt": null,
-      "durationSecs": null
-    },
-    {
-      "id": "S4",
-      "priority": 4,
-      "title": "Track token usage in App state",
       "description": "In crates/baro-tui/src/app.rs: (1) Add three new fields to the App struct: token_usage: HashMap<String, (u64, u64)> for per-story token tracking, total_input_tokens: u64, and total_output_tokens: u64. Initialize all to default/zero in App::new(). (2) In the handle_event method, add a match arm for BaroEvent::TokenUsage { id, input_tokens, output_tokens }. It should: insert or update the entry in token_usage HashMap (accumulate if multiple events per story), and add to total_input_tokens and total_output_tokens. Make sure to add 'use std::collections::HashMap' if not already imported (it is already used for active_stories).",
-      "dependsOn": [
-        "S1"
-      ],
-      "retries": 2,
-      "acceptance": [],
-      "tests": [],
+      "durationSecs": null,
+      "id": "S4",
       "passes": false,
-      "completedAt": null,
-      "durationSecs": null
+      "priority": 4,
+      "retries": 2,
+      "tests": [],
+      "title": "Track token usage in App state"
     },
     {
-      "id": "S5",
-      "priority": 5,
-      "title": "Display tokens in stats, completion screen, and PR body",
-      "description": "Three files to modify: (1) crates/baro-tui/src/screens/execute_stats.rs: In the Summary section, add a new line showing total tokens: 'Tokens: {total_input} in / {total_output} out' using app.total_input_tokens and app.total_output_tokens. Format large numbers with comma separators for readability. In the Story table, add a 'Tokens' column showing per-story token counts from app.token_usage. (2) crates/baro-tui/src/screens/execute_completion.rs: Add a line showing total tokens after the 'Model' line: 'Tokens: {total_input} in / {total_output} out'. Adjust box_height by +1 to accommodate. (3) crates/baro-tui/src/executor.rs: In the PR body Stats section (around line ~1280-1294), add a line '- **Tokens:** {total_input} input / {total_output} output'. The executor needs access to total tokens - since executor.rs doesn't have app state, track totals in run_executor using variables that accumulate from TokenUsage events sent, OR compute from the events already sent. Simplest: maintain local total_input_tokens and total_output_tokens counters in run_executor alongside existing counters, incrementing them when TokenUsage is emitted.",
+      "acceptance": [],
+      "completedAt": null,
       "dependsOn": [
         "S3",
         "S4"
       ],
-      "retries": 2,
-      "acceptance": [],
-      "tests": [],
-      "passes": false,
-      "completedAt": null,
+      "description": "Three files to modify: (1) crates/baro-tui/src/screens/execute_stats.rs: In the Summary section, add a new line showing total tokens: 'Tokens: {total_input} in / {total_output} out' using app.total_input_tokens and app.total_output_tokens. Format large numbers with comma separators for readability. In the Story table, add a 'Tokens' column showing per-story token counts from app.token_usage. (2) crates/baro-tui/src/screens/execute_completion.rs: Add a line showing total tokens after the 'Model' line: 'Tokens: {total_input} in / {total_output} out'. Adjust box_height by +1 to accommodate. (3) crates/baro-tui/src/executor.rs: In the PR body Stats section (around line ~1280-1294), add a line '- **Tokens:** {total_input} input / {total_output} output'. The executor needs access to total tokens - since executor.rs doesn't have app state, track totals in run_executor using variables that accumulate from TokenUsage events sent, OR compute from the events already sent. Simplest: maintain local total_input_tokens and total_output_tokens counters in run_executor alongside existing counters, incrementing them when TokenUsage is emitted.",
       "durationSecs": null,
-      "model": "opus"
+      "id": "S5",
+      "model": "opus",
+      "passes": false,
+      "priority": 5,
+      "retries": 2,
+      "tests": [],
+      "title": "Display tokens in stats, completion screen, and PR body"
     },
     {
-      "id": "S6",
-      "priority": 6,
-      "title": "Final cargo build zero-warnings check and integration validation",
-      "description": "Run 'cargo build 2>&1' and 'cargo clippy 2>&1' on the workspace. Fix ANY warnings (unused imports, unused variables, dead code, clippy lints). Verify all changes integrate correctly: events.rs has both new variants, executor.rs emits both events and no longer has notification code, main.rs handles notification after TUI exit, app.rs tracks tokens, stats/completion screens display tokens, PR body includes tokens. If any warnings remain, fix them. This is the final quality gate.",
+      "acceptance": [],
+      "completedAt": null,
       "dependsOn": [
         "S2",
         "S5"
       ],
-      "retries": 2,
-      "acceptance": [],
-      "tests": [],
+      "description": "Run 'cargo build 2>&1' and 'cargo clippy 2>&1' on the workspace. Fix ANY warnings (unused imports, unused variables, dead code, clippy lints). Verify all changes integrate correctly: events.rs has both new variants, executor.rs emits both events and no longer has notification code, main.rs handles notification after TUI exit, app.rs tracks tokens, stats/completion screens display tokens, PR body includes tokens. If any warnings remain, fix them. This is the final quality gate.",
+      "durationSecs": null,
+      "id": "S6",
       "passes": false,
-      "completedAt": null,
-      "durationSecs": null
+      "priority": 6,
+      "retries": 2,
+      "tests": [],
+      "title": "Final cargo build zero-warnings check and integration validation"
     }
   ]
 }

--- a/prd.json
+++ b/prd.json
@@ -18,15 +18,15 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T19:46:47.300365+00:00",
       "dependsOn": [
         "S1"
       ],
       "description": "Two changes: (1) In crates/baro-tui/src/executor.rs, replace the notification code block (terminal bell print!('\\x07') and osascript/notify-send spawn at lines ~1159-1176) with emitting BaroEvent::NotificationReady via the tx channel. Keep it after the Done event send. Remove the old print!/osascript/notify-send code entirely from executor.rs. (2) In crates/baro-tui/src/main.rs, after the terminal cleanup (after disable_raw_mode and LeaveAlternateScreen at ~line 153-156), and after the run_app result check, but before Ok(()), add notification code: print terminal bell, then run osascript on macos or notify-send on linux. This runs AFTER leaving the alternate screen so the notification actually fires. Also in main.rs handle_event or the event loop, add a match arm for BaroEvent::NotificationReady that sets a flag on App (add a field notification_ready: bool to App in app.rs), and after run_app returns in main(), check that flag to decide whether to notify. Pass the app out of run_app or use a shared flag.",
-      "durationSecs": null,
+      "durationSecs": 127,
       "id": "S2",
       "model": "opus",
-      "passes": false,
+      "passes": true,
       "priority": 2,
       "retries": 2,
       "tests": [],
@@ -34,14 +34,14 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T19:47:05.861486+00:00",
       "dependsOn": [
         "S1"
       ],
       "description": "In crates/baro-tui/src/executor.rs, modify the parse_claude_stream_line function. In the 'result' match arm (line ~156), after the existing result text parsing, check if the JSON event object has a 'usage' field. If ev.get('usage') exists, extract input_tokens and output_tokens as u64 from it. Return these values alongside the log lines. Change the return type to include optional token usage data, or add a second function. Then in the caller of parse_claude_stream_line (in run_claude_for_story or wherever stdout lines are processed), when token usage data is found, send a BaroEvent::TokenUsage { id: story_id, input_tokens, output_tokens } via the tx channel. The story_id parameter is already available as _story_id (rename it to story_id).",
-      "durationSecs": null,
+      "durationSecs": 145,
       "id": "S3",
-      "passes": false,
+      "passes": true,
       "priority": 3,
       "retries": 2,
       "tests": [],

--- a/prd.json
+++ b/prd.json
@@ -1,96 +1,99 @@
 {
-  "branchName": "feat-model-routing",
-  "description": "Add model routing to baro: opus for planning, sonnet for execution, haiku for review, with CLI override flags. The planner can escalate complex stories to opus for implementation.",
-  "project": "baro-model-routing",
+  "project": "baro-notification-and-tokens",
+  "branchName": "fix-notification-add-token-tracking",
+  "description": "Fix completion notification (runs outside TUI) and add token cost tracking with per-story and total display",
   "userStories": [
     {
-      "acceptance": [],
-      "completedAt": "2026-03-26T19:22:50.084844+00:00",
-      "dependsOn": [],
-      "description": "In crates/baro-tui/src/app.rs, add two new fields to the App struct: `model_routing: bool` (default true) and `override_model: Option<String>` (default None). Initialize them in App::new(). In crates/baro-tui/src/main.rs, add two new CLI flags to the Cli struct: `--model <name>` (optional, valid values: opus, sonnet, haiku) which sets override_model and disables routing, and `--no-model-routing` (bool flag) which is equivalent to --model opus. In run_app(), wire the CLI values into the App struct: if --model is set, set app.override_model = Some(value) and app.model_routing = false; if --no-model-routing is set, set app.override_model = Some(\"opus\") and app.model_routing = false. Also add a helper method on App like `fn model_for_phase(&self, phase: &str) -> Option<String>` that returns: if override_model is set, return that; if model_routing is true, return opus for \"planning\", sonnet for \"execution\", haiku for \"review\"; if model_routing is false and no override, return None (use default). Ensure cargo build passes with zero warnings.",
-      "durationSecs": 121,
       "id": "S1",
-      "passes": true,
       "priority": 1,
-      "retries": 2,
-      "tests": [],
-      "title": "Add model config to App struct and CLI flags"
-    },
-    {
-      "acceptance": [],
-      "completedAt": "2026-03-26T19:24:19.089417+00:00",
-      "dependsOn": [
-        "S1"
-      ],
-      "description": "In crates/baro-tui/src/main.rs, modify spawn_planner() to accept model config. Use app.model_for_phase(\"planning\") to get the model. Modify run_claude_planner() to accept an optional model parameter (Option<String>). When the model is Some(name), add \"--model\" and the name to the args array passed to Command::new(\"claude\"). The claude CLI accepts `--model <name>` flag. Do the same for spawn_refiner() / its claude call — use the planning model for refinement too. Ensure cargo build passes with zero warnings.",
-      "durationSecs": 74,
-      "id": "S2",
-      "passes": true,
-      "priority": 2,
-      "retries": 2,
-      "tests": [],
-      "title": "Pass model config to planner spawn and add --model flag to claude args"
-    },
-    {
-      "acceptance": [],
-      "completedAt": "2026-03-26T19:28:15.848501+00:00",
-      "dependsOn": [
-        "S1"
-      ],
-      "description": "In crates/baro-tui/src/main.rs, modify spawn_executor() to accept the model config (model_routing: bool, override_model: Option<String>). Pass it through to executor::run_executor(). In crates/baro-tui/src/executor.rs, update run_executor() signature to accept model_routing: bool and override_model: Option<String>. Add a local helper function (or inline logic) to resolve the model for a given story: (1) if override_model is Some, always use it (CLI override wins); (2) if the story's PrdStory struct has a non-None `model` field (see S3a), use that (planner-selected override); (3) if model_routing is true, use \"sonnet\" for story execution and \"haiku\" for review; (4) else None (default). Pass the resolved execution model to run_claude_for_story() — update its signature to accept model: Option<String>, and when Some, add \"--model\" and the name to the claude args array. Similarly, in run_review_for_level(), resolve the review model and add \"--model\" flag to the review claude spawn args. Also pass the execution model to execute_story() so fix stories spawned during review also get the correct model. Log the model being used: at the start of each story, emit a StoryLog with line \"[model] using <model_name>\" (or \"[model] using default\" if None). Ensure cargo build passes with zero warnings.",
-      "durationSecs": 310,
-      "id": "S3",
-      "passes": true,
-      "priority": 3,
-      "retries": 2,
-      "tests": [],
-      "title": "Pass model config to executor and add --model flag to story execution and review agent"
-    },
-    {
-      "acceptance": [],
-      "completedAt": "2026-03-26T19:22:20.980081+00:00",
+      "title": "Add NotificationReady and TokenUsage events",
+      "description": "In crates/baro-tui/src/events.rs, add two new variants to the BaroEvent enum: (1) NotificationReady - a simple variant with no fields, serde-renamed to 'notification_ready'. (2) TokenUsage { id: String, input_tokens: u64, output_tokens: u64 } - serde-renamed to 'token_usage'. These are the foundation events that other stories will emit and handle.",
       "dependsOn": [],
-      "description": "Add an optional `model` field (Option<String>) to the PrdStory struct in the PRD data model (likely in crates/baro-tui/src/prd.rs or wherever PrdStory is defined). This field allows the planner to specify a per-story model override — for example, setting model to \"opus\" for a complex story that needs the full 1M-context model for implementation. The field defaults to None (meaning use the routing default). Update the planner prompt template to instruct the planner: \"If a story is complex enough to require the most capable model (opus with 1M context) for implementation, set its `model` field to `opus`. Otherwise leave it null/omit it.\" This way the intelligent planner (which itself runs on opus) can decide at planning time which stories need opus-level implementation versus which can use sonnet. Ensure the JSON deserialization handles the optional field gracefully (serde skip_serializing_if = Option::is_none, default). Ensure cargo build passes with zero warnings.",
-      "durationSecs": 93,
-      "id": "S3a",
-      "passes": true,
-      "priority": 4,
       "retries": 2,
+      "acceptance": [],
       "tests": [],
-      "title": "Add per-story model field to PrdStory and update planner prompt to allow opus escalation"
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null
     },
     {
-      "acceptance": [],
-      "completedAt": "2026-03-26T19:24:46.835410+00:00",
+      "id": "S2",
+      "priority": 2,
+      "title": "Fix notification to run outside TUI alternate screen",
+      "description": "Two changes: (1) In crates/baro-tui/src/executor.rs, replace the notification code block (terminal bell print!('\\x07') and osascript/notify-send spawn at lines ~1159-1176) with emitting BaroEvent::NotificationReady via the tx channel. Keep it after the Done event send. Remove the old print!/osascript/notify-send code entirely from executor.rs. (2) In crates/baro-tui/src/main.rs, after the terminal cleanup (after disable_raw_mode and LeaveAlternateScreen at ~line 153-156), and after the run_app result check, but before Ok(()), add notification code: print terminal bell, then run osascript on macos or notify-send on linux. This runs AFTER leaving the alternate screen so the notification actually fires. Also in main.rs handle_event or the event loop, add a match arm for BaroEvent::NotificationReady that sets a flag on App (add a field notification_ready: bool to App in app.rs), and after run_app returns in main(), check that flag to decide whether to notify. Pass the app out of run_app or use a shared flag.",
       "dependsOn": [
         "S1"
       ],
-      "description": "In crates/baro-tui/src/screens/execute.rs, modify render_header() to add a model indicator span in the header info line after the existing spans. If app.model_routing is true and app.override_model is None, show \"model: routed\" in ACCENT color. If app.override_model is Some(name), show \"model: <name>\" in WARNING color. If model_routing is false and override_model is None, show \"model: default\" in MUTED color. Add it with a separator like the existing spans. Also check screens/execute_completion.rs — if there's a summary section, add the model info there too. Ensure cargo build passes with zero warnings.",
-      "durationSecs": 103,
-      "id": "S4",
-      "passes": true,
-      "priority": 5,
       "retries": 2,
+      "acceptance": [],
       "tests": [],
-      "title": "Show active model in TUI header and completion screen"
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null,
+      "model": "opus"
     },
     {
-      "acceptance": [],
-      "completedAt": "2026-03-26T19:32:46.340097+00:00",
+      "id": "S3",
+      "priority": 3,
+      "title": "Parse token usage from Claude stream and emit TokenUsage",
+      "description": "In crates/baro-tui/src/executor.rs, modify the parse_claude_stream_line function. In the 'result' match arm (line ~156), after the existing result text parsing, check if the JSON event object has a 'usage' field. If ev.get('usage') exists, extract input_tokens and output_tokens as u64 from it. Return these values alongside the log lines. Change the return type to include optional token usage data, or add a second function. Then in the caller of parse_claude_stream_line (in run_claude_for_story or wherever stdout lines are processed), when token usage data is found, send a BaroEvent::TokenUsage { id: story_id, input_tokens, output_tokens } via the tx channel. The story_id parameter is already available as _story_id (rename it to story_id).",
       "dependsOn": [
-        "S2",
+        "S1"
+      ],
+      "retries": 2,
+      "acceptance": [],
+      "tests": [],
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null
+    },
+    {
+      "id": "S4",
+      "priority": 4,
+      "title": "Track token usage in App state",
+      "description": "In crates/baro-tui/src/app.rs: (1) Add three new fields to the App struct: token_usage: HashMap<String, (u64, u64)> for per-story token tracking, total_input_tokens: u64, and total_output_tokens: u64. Initialize all to default/zero in App::new(). (2) In the handle_event method, add a match arm for BaroEvent::TokenUsage { id, input_tokens, output_tokens }. It should: insert or update the entry in token_usage HashMap (accumulate if multiple events per story), and add to total_input_tokens and total_output_tokens. Make sure to add 'use std::collections::HashMap' if not already imported (it is already used for active_stories).",
+      "dependsOn": [
+        "S1"
+      ],
+      "retries": 2,
+      "acceptance": [],
+      "tests": [],
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null
+    },
+    {
+      "id": "S5",
+      "priority": 5,
+      "title": "Display tokens in stats, completion screen, and PR body",
+      "description": "Three files to modify: (1) crates/baro-tui/src/screens/execute_stats.rs: In the Summary section, add a new line showing total tokens: 'Tokens: {total_input} in / {total_output} out' using app.total_input_tokens and app.total_output_tokens. Format large numbers with comma separators for readability. In the Story table, add a 'Tokens' column showing per-story token counts from app.token_usage. (2) crates/baro-tui/src/screens/execute_completion.rs: Add a line showing total tokens after the 'Model' line: 'Tokens: {total_input} in / {total_output} out'. Adjust box_height by +1 to accommodate. (3) crates/baro-tui/src/executor.rs: In the PR body Stats section (around line ~1280-1294), add a line '- **Tokens:** {total_input} input / {total_output} output'. The executor needs access to total tokens - since executor.rs doesn't have app state, track totals in run_executor using variables that accumulate from TokenUsage events sent, OR compute from the events already sent. Simplest: maintain local total_input_tokens and total_output_tokens counters in run_executor alongside existing counters, incrementing them when TokenUsage is emitted.",
+      "dependsOn": [
         "S3",
-        "S3a",
         "S4"
       ],
-      "description": "Run cargo build on the entire workspace and fix any remaining warnings or errors. Check that all the pieces connect: CLI flags parsed -> App struct populated -> planner gets model -> planner can set per-story model field -> executor reads per-story model -> executor falls back to routing default -> review agent gets model -> TUI shows model. Verify that a story with model: \"opus\" in the PRD would cause the executor to spawn claude with --model opus for that story, overriding the default sonnet routing. Read through main.rs, app.rs, executor.rs, prd.rs, and the execute screen files to verify the full data flow is correct. Fix any unused imports, unused variables, or type mismatches. Ensure cargo build passes with zero warnings. Also verify that cargo clippy (if available) passes cleanly.",
-      "durationSecs": 245,
-      "id": "S5",
-      "passes": true,
-      "priority": 6,
       "retries": 2,
+      "acceptance": [],
       "tests": [],
-      "title": "Final cargo build zero-warnings check and integration validation"
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null,
+      "model": "opus"
+    },
+    {
+      "id": "S6",
+      "priority": 6,
+      "title": "Final cargo build zero-warnings check and integration validation",
+      "description": "Run 'cargo build 2>&1' and 'cargo clippy 2>&1' on the workspace. Fix ANY warnings (unused imports, unused variables, dead code, clippy lints). Verify all changes integrate correctly: events.rs has both new variants, executor.rs emits both events and no longer has notification code, main.rs handles notification after TUI exit, app.rs tracks tokens, stats/completion screens display tokens, PR body includes tokens. If any warnings remain, fix them. This is the final quality gate.",
+      "dependsOn": [
+        "S2",
+        "S5"
+      ],
+      "retries": 2,
+      "acceptance": [],
+      "tests": [],
+      "passes": false,
+      "completedAt": null,
+      "durationSecs": null
     }
   ]
 }

--- a/prd.json
+++ b/prd.json
@@ -49,14 +49,14 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T19:45:10.107832+00:00",
       "dependsOn": [
         "S1"
       ],
       "description": "In crates/baro-tui/src/app.rs: (1) Add three new fields to the App struct: token_usage: HashMap<String, (u64, u64)> for per-story token tracking, total_input_tokens: u64, and total_output_tokens: u64. Initialize all to default/zero in App::new(). (2) In the handle_event method, add a match arm for BaroEvent::TokenUsage { id, input_tokens, output_tokens }. It should: insert or update the entry in token_usage HashMap (accumulate if multiple events per story), and add to total_input_tokens and total_output_tokens. Make sure to add 'use std::collections::HashMap' if not already imported (it is already used for active_stories).",
-      "durationSecs": null,
+      "durationSecs": 31,
       "id": "S4",
-      "passes": false,
+      "passes": true,
       "priority": 4,
       "retries": 2,
       "tests": [],

--- a/prd.json
+++ b/prd.json
@@ -64,16 +64,16 @@
     },
     {
       "acceptance": [],
-      "completedAt": null,
+      "completedAt": "2026-03-26T19:52:52.891945+00:00",
       "dependsOn": [
         "S3",
         "S4"
       ],
       "description": "Three files to modify: (1) crates/baro-tui/src/screens/execute_stats.rs: In the Summary section, add a new line showing total tokens: 'Tokens: {total_input} in / {total_output} out' using app.total_input_tokens and app.total_output_tokens. Format large numbers with comma separators for readability. In the Story table, add a 'Tokens' column showing per-story token counts from app.token_usage. (2) crates/baro-tui/src/screens/execute_completion.rs: Add a line showing total tokens after the 'Model' line: 'Tokens: {total_input} in / {total_output} out'. Adjust box_height by +1 to accommodate. (3) crates/baro-tui/src/executor.rs: In the PR body Stats section (around line ~1280-1294), add a line '- **Tokens:** {total_input} input / {total_output} output'. The executor needs access to total tokens - since executor.rs doesn't have app state, track totals in run_executor using variables that accumulate from TokenUsage events sent, OR compute from the events already sent. Simplest: maintain local total_input_tokens and total_output_tokens counters in run_executor alongside existing counters, incrementing them when TokenUsage is emitted.",
-      "durationSecs": null,
+      "durationSecs": 318,
       "id": "S5",
       "model": "opus",
-      "passes": false,
+      "passes": true,
       "priority": 5,
       "retries": 2,
       "tests": [],


### PR DESCRIPTION
Fix completion notification (runs outside TUI) and add token cost tracking with per-story and total display

## Stories

| ID | Title | Duration | Status |
|:---|:------|:---------|:-------|
| S1 | Add NotificationReady and TokenUsage events | 16s | Done |
| S2 | Fix notification to run outside TUI alternate screen | 2m 7s | Done |
| S3 | Parse token usage from Claude stream and emit TokenUsage | 2m 25s | Done |
| S4 | Track token usage in App state | 31s | Done |
| S5 | Display tokens in stats, completion screen, and PR body | 5m 18s | Done |
| S6 | Final cargo build zero-warnings check and integration validation | 26s | Done |

## Stats

- **Wall time:** 11m 55s
- **Time saved:** 0s (parallelism)
- **Speedup:** 1.0x
- **Files created:** 0
- **Files modified:** 14
- **Stories:** 6/6 completed, 0 skipped

## Review

- **Review cycles:** 5
- **Fixes auto-applied:** 1

---

Built with [baro](https://www.npmjs.com/package/baro-ai) — Background Agent Runtime Orchestrator
