### PR TITLE
baro-windows-support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact: baro-linux-arm64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: baro-windows-x64.exe
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -45,8 +48,13 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
-      - name: Rename binary
+      - name: Rename binary (Unix)
+        if: runner.os != 'Windows'
         run: cp target/${{ matrix.target }}/release/baro ${{ matrix.artifact }}
+
+      - name: Rename binary (Windows)
+        if: runner.os == 'Windows'
+        run: cp target/${{ matrix.target }}/release/baro.exe ${{ matrix.artifact }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ baro --cwd ~/projects/myapp "Add REST API"
 - **Configurable parallelism** — `--parallel N` to limit concurrent story execution
 - **Story timeout** — `--timeout SECONDS` kills stuck agents (default: 10 minutes)
 - **Time saved** — shows parallel speedup vs sequential execution
-- **System notifications** — terminal bell + OS notification (macOS/Linux) when done
+- **System notifications** — terminal bell + OS notification (macOS/Linux/Windows) when done
 - **Retry logic** — failed stories retry automatically (configurable per story)
 
 ## Options
@@ -96,9 +96,11 @@ Options:
 ## Requirements
 
 - [Claude CLI](https://docs.anthropic.com/en/docs/claude-cli) installed and authenticated
-- macOS (arm64/x64) or Linux (x64/arm64)
+- macOS (arm64/x64), Linux (x64/arm64), or Windows (x64)
 - Node.js 18+ (only if using `--planner openai`)
 - `gh` CLI (optional, for automatic PR creation)
+
+> **Windows note:** Windows 10+ is required. For best TUI experience, use [Windows Terminal](https://aka.ms/terminal) or another modern terminal emulator.
 
 ## Architecture
 

--- a/crates/baro-tui/Cargo.toml
+++ b/crates/baro-tui/Cargo.toml
@@ -9,6 +9,9 @@ path = "src/main.rs"
 
 [dependencies]
 ratatui = "0.29"
+crossterm = "0.28"
+
+[target.'cfg(unix)'.dependencies]
 crossterm = { version = "0.28", features = ["use-dev-tty"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -269,6 +269,11 @@ async fn run_app(
                                 .args(["baro", "All stories complete"])
                                 .spawn();
                         }
+                        "windows" => {
+                            let _ = std::process::Command::new("powershell")
+                                .args(["-Command", "[console]::beep(1000,500)"])
+                                .spawn();
+                        }
                         _ => {}
                     }
                 }

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -7,7 +7,6 @@ mod screens;
 mod theme;
 mod ui;
 
-use std::fs::OpenOptions;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -72,8 +71,19 @@ enum AppEvent {
     Tick,
 }
 
-fn open_tty() -> io::Result<std::fs::File> {
-    OpenOptions::new().read(true).write(true).open("/dev/tty")
+fn open_terminal_writer() -> io::Result<Box<dyn Write>> {
+    #[cfg(unix)]
+    {
+        let f = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/tty")?;
+        Ok(Box::new(f))
+    }
+    #[cfg(not(unix))]
+    {
+        Ok(Box::new(io::stdout()))
+    }
 }
 
 const CLAUDE_PLANNER_PROMPT: &str = r#"You are an expert software architect. Break down the user's project goal into concrete user stories that form a dependency DAG.
@@ -141,12 +151,12 @@ struct PrdStoryOutput {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
-    let mut tty = open_tty()?;
+    let mut writer = open_terminal_writer()?;
     enable_raw_mode()?;
-    execute!(tty, EnterAlternateScreen)?;
-    execute!(tty, Clear(ClearType::All))?;
-    execute!(tty, Clear(ClearType::Purge))?;
-    let backend = CrosstermBackend::new(tty);
+    execute!(writer, EnterAlternateScreen)?;
+    execute!(writer, Clear(ClearType::All))?;
+    execute!(writer, Clear(ClearType::Purge))?;
+    let backend = CrosstermBackend::new(writer);
     let mut terminal = Terminal::new(backend)?;
 
     let result = run_app(&mut terminal, cli).await;
@@ -164,7 +174,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn run_app(
-    terminal: &mut Terminal<CrosstermBackend<std::fs::File>>,
+    terminal: &mut Terminal<CrosstermBackend<Box<dyn Write>>>,
     cli: Cli,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut app = App::new();

--- a/packages/baro-app/bin/baro.cmd
+++ b/packages/baro-app/bin/baro.cmd
@@ -1,0 +1,3 @@
+@echo off
+echo baro: binary not yet installed. Run: npm rebuild baro-ai 1>&2
+exit /b 1

--- a/packages/baro-app/scripts/postinstall.js
+++ b/packages/baro-app/scripts/postinstall.js
@@ -12,7 +12,7 @@ import * as https from "https"
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const PACKAGE_ROOT = path.resolve(__dirname, "..")
 const BIN_DIR = path.join(PACKAGE_ROOT, "bin")
-const BINARY_NAME = "baro"
+const BINARY_NAME = process.platform === "win32" ? "baro.exe" : "baro"
 const REPO = "Lotus015/baro"
 
 function getPlatformKey() {

--- a/packages/baro-app/scripts/postinstall.js
+++ b/packages/baro-app/scripts/postinstall.js
@@ -24,6 +24,7 @@ function getPlatformKey() {
         "darwin-x64": "darwin-x64",
         "linux-x64": "linux-x64",
         "linux-arm64": "linux-arm64",
+        "win32-x64": "windows-x64",
     }
 
     const key = `${platform}-${arch}`
@@ -67,7 +68,10 @@ async function main() {
     const platformKey = getPlatformKey()
     const version = getVersion()
 
-    const url = `https://github.com/${REPO}/releases/download/v${version}/${BINARY_NAME}-${platformKey}`
+    const artifactName = process.platform === "win32"
+        ? `baro-${platformKey}.exe`
+        : `${BINARY_NAME}-${platformKey}`
+    const url = `https://github.com/${REPO}/releases/download/v${version}/${artifactName}`
 
     console.log(`Downloading baro for ${platformKey}...`)
 
@@ -75,7 +79,9 @@ async function main() {
 
     try {
         await download(url, binaryPath)
-        fs.chmodSync(binaryPath, 0o755)
+        if (process.platform !== "win32") {
+            fs.chmodSync(binaryPath, 0o755)
+        }
         console.log(`baro installed successfully`)
     } catch (err) {
         console.warn(`Warning: Could not download baro: ${err.message}`)


### PR DESCRIPTION
Add Windows platform support for the baro CLI tool

## Stories

| ID | Title | Duration | Status |
|:---|:------|:---------|:-------|
| S1 | Replace /dev/tty with cross-platform terminal I/O | 1m 30s | Done |
| S2 | Add Windows notification support | 15s | Done |
| S3 | Add Windows binary target to CI release workflow | 20s | Done |
| S4 | Update npm postinstall for Windows platform | 1m 12s | Done |
| S5 | Add cross-platform bin launcher for Windows | 17s | Done |
| S6 | Update README and requirements for Windows | 34s | Done |

## Stats

- **Wall time:** 4m 11s
- **Time saved:** 0s (parallelism)
- **Speedup:** 1.0x
- **Files created:** 1
- **Files modified:** 7
- **Tokens:** 1,118 input / 9,401 output
- **Stories:** 6/6 completed, 0 skipped

## Review

- **Review cycles:** 3
- **Fixes auto-applied:** 0

---

Built with [baro](https://www.npmjs.com/package/baro-ai) — Background Agent Runtime Orchestrator
