### PR TITLE
baro-context-builder

### DIFF
--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -101,6 +101,9 @@ pub struct App {
     // Welcome screen
     pub goal_input: String,
 
+    // Context building screen
+    pub claude_md_content: Option<String>,
+
     // Planning screen
     pub planning_start: Option<Instant>,
     pub planning_error: Option<String>,
@@ -177,6 +180,8 @@ impl App {
 
             goal_input: String::new(),
 
+            claude_md_content: None,
+
             planning_start: None,
             planning_error: None,
 
@@ -222,6 +227,11 @@ impl App {
     }
 
     // Screen transitions
+    pub fn start_context(&mut self) {
+        self.screen = Screen::Context;
+        self.tick_count = 0;
+    }
+
     pub fn start_planning(&mut self) {
         self.screen = Screen::Planning;
         self.planning_start = Some(Instant::now());

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -8,6 +8,7 @@ const MAX_LOG_LINES: usize = 200;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Screen {
     Welcome,
+    Context,
     Planning,
     Review,
     Execute,
@@ -151,6 +152,9 @@ pub struct App {
     pub model_routing: bool,
     pub override_model: Option<String>,
 
+    // Context building
+    pub skip_context: bool,
+
     // Notification flag
     pub notification_ready: bool,
 
@@ -207,6 +211,7 @@ impl App {
             notification_ready: false,
             model_routing: true,
             override_model: None,
+            skip_context: false,
             token_usage: HashMap::new(),
             total_input_tokens: 0,
             total_output_tokens: 0,

--- a/crates/baro-tui/src/context.rs
+++ b/crates/baro-tui/src/context.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::path::{Path, PathBuf};
 
 use tokio::fs;
+use tokio::process::Command;
 
 /// Build a CLAUDE.md context string by scanning the project at `cwd`.
 pub async fn build_context(cwd: &Path) -> Result<String, Box<dyn Error + Send + Sync>> {
@@ -100,7 +101,54 @@ pub async fn build_context(cwd: &Path) -> Result<String, Box<dyn Error + Send + 
         }
     }
 
-    Ok(md)
+    // Enhance the raw scan output with haiku model for a better-structured CLAUDE.md
+    if let Some(enhanced) = enhance_with_haiku(&md).await {
+        Ok(enhanced)
+    } else {
+        Ok(md)
+    }
+}
+
+/// Use the haiku model to refine the raw project scan into a concise, well-structured CLAUDE.md.
+/// Falls back to the raw scan if haiku is unavailable or returns an empty result.
+async fn enhance_with_haiku(raw_context: &str) -> Option<String> {
+    let prompt = format!(
+        "You are a technical documentation assistant. Below is raw project scan data. \
+         Rewrite it as a clean, concise CLAUDE.md file that helps an AI coding assistant \
+         understand this project. Keep it under 500 words. Use markdown headers. \
+         Include: project overview, tech stack, key files, build commands, and conventions.\n\n\
+         Raw scan data:\n{}\n\nReturn ONLY the CLAUDE.md content, no preamble or code fences.",
+        raw_context
+    );
+
+    let output = Command::new("claude")
+        .args([
+            "--dangerously-skip-permissions",
+            "--model",
+            "haiku",
+            "--output-format",
+            "json",
+            "-p",
+            &prompt,
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .await
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).ok()?;
+    let result = json.get("result").and_then(|r| r.as_str())?;
+    let trimmed = result.trim().to_string();
+    if trimmed.is_empty() || trimmed == "No response." {
+        return None;
+    }
+    Some(trimmed)
 }
 
 struct TechStackEntry {

--- a/crates/baro-tui/src/context.rs
+++ b/crates/baro-tui/src/context.rs
@@ -314,7 +314,7 @@ fn extract_toml_value(content: &str, key: &str) -> Option<String> {
     for line in content.lines() {
         let trimmed = line.trim();
         if trimmed.starts_with(&format!("{} ", key)) || trimmed.starts_with(&format!("{}=", key)) {
-            if let Some(val) = trimmed.splitn(2, '=').nth(1) {
+            if let Some(val) = trimmed.split_once('=').map(|x| x.1) {
                 let val = val.trim().trim_matches('"');
                 if !val.is_empty() {
                     return Some(val.to_string());
@@ -552,7 +552,7 @@ async fn detect_conventions(cwd: &Path) -> Conventions {
         ),
     ]);
 
-    for (_prefix, variants) in &prefix_configs {
+    for variants in prefix_configs.values() {
         for name in *variants {
             if fs::metadata(cwd.join(name)).await.is_ok() {
                 linter_configs.push(name.to_string());

--- a/crates/baro-tui/src/context.rs
+++ b/crates/baro-tui/src/context.rs
@@ -1,0 +1,598 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+use tokio::fs;
+
+/// Build a CLAUDE.md context string by scanning the project at `cwd`.
+pub async fn build_context(cwd: &Path) -> Result<String, Box<dyn Error + Send + Sync>> {
+    let tech_stack = detect_tech_stack(cwd).await;
+    let dir_tree = build_directory_tree(cwd, cwd, 0, 3).await;
+    let entry_points = find_entry_points(cwd).await;
+    let build_commands = detect_build_commands(cwd).await;
+    let conventions = detect_conventions(cwd).await;
+
+    let project_name = tech_stack
+        .iter()
+        .find_map(|ts| ts.project_name.clone())
+        .unwrap_or_else(|| {
+            cwd.file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| "Unknown Project".to_string())
+        });
+
+    let description = tech_stack
+        .iter()
+        .find_map(|ts| ts.description.clone())
+        .unwrap_or_default();
+
+    let mut md = String::new();
+
+    // Project Overview
+    md.push_str(&format!("# Project Overview\n\n**{}**", project_name));
+    if !description.is_empty() {
+        md.push_str(&format!(" — {}", description));
+    }
+    md.push('\n');
+
+    // Tech Stack
+    md.push_str("\n## Tech Stack\n\n");
+    if tech_stack.is_empty() {
+        md.push_str("No recognized config files found.\n");
+    } else {
+        for ts in &tech_stack {
+            md.push_str(&format!("- **{}**", ts.config_file));
+            if let Some(v) = &ts.version {
+                md.push_str(&format!(" (v{})", v));
+            }
+            md.push('\n');
+            for dep in &ts.key_deps {
+                md.push_str(&format!("  - {}\n", dep));
+            }
+        }
+    }
+
+    // Directory Structure
+    md.push_str("\n## Directory Structure\n\n```\n");
+    md.push_str(&dir_tree);
+    md.push_str("```\n");
+
+    // Build and Test Commands
+    md.push_str("\n## Build and Test Commands\n\n");
+    if build_commands.is_empty() {
+        md.push_str("No build commands detected.\n");
+    } else {
+        for (label, cmd) in &build_commands {
+            md.push_str(&format!("- **{}**: `{}`\n", label, cmd));
+        }
+    }
+
+    // Key Files
+    md.push_str("\n## Key Files\n\n");
+    if entry_points.is_empty() {
+        md.push_str("No standard entry points detected.\n");
+    } else {
+        for ep in &entry_points {
+            md.push_str(&format!("- `{}`\n", ep));
+        }
+    }
+    // Add detected config files
+    for ts in &tech_stack {
+        md.push_str(&format!("- `{}`\n", ts.config_file));
+    }
+
+    // Conventions
+    md.push_str("\n## Conventions\n\n");
+    if conventions.linter_configs.is_empty() && conventions.test_dirs.is_empty() {
+        md.push_str("No linter/formatter configs or test directories detected.\n");
+    } else {
+        if !conventions.linter_configs.is_empty() {
+            md.push_str("**Linter/Formatter configs:**\n");
+            for c in &conventions.linter_configs {
+                md.push_str(&format!("- `{}`\n", c));
+            }
+        }
+        if !conventions.test_dirs.is_empty() {
+            md.push_str("\n**Test directories:**\n");
+            for d in &conventions.test_dirs {
+                md.push_str(&format!("- `{}/`\n", d));
+            }
+        }
+    }
+
+    Ok(md)
+}
+
+struct TechStackEntry {
+    config_file: String,
+    project_name: Option<String>,
+    description: Option<String>,
+    version: Option<String>,
+    key_deps: Vec<String>,
+}
+
+async fn detect_tech_stack(cwd: &Path) -> Vec<TechStackEntry> {
+    let mut entries = Vec::new();
+
+    // package.json
+    if let Some(e) = parse_package_json(cwd).await {
+        entries.push(e);
+    }
+    // Cargo.toml
+    if let Some(e) = parse_cargo_toml(cwd).await {
+        entries.push(e);
+    }
+    // go.mod
+    if let Some(e) = parse_go_mod(cwd).await {
+        entries.push(e);
+    }
+    // pyproject.toml
+    if let Some(e) = parse_pyproject_toml(cwd).await {
+        entries.push(e);
+    }
+    // requirements.txt
+    if let Some(e) = parse_requirements_txt(cwd).await {
+        entries.push(e);
+    }
+
+    // Simple presence-based detection for remaining config files
+    let simple_configs = [
+        "Makefile",
+        "CMakeLists.txt",
+        "build.gradle",
+        "pom.xml",
+        "Gemfile",
+        "composer.json",
+    ];
+    for name in simple_configs {
+        let path = cwd.join(name);
+        if fs::metadata(&path).await.is_ok() {
+            entries.push(TechStackEntry {
+                config_file: name.to_string(),
+                project_name: None,
+                description: None,
+                version: None,
+                key_deps: Vec::new(),
+            });
+        }
+    }
+
+    entries
+}
+
+async fn parse_package_json(cwd: &Path) -> Option<TechStackEntry> {
+    let content = fs::read_to_string(cwd.join("package.json")).await.ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+    let project_name = json.get("name").and_then(|v| v.as_str()).map(String::from);
+    let description = json
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let version = json
+        .get("version")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let mut key_deps = Vec::new();
+    if let Some(deps) = json.get("dependencies").and_then(|v| v.as_object()) {
+        for k in deps.keys().take(10) {
+            key_deps.push(k.clone());
+        }
+    }
+
+    Some(TechStackEntry {
+        config_file: "package.json".to_string(),
+        project_name,
+        description,
+        version,
+        key_deps,
+    })
+}
+
+async fn parse_cargo_toml(cwd: &Path) -> Option<TechStackEntry> {
+    let content = fs::read_to_string(cwd.join("Cargo.toml")).await.ok()?;
+
+    let project_name = extract_toml_value(&content, "name");
+    let description = extract_toml_value(&content, "description");
+    let version = extract_toml_value(&content, "version");
+
+    let mut key_deps = Vec::new();
+    let mut in_deps = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("[dependencies]") || trimmed.starts_with("[dev-dependencies]") {
+            in_deps = true;
+            continue;
+        }
+        if trimmed.starts_with('[') {
+            in_deps = false;
+            continue;
+        }
+        if in_deps {
+            if let Some(name) = trimmed.split('=').next() {
+                let name = name.trim();
+                if !name.is_empty() && key_deps.len() < 10 {
+                    key_deps.push(name.to_string());
+                }
+            }
+        }
+    }
+
+    Some(TechStackEntry {
+        config_file: "Cargo.toml".to_string(),
+        project_name,
+        description,
+        version,
+        key_deps,
+    })
+}
+
+async fn parse_go_mod(cwd: &Path) -> Option<TechStackEntry> {
+    let content = fs::read_to_string(cwd.join("go.mod")).await.ok()?;
+
+    let project_name = content
+        .lines()
+        .find(|l| l.starts_with("module "))
+        .map(|l| l.trim_start_matches("module ").trim().to_string());
+
+    let mut key_deps = Vec::new();
+    let mut in_require = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("require (") {
+            in_require = true;
+            continue;
+        }
+        if trimmed == ")" {
+            in_require = false;
+            continue;
+        }
+        if in_require && key_deps.len() < 10 {
+            if let Some(dep) = trimmed.split_whitespace().next() {
+                if !dep.is_empty() {
+                    key_deps.push(dep.to_string());
+                }
+            }
+        }
+    }
+
+    Some(TechStackEntry {
+        config_file: "go.mod".to_string(),
+        project_name,
+        description: None,
+        version: None,
+        key_deps,
+    })
+}
+
+async fn parse_pyproject_toml(cwd: &Path) -> Option<TechStackEntry> {
+    let content = fs::read_to_string(cwd.join("pyproject.toml")).await.ok()?;
+
+    let project_name = extract_toml_value(&content, "name");
+    let description = extract_toml_value(&content, "description");
+    let version = extract_toml_value(&content, "version");
+
+    Some(TechStackEntry {
+        config_file: "pyproject.toml".to_string(),
+        project_name,
+        description,
+        version,
+        key_deps: Vec::new(),
+    })
+}
+
+async fn parse_requirements_txt(cwd: &Path) -> Option<TechStackEntry> {
+    let content = fs::read_to_string(cwd.join("requirements.txt"))
+        .await
+        .ok()?;
+
+    let key_deps: Vec<String> = content
+        .lines()
+        .filter(|l| !l.trim().is_empty() && !l.starts_with('#'))
+        .take(10)
+        .map(|l| {
+            l.split(['=', '>', '<', '!', '~', ';'])
+                .next()
+                .unwrap_or(l)
+                .trim()
+                .to_string()
+        })
+        .collect();
+
+    Some(TechStackEntry {
+        config_file: "requirements.txt".to_string(),
+        project_name: None,
+        description: None,
+        version: None,
+        key_deps,
+    })
+}
+
+/// Extract a simple `key = "value"` from TOML content (within [package] or top-level).
+fn extract_toml_value(content: &str, key: &str) -> Option<String> {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with(&format!("{} ", key)) || trimmed.starts_with(&format!("{}=", key)) {
+            if let Some(val) = trimmed.splitn(2, '=').nth(1) {
+                let val = val.trim().trim_matches('"');
+                if !val.is_empty() {
+                    return Some(val.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+const SKIP_DIRS: &[&str] = &[
+    "node_modules",
+    "target",
+    "dist",
+    ".git",
+    "__pycache__",
+    ".next",
+    "build",
+    "vendor",
+    ".gradle",
+    ".idea",
+    ".vscode",
+    "venv",
+    ".env",
+];
+
+async fn build_directory_tree(base: &Path, dir: &Path, depth: u32, max_depth: u32) -> String {
+    if depth >= max_depth {
+        return String::new();
+    }
+
+    let mut entries: Vec<PathBuf> = Vec::new();
+    let mut read_dir = match fs::read_dir(dir).await {
+        Ok(rd) => rd,
+        Err(_) => return String::new(),
+    };
+
+    while let Ok(Some(entry)) = read_dir.next_entry().await {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if SKIP_DIRS.contains(&name_str.as_ref()) {
+            continue;
+        }
+        entries.push(entry.path());
+    }
+
+    entries.sort();
+
+    let mut result = String::new();
+    let indent = "  ".repeat(depth as usize);
+
+    for entry_path in entries {
+        let name = entry_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        if let Ok(meta) = fs::metadata(&entry_path).await {
+            if meta.is_dir() {
+                result.push_str(&format!("{}{}/\n", indent, name));
+                let subtree =
+                    Box::pin(build_directory_tree(base, &entry_path, depth + 1, max_depth)).await;
+                result.push_str(&subtree);
+            } else {
+                result.push_str(&format!("{}{}\n", indent, name));
+            }
+        }
+    }
+
+    result
+}
+
+const ENTRY_POINT_FILES: &[&str] = &[
+    "main.rs",
+    "main.go",
+    "main.py",
+    "index.ts",
+    "index.js",
+    "App.tsx",
+    "app.py",
+    "manage.py",
+];
+
+async fn find_entry_points(cwd: &Path) -> Vec<String> {
+    let mut found = Vec::new();
+
+    // Check src/ directory
+    let src_dir = cwd.join("src");
+    if fs::metadata(&src_dir).await.is_ok() {
+        found.push("src/".to_string());
+        // Look for entry points inside src/
+        for name in ENTRY_POINT_FILES {
+            let p = src_dir.join(name);
+            if fs::metadata(&p).await.is_ok() {
+                found.push(format!("src/{}", name));
+            }
+        }
+    }
+
+    // Check bin/ directory
+    let bin_dir = cwd.join("bin");
+    if fs::metadata(&bin_dir).await.is_ok() {
+        found.push("bin/".to_string());
+    }
+
+    // Check root-level entry points
+    for name in ENTRY_POINT_FILES {
+        let p = cwd.join(name);
+        if fs::metadata(&p).await.is_ok() {
+            found.push(name.to_string());
+        }
+    }
+
+    found
+}
+
+async fn detect_build_commands(cwd: &Path) -> Vec<(String, String)> {
+    let mut commands = Vec::new();
+
+    // package.json scripts
+    if let Ok(content) = fs::read_to_string(cwd.join("package.json")).await {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Some(scripts) = json.get("scripts").and_then(|v| v.as_object()) {
+                for (k, v) in scripts {
+                    if let Some(cmd) = v.as_str() {
+                        commands.push((format!("npm run {}", k), cmd.to_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    // Cargo.toml
+    if fs::metadata(cwd.join("Cargo.toml")).await.is_ok() {
+        commands.push(("Build (Rust)".to_string(), "cargo build".to_string()));
+        commands.push(("Test (Rust)".to_string(), "cargo test".to_string()));
+    }
+
+    // go.mod
+    if fs::metadata(cwd.join("go.mod")).await.is_ok() {
+        commands.push(("Build (Go)".to_string(), "go build ./...".to_string()));
+        commands.push(("Test (Go)".to_string(), "go test ./...".to_string()));
+    }
+
+    // Makefile targets
+    if let Ok(content) = fs::read_to_string(cwd.join("Makefile")).await {
+        for line in content.lines() {
+            if let Some(target) = line.strip_suffix(':') {
+                let target = target.trim();
+                // Only include simple targets (no variables, no prerequisites on this check)
+                if !target.is_empty()
+                    && !target.contains('$')
+                    && !target.contains(' ')
+                    && !target.starts_with('.')
+                    && !target.starts_with('#')
+                {
+                    commands.push((format!("make {}", target), format!("make {}", target)));
+                }
+            }
+        }
+    }
+
+    // pyproject.toml scripts
+    if let Ok(content) = fs::read_to_string(cwd.join("pyproject.toml")).await {
+        let mut in_scripts = false;
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed == "[tool.poetry.scripts]" || trimmed == "[project.scripts]" {
+                in_scripts = true;
+                continue;
+            }
+            if trimmed.starts_with('[') {
+                in_scripts = false;
+                continue;
+            }
+            if in_scripts {
+                if let Some((name, _)) = trimmed.split_once('=') {
+                    commands.push((name.trim().to_string(), name.trim().to_string()));
+                }
+            }
+        }
+    }
+
+    commands
+}
+
+struct Conventions {
+    linter_configs: Vec<String>,
+    test_dirs: Vec<String>,
+}
+
+async fn detect_conventions(cwd: &Path) -> Conventions {
+    let mut linter_configs = Vec::new();
+    let mut test_dirs = Vec::new();
+
+    // Check for linter/formatter configs
+    let exact_configs = [
+        "rustfmt.toml",
+        ".rustfmt.toml",
+        "clippy.toml",
+        ".golangci.yml",
+        ".flake8",
+        "setup.cfg",
+        ".editorconfig",
+        "tsconfig.json",
+    ];
+
+    for name in exact_configs {
+        if fs::metadata(cwd.join(name)).await.is_ok() {
+            linter_configs.push(name.to_string());
+        }
+    }
+
+    // Check for eslintrc/prettierrc variants
+    let prefix_configs: BTreeMap<&str, &[&str]> = BTreeMap::from([
+        (
+            ".eslintrc",
+            &[
+                ".eslintrc",
+                ".eslintrc.js",
+                ".eslintrc.cjs",
+                ".eslintrc.json",
+                ".eslintrc.yml",
+            ][..],
+        ),
+        (
+            ".prettierrc",
+            &[
+                ".prettierrc",
+                ".prettierrc.js",
+                ".prettierrc.cjs",
+                ".prettierrc.json",
+                ".prettierrc.yml",
+            ][..],
+        ),
+    ]);
+
+    for (_prefix, variants) in &prefix_configs {
+        for name in *variants {
+            if fs::metadata(cwd.join(name)).await.is_ok() {
+                linter_configs.push(name.to_string());
+                break;
+            }
+        }
+    }
+
+    // Check pyproject.toml for [tool.*] sections
+    if let Ok(content) = fs::read_to_string(cwd.join("pyproject.toml")).await {
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("[tool.") && trimmed.ends_with(']') {
+                let tool_name = trimmed
+                    .trim_start_matches("[tool.")
+                    .trim_end_matches(']')
+                    .split('.')
+                    .next()
+                    .unwrap_or("");
+                let entry = format!("pyproject.toml [tool.{}]", tool_name);
+                if !linter_configs.contains(&entry) {
+                    linter_configs.push(entry);
+                }
+            }
+        }
+    }
+
+    // Check for test directories
+    let test_dir_names = ["tests", "test", "__tests__", "spec"];
+    for name in test_dir_names {
+        let path = cwd.join(name);
+        if let Ok(meta) = fs::metadata(&path).await {
+            if meta.is_dir() {
+                test_dirs.push(name.to_string());
+            }
+        }
+    }
+
+    Conventions {
+        linter_configs,
+        test_dirs,
+    }
+}

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -55,7 +55,7 @@ fn default_retries() -> u32 {
 
 // ─── Story prompt builder ───────────────────────────────────
 
-fn build_prompt(story: &PrdStory, cwd: &Path) -> String {
+fn build_prompt(story: &PrdStory, cwd: &Path, context: Option<&str>) -> String {
     let template_path = cwd.join("prompt.md");
     let template = if template_path.exists() {
         std::fs::read_to_string(&template_path).unwrap_or_default()
@@ -94,12 +94,17 @@ fn build_prompt(story: &PrdStory, cwd: &Path) -> String {
         story.tests.join(" && ")
     };
 
-    template
+    let template_result = template
         .replace("STORY_ID", &story.id)
         .replace("STORY_TITLE", &story.title)
         .replace("STORY_DESCRIPTION", &story.description)
         .replace("ACCEPTANCE_CRITERIA", &acceptance)
-        .replace("TEST_COMMANDS", &tests)
+        .replace("TEST_COMMANDS", &tests);
+
+    match context {
+        Some(ctx) => format!("Here is the project context:\n{}\n\n{}", ctx, template_result),
+        None => template_result,
+    }
 }
 
 // ─── Claude stream-json parser ──────────────────────────────
@@ -250,6 +255,7 @@ async fn execute_story(
     git_mutex: &Mutex<()>,
     timeout_secs: u64,
     model: Option<String>,
+    context: Option<&str>,
 ) -> Result<(u64, u32, u32, u64, u64), String> {
     let max_attempts = story.retries + 1;
 
@@ -278,7 +284,7 @@ async fn execute_story(
         }
 
         let start = Instant::now();
-        let prompt = build_prompt(story, cwd);
+        let prompt = build_prompt(story, cwd, context);
 
         let result =
             run_claude_for_story(&story.id, &prompt, cwd, tx, timeout_secs, &model).await;
@@ -611,6 +617,7 @@ async fn run_review_for_level(
     timeout_secs: u64,
     model_routing: bool,
     override_model: &Option<String>,
+    context: Option<&str>,
 ) -> (u32, u32) {
     let mut cycles_run: u32 = 0;
     let mut total_fixes_applied: u32 = 0;
@@ -717,7 +724,7 @@ async fn run_review_for_level(
         };
 
         // Build review prompt — acceptance criteria + code quality checks
-        let prompt = format!(
+        let base_review_prompt = format!(
             "You are a focused code reviewer. Check whether the acceptance criteria are met by the diff, \
              and also check for obvious code quality problems.\n\n\
              ACCEPTANCE CRITERIA:\n{}\n\n\
@@ -747,6 +754,10 @@ async fn run_review_for_level(
                 &diff
             }
         );
+        let prompt = match context {
+            Some(ctx) => format!("Here is the project context:\n{}\n\n{}", ctx, base_review_prompt),
+            None => base_review_prompt,
+        };
 
         let review_model = resolve_model(override_model, &None, model_routing, "review");
         let review_model_label = review_model.as_deref().unwrap_or("default");
@@ -908,7 +919,7 @@ async fn run_review_for_level(
             };
 
             let fix_model = resolve_model(override_model, &None, model_routing, "execute");
-            match execute_story(&fix_story, cwd, prd_path, tx, git_mutex, timeout_secs, fix_model)
+            match execute_story(&fix_story, cwd, prd_path, tx, git_mutex, timeout_secs, fix_model, context)
                 .await
             {
                 Ok((duration_secs, files_created, files_modified, _, _)) => {
@@ -979,6 +990,7 @@ pub async fn run_executor(
     timeout_secs: u64,
     model_routing: bool,
     override_model: Option<String>,
+    context_content: Option<String>,
 ) {
     let prd_path = cwd.join("prd.json");
     let stories = &prd.user_stories;
@@ -1091,6 +1103,7 @@ pub async fn run_executor(
             let semaphore = semaphore.clone();
             let story_model =
                 resolve_model(&override_model, &story.model, model_routing, "execute");
+            let ctx = context_content.clone();
             let handle = tokio::spawn(async move {
                 let _permit = if let Some(ref sem) = semaphore {
                     Some(sem.acquire().await.expect("semaphore closed"))
@@ -1105,6 +1118,7 @@ pub async fn run_executor(
                     &git_mutex,
                     timeout_secs,
                     story_model,
+                    ctx.as_deref(),
                 )
                 .await
             });
@@ -1179,6 +1193,7 @@ pub async fn run_executor(
                 timeout_secs,
                 model_routing,
                 &override_model,
+                context_content.as_deref(),
             )
             .await;
             review_cycles += cycles;

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -53,6 +53,22 @@ fn default_retries() -> u32 {
     2
 }
 
+/// Configuration passed to [`run_executor`] and friends.
+pub struct ExecutorConfig {
+    pub parallel: u32,
+    pub timeout_secs: u64,
+    pub model_routing: bool,
+    pub override_model: Option<String>,
+    pub context_content: Option<String>,
+}
+
+/// Per-story execution parameters (avoids too-many-arguments).
+struct StoryExecConfig<'a> {
+    timeout_secs: u64,
+    model: Option<String>,
+    context: Option<&'a str>,
+}
+
 // ─── Story prompt builder ───────────────────────────────────
 
 fn build_prompt(story: &PrdStory, cwd: &Path, context: Option<&str>) -> String {
@@ -253,10 +269,9 @@ async fn execute_story(
     prd_path: &Path,
     tx: &mpsc::Sender<BaroEvent>,
     git_mutex: &Mutex<()>,
-    timeout_secs: u64,
-    model: Option<String>,
-    context: Option<&str>,
+    cfg: StoryExecConfig<'_>,
 ) -> Result<(u64, u32, u32, u64, u64), String> {
+    let StoryExecConfig { timeout_secs, model, context } = cfg;
     let max_attempts = story.retries + 1;
 
     for attempt in 1..=max_attempts {
@@ -919,7 +934,7 @@ async fn run_review_for_level(
             };
 
             let fix_model = resolve_model(override_model, &None, model_routing, "execute");
-            match execute_story(&fix_story, cwd, prd_path, tx, git_mutex, timeout_secs, fix_model, context)
+            match execute_story(&fix_story, cwd, prd_path, tx, git_mutex, StoryExecConfig { timeout_secs, model: fix_model, context })
                 .await
             {
                 Ok((duration_secs, files_created, files_modified, _, _)) => {
@@ -986,12 +1001,9 @@ pub async fn run_executor(
     prd: PrdFile,
     cwd: PathBuf,
     tx: mpsc::Sender<BaroEvent>,
-    parallel: u32,
-    timeout_secs: u64,
-    model_routing: bool,
-    override_model: Option<String>,
-    context_content: Option<String>,
+    config: ExecutorConfig,
 ) {
+    let ExecutorConfig { parallel, timeout_secs, model_routing, override_model, context_content } = config;
     let prd_path = cwd.join("prd.json");
     let stories = &prd.user_stories;
     let incomplete: Vec<&PrdStory> = stories.iter().filter(|s| !s.passes).collect();
@@ -1116,9 +1128,7 @@ pub async fn run_executor(
                     &prd_path,
                     &tx,
                     &git_mutex,
-                    timeout_secs,
-                    story_model,
-                    ctx.as_deref(),
+                    StoryExecConfig { timeout_secs, model: story_model, context: ctx.as_deref() },
                 )
                 .await
             });
@@ -1291,10 +1301,7 @@ pub async fn run_executor(
         let current_prd: PrdFile = serde_json::from_str(&prd_data).ok()?;
 
         // Calculate per-level parallelism gain using DAG
-        let dag_levels = match crate::dag::build_dag(&current_prd.user_stories) {
-            Ok(levels) => levels,
-            Err(_) => Vec::new(),
-        };
+        let dag_levels = crate::dag::build_dag(&current_prd.user_stories).unwrap_or_default();
         let (level_saved, sequential_time) = {
             let mut tseq = 0u64;
             let mut tpar = 0u64;

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -605,6 +605,97 @@ async fn detect_project_and_build(cwd: &Path) -> Option<String> {
     None
 }
 
+// ─── Final build verification with haiku ────────────────────
+
+async fn verify_build_with_haiku(
+    build_output: &str,
+    tx: &mpsc::Sender<BaroEvent>,
+    override_model: &Option<String>,
+    model_routing: bool,
+) {
+    let verification_model = resolve_model(override_model, &None, model_routing, "review");
+    let model_label = verification_model.as_deref().unwrap_or("default");
+
+    let _ = tx
+        .send(BaroEvent::StoryLog {
+            id: "finalize".to_string(),
+            line: format!("[model] final build verification using {}", model_label),
+        })
+        .await;
+
+    let prompt = format!(
+        "Analyze this build output and determine if the build succeeded or failed.\n\
+         Respond with ONLY valid JSON (no markdown fences):\n\
+         {{\"passed\": boolean, \"summary\": \"one-line summary of build result\"}}\n\n\
+         Build output:\n{}",
+        if build_output.len() > 5000 {
+            &build_output[..5000]
+        } else {
+            build_output
+        }
+    );
+
+    let mut args = vec![
+        "--dangerously-skip-permissions".to_string(),
+        "--output-format".to_string(),
+        "json".to_string(),
+        "-p".to_string(),
+        prompt,
+    ];
+    if let Some(ref m) = verification_model {
+        args.push("--model".to_string());
+        args.push(m.clone());
+    }
+
+    let output = match Command::new("claude")
+        .args(&args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            let _ = tx
+                .send(BaroEvent::StoryLog {
+                    id: "finalize".to_string(),
+                    line: format!("[build-verify] failed to spawn: {}", e),
+                })
+                .await;
+            return;
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json_str = extract_json(&stdout);
+
+    #[derive(serde::Deserialize)]
+    struct BuildVerificationResult {
+        passed: bool,
+        summary: String,
+    }
+
+    match serde_json::from_str::<BuildVerificationResult>(&json_str) {
+        Ok(result) => {
+            let status = if result.passed { "PASSED" } else { "FAILED" };
+            let _ = tx
+                .send(BaroEvent::StoryLog {
+                    id: "finalize".to_string(),
+                    line: format!("[build-verify] {} — {}", status, result.summary),
+                })
+                .await;
+        }
+        Err(_) => {
+            let _ = tx
+                .send(BaroEvent::StoryLog {
+                    id: "finalize".to_string(),
+                    line: "[build-verify] could not parse verification result".to_string(),
+                })
+                .await;
+        }
+    }
+}
+
 // ─── Review agent ───────────────────────────────────────────
 
 #[derive(Debug, serde::Deserialize)]
@@ -1267,16 +1358,9 @@ pub async fn run_executor(
     // ─── Finalize phase ─────────────────────────────────────────
     let _ = tx.send(BaroEvent::FinalizeStart).await;
 
-    // Step 1: Run build detection
+    // Step 1: Run build detection and verify with haiku model
     if let Some(output) = detect_project_and_build(&cwd).await {
-        if output.to_lowercase().contains("error") {
-            let _ = tx
-                .send(BaroEvent::StoryLog {
-                    id: "finalize".to_string(),
-                    line: format!("Build warning: {}", output),
-                })
-                .await;
-        }
+        verify_build_with_haiku(&output, &tx, &override_model, model_routing).await;
     }
 
     // Step 2: Try to create a GitHub PR

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -431,11 +431,12 @@ async fn run_app(
                                         let branch_tx = tx.clone();
                                         let mr = app.model_routing;
                                         let om = app.override_model.clone();
+                                        let ctx = app.claude_md_content.clone();
                                         tokio::spawn(async move {
                                             if let Err(e) = git::create_or_checkout_branch(&branch_cwd, &branch_name_clone).await {
                                                 eprintln!("[baro] branch checkout failed: {}", e);
                                             }
-                                            spawn_executor(prd, exec_cwd, branch_tx, parallel, timeout_secs, mr, om);
+                                            spawn_executor(prd, exec_cwd, branch_tx, parallel, timeout_secs, mr, om, ctx);
                                         });
                                     }
                                     Err(e) => {
@@ -464,11 +465,12 @@ async fn run_app(
                                     let branch_tx = tx.clone();
                                     let mr = app.model_routing;
                                     let om = app.override_model.clone();
+                                    let ctx = app.claude_md_content.clone();
                                     tokio::spawn(async move {
                                         if let Err(e) = git::create_or_checkout_branch(&branch_cwd, &branch_name_clone).await {
                                             eprintln!("[baro] branch creation failed: {}", e);
                                         }
-                                        spawn_executor(exec_prd, exec_cwd, branch_tx, parallel, timeout_secs, mr, om);
+                                        spawn_executor(exec_prd, exec_cwd, branch_tx, parallel, timeout_secs, mr, om, ctx);
                                     });
                                 }
                             }
@@ -507,10 +509,11 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
     let planner = app.planner;
     let cwd = cwd.to_path_buf();
     let model = app.model_for_phase("planning");
+    let context = app.claude_md_content.clone();
 
     tokio::spawn(async move {
         let result = match planner {
-            Planner::Claude => run_claude_planner(&goal, &cwd, model.as_deref()).await,
+            Planner::Claude => run_claude_planner(&goal, &cwd, model.as_deref(), context.as_deref()).await,
             Planner::OpenAI => run_openai_planner(&goal, &cwd).await,
         };
 
@@ -548,6 +551,7 @@ fn spawn_refiner(app: &App, feedback: &str, cwd: &Path, tx: mpsc::Sender<AppEven
     let feedback = feedback.to_string();
     let cwd = cwd.to_path_buf();
     let model = app.model_for_phase("planning");
+    let context = app.claude_md_content.clone();
 
     // Build current plan JSON from app state
     let stories_json: Vec<serde_json::Value> = app.review_stories.iter().map(|s| {
@@ -567,10 +571,14 @@ fn spawn_refiner(app: &App, feedback: &str, cwd: &Path, tx: mpsc::Sender<AppEven
     let plan_str = serde_json::to_string_pretty(&plan_json).unwrap_or_default();
 
     tokio::spawn(async move {
-        let prompt = format!(
+        let base_prompt = format!(
             "Here is the current plan:\n{}\nThe user wants these changes: {}\nGenerate an updated plan with the same JSON schema. Keep stories the user did not mention unchanged. Output ONLY valid JSON, no markdown, no explanation.",
             plan_str, feedback
         );
+        let prompt = match context {
+            Some(ctx) => format!("Here is the project context:\n{}\n\n{}", ctx, base_prompt),
+            None => base_prompt,
+        };
 
         let result = async {
             let mut args = vec![
@@ -646,6 +654,7 @@ fn spawn_executor(
     timeout_secs: u64,
     model_routing: bool,
     override_model: Option<String>,
+    context_content: Option<String>,
 ) {
     // Create a channel bridge: executor sends BaroEvent, we wrap them as AppEvent::Baro
     let (exec_tx, mut exec_rx) = mpsc::channel::<BaroEvent>(256);
@@ -662,12 +671,16 @@ fn spawn_executor(
 
     // Run executor
     tokio::spawn(async move {
-        executor::run_executor(prd, cwd, exec_tx, parallel, timeout_secs, model_routing, override_model).await;
+        executor::run_executor(prd, cwd, exec_tx, parallel, timeout_secs, model_routing, override_model, context_content).await;
     });
 }
 
-async fn run_claude_planner(goal: &str, cwd: &Path, model: Option<&str>) -> Result<(Vec<ReviewStory>, String, String, String), Box<dyn std::error::Error + Send + Sync>> {
-    let prompt = format!("{}\n\nUser goal: {}", CLAUDE_PLANNER_PROMPT, goal);
+async fn run_claude_planner(goal: &str, cwd: &Path, model: Option<&str>, context: Option<&str>) -> Result<(Vec<ReviewStory>, String, String, String), Box<dyn std::error::Error + Send + Sync>> {
+    let base_prompt = format!("{}\n\nUser goal: {}", CLAUDE_PLANNER_PROMPT, goal);
+    let prompt = match context {
+        Some(ctx) => format!("Here is the project context:\n{}\n\n{}", ctx, base_prompt),
+        None => base_prompt,
+    };
 
     let mut args = vec![
         "--dangerously-skip-permissions",

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -59,6 +59,10 @@ struct Cli {
     /// Disable model routing (equivalent to --model opus)
     #[arg(long = "no-model-routing")]
     no_model_routing: bool,
+
+    /// Skip the context building phase entirely
+    #[arg(long)]
+    skip_context: bool,
 }
 
 enum AppEvent {
@@ -197,6 +201,8 @@ async fn run_app(
         app.override_model = Some("opus".to_string());
         app.model_routing = false;
     }
+
+    app.skip_context = cli.skip_context;
 
     let (tx, mut rx) = mpsc::channel::<AppEvent>(256);
 

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -244,8 +244,17 @@ async fn run_app(
                 app.start_planning();
                 spawn_planner(&app, &cwd, tx.clone());
             } else {
-                app.start_context();
-                spawn_context_builder(&cwd, tx.clone());
+                let claude_md_path = cwd.join("CLAUDE.md");
+                if claude_md_path.exists() {
+                    if let Ok(content) = std::fs::read_to_string(&claude_md_path) {
+                        app.claude_md_content = Some(content);
+                    }
+                    app.start_planning();
+                    spawn_planner(&app, &cwd, tx.clone());
+                } else {
+                    app.start_context();
+                    spawn_context_builder(&cwd, tx.clone());
+                }
             }
         }
     }
@@ -346,8 +355,17 @@ async fn run_app(
                                     app.start_planning();
                                     spawn_planner(&app, &cwd, tx.clone());
                                 } else {
-                                    app.start_context();
-                                    spawn_context_builder(&cwd, tx.clone());
+                                    let claude_md_path = cwd.join("CLAUDE.md");
+                                    if claude_md_path.exists() {
+                                        if let Ok(content) = std::fs::read_to_string(&claude_md_path) {
+                                            app.claude_md_content = Some(content);
+                                        }
+                                        app.start_planning();
+                                        spawn_planner(&app, &cwd, tx.clone());
+                                    } else {
+                                        app.start_context();
+                                        spawn_context_builder(&cwd, tx.clone());
+                                    }
                                 }
                             }
                         }
@@ -510,25 +528,19 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
 fn spawn_context_builder(cwd: &Path, tx: mpsc::Sender<AppEvent>) {
     let cwd = cwd.to_path_buf();
     tokio::spawn(async move {
-        let claude_md_path = cwd.join("CLAUDE.md");
-        let content = if claude_md_path.exists() {
-            match tokio::fs::read_to_string(&claude_md_path).await {
-                Ok(c) => c,
-                Err(e) => {
-                    let _ = tx.send(AppEvent::ContextError(format!("Failed to read CLAUDE.md: {}", e))).await;
+        match context::build_context(&cwd).await {
+            Ok(content) => {
+                let claude_md_path = cwd.join("CLAUDE.md");
+                if let Err(e) = tokio::fs::write(&claude_md_path, &content).await {
+                    let _ = tx.send(AppEvent::ContextError(format!("Failed to write CLAUDE.md: {}", e))).await;
                     return;
                 }
+                let _ = tx.send(AppEvent::ContextReady(content)).await;
             }
-        } else {
-            match context::build_context(&cwd).await {
-                Ok(c) => c,
-                Err(e) => {
-                    let _ = tx.send(AppEvent::ContextError(format!("Failed to build context: {}", e))).await;
-                    return;
-                }
+            Err(e) => {
+                let _ = tx.send(AppEvent::ContextError(format!("Failed to build context: {}", e))).await;
             }
-        };
-        let _ = tx.send(AppEvent::ContextReady(content)).await;
+        }
     });
 }
 

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod context;
 mod dag;
 mod events;
 mod executor;
@@ -519,7 +520,13 @@ fn spawn_context_builder(cwd: &Path, tx: mpsc::Sender<AppEvent>) {
                 }
             }
         } else {
-            String::new()
+            match context::build_context(&cwd).await {
+                Ok(c) => c,
+                Err(e) => {
+                    let _ = tx.send(AppEvent::ContextError(format!("Failed to build context: {}", e))).await;
+                    return;
+                }
+            }
         };
         let _ = tx.send(AppEvent::ContextReady(content)).await;
     });

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -436,7 +436,7 @@ async fn run_app(
                                             if let Err(e) = git::create_or_checkout_branch(&branch_cwd, &branch_name_clone).await {
                                                 eprintln!("[baro] branch checkout failed: {}", e);
                                             }
-                                            spawn_executor(prd, exec_cwd, branch_tx, parallel, timeout_secs, mr, om, ctx);
+                                            spawn_executor(prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel, timeout_secs, model_routing: mr, override_model: om, context_content: ctx });
                                         });
                                     }
                                     Err(e) => {
@@ -470,7 +470,7 @@ async fn run_app(
                                         if let Err(e) = git::create_or_checkout_branch(&branch_cwd, &branch_name_clone).await {
                                             eprintln!("[baro] branch creation failed: {}", e);
                                         }
-                                        spawn_executor(exec_prd, exec_cwd, branch_tx, parallel, timeout_secs, mr, om, ctx);
+                                        spawn_executor(exec_prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel, timeout_secs, model_routing: mr, override_model: om, context_content: ctx });
                                     });
                                 }
                             }
@@ -650,11 +650,7 @@ fn spawn_executor(
     prd: executor::PrdFile,
     cwd: PathBuf,
     tx: mpsc::Sender<AppEvent>,
-    parallel: u32,
-    timeout_secs: u64,
-    model_routing: bool,
-    override_model: Option<String>,
-    context_content: Option<String>,
+    config: executor::ExecutorConfig,
 ) {
     // Create a channel bridge: executor sends BaroEvent, we wrap them as AppEvent::Baro
     let (exec_tx, mut exec_rx) = mpsc::channel::<BaroEvent>(256);
@@ -671,7 +667,7 @@ fn spawn_executor(
 
     // Run executor
     tokio::spawn(async move {
-        executor::run_executor(prd, cwd, exec_tx, parallel, timeout_secs, model_routing, override_model, context_content).await;
+        executor::run_executor(prd, cwd, exec_tx, config).await;
     });
 }
 

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -68,6 +68,8 @@ struct Cli {
 enum AppEvent {
     Baro(BaroEvent),
     Key(crossterm::event::KeyEvent),
+    ContextReady(String),
+    ContextError(String),
     PlanReady(Vec<ReviewStory>, String, String, String),
     PlanError(String),
     RefineReady(Vec<ReviewStory>, String, String, String),
@@ -233,12 +235,17 @@ async fn run_app(
         }
     }
 
-    // If goal provided via CLI (and not resuming), skip welcome and start planning immediately
+    // If goal provided via CLI (and not resuming), skip welcome and start context/planning
     if !entered_resume {
         if let Some(goal) = cli.goal {
             app.goal_input = goal;
-            app.start_planning();
-            spawn_planner(&app, &cwd, tx.clone());
+            if app.skip_context {
+                app.start_planning();
+                spawn_planner(&app, &cwd, tx.clone());
+            } else {
+                app.start_context();
+                spawn_context_builder(&cwd, tx.clone());
+            }
         }
     }
 
@@ -295,6 +302,14 @@ async fn run_app(
                 }
                 app.handle_event(ev);
             }
+            Some(AppEvent::ContextReady(content)) => {
+                app.claude_md_content = Some(content);
+                app.start_planning();
+                spawn_planner(&app, &cwd, tx.clone());
+            }
+            Some(AppEvent::ContextError(err)) => {
+                app.planning_error = Some(err);
+            }
             Some(AppEvent::PlanReady(stories, project, branch, description)) => {
                 app.project = project;
                 app.branch_name = branch;
@@ -326,13 +341,22 @@ async fn run_app(
                         KeyCode::Esc => return Ok(()),
                         KeyCode::Enter => {
                             if !app.goal_input.is_empty() {
-                                app.start_planning();
-                                spawn_planner(&app, &cwd, tx.clone());
+                                if app.skip_context {
+                                    app.start_planning();
+                                    spawn_planner(&app, &cwd, tx.clone());
+                                } else {
+                                    app.start_context();
+                                    spawn_context_builder(&cwd, tx.clone());
+                                }
                             }
                         }
                         KeyCode::Char(c) => app.goal_input.push(c),
                         KeyCode::Backspace => { app.goal_input.pop(); }
                         KeyCode::Left | KeyCode::Right => app.toggle_planner(),
+                        _ => {}
+                    },
+                    Screen::Context => match key.code {
+                        KeyCode::Esc | KeyCode::Char('q') => return Ok(()),
                         _ => {}
                     },
                     Screen::Planning => match key.code {
@@ -479,6 +503,25 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
                 let _ = tx.send(AppEvent::PlanError(e.to_string())).await;
             }
         }
+    });
+}
+
+fn spawn_context_builder(cwd: &Path, tx: mpsc::Sender<AppEvent>) {
+    let cwd = cwd.to_path_buf();
+    tokio::spawn(async move {
+        let claude_md_path = cwd.join("CLAUDE.md");
+        let content = if claude_md_path.exists() {
+            match tokio::fs::read_to_string(&claude_md_path).await {
+                Ok(c) => c,
+                Err(e) => {
+                    let _ = tx.send(AppEvent::ContextError(format!("Failed to read CLAUDE.md: {}", e))).await;
+                    return;
+                }
+            }
+        } else {
+            String::new()
+        };
+        let _ = tx.send(AppEvent::ContextReady(content)).await;
     });
 }
 

--- a/crates/baro-tui/src/screens/context.rs
+++ b/crates/baro-tui/src/screens/context.rs
@@ -1,0 +1,122 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, LineGauge, Paragraph},
+    Frame,
+};
+
+use crate::app::App;
+use crate::theme;
+
+const SPINNER_FRAMES: &[&str] = &[
+    "\u{28cb}", "\u{28d9}", "\u{28f9}", "\u{28f8}", "\u{28fc}",
+    "\u{28f4}", "\u{28e6}", "\u{28e7}", "\u{28c7}", "\u{28cf}",
+];
+
+pub fn render(f: &mut Frame, app: &App) {
+    let area = f.area();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(2),
+            Constraint::Length(7),   // Central box
+            Constraint::Length(1),   // Spacer
+            Constraint::Length(1),   // LineGauge
+            Constraint::Length(1),   // Spacer
+            Constraint::Length(1),   // Hint
+            Constraint::Min(1),
+        ])
+        .split(area);
+
+    let center = |area: Rect, width: u16| -> Rect {
+        let pad = area.width.saturating_sub(width) / 2;
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Length(pad),
+                Constraint::Length(width.min(area.width)),
+                Constraint::Min(0),
+            ])
+            .split(area)[1]
+    };
+
+    let box_width = 50.min(area.width.saturating_sub(4));
+    let box_area = center(chunks[1], box_width);
+
+    let frame_idx = (app.tick_count / 2) as usize % SPINNER_FRAMES.len();
+    let spinner = SPINNER_FRAMES[frame_idx];
+
+    let goal_display = if app.goal_input.len() > 42 {
+        format!("{}...", &app.goal_input[..39])
+    } else {
+        app.goal_input.clone()
+    };
+
+    // Pulse color on the spinner
+    let spin_color = match (app.tick_count / 5) % 3 {
+        0 => theme::LOGO_1,
+        1 => theme::LOGO_2,
+        _ => theme::LOGO_3,
+    };
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                format!(" {} ", spinner),
+                Style::default().fg(spin_color).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "Building context".to_string(),
+                Style::default().fg(theme::TEXT).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(" \u{2502} ", Style::default().fg(theme::BORDER)),
+            Span::styled(&goal_display, Style::default().fg(theme::TEXT_DIM)),
+        ]),
+        Line::from(""),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::ACCENT_DIM))
+        .title(Span::styled(
+            " Context ",
+            Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD),
+        ));
+
+    let p = Paragraph::new(lines).block(block);
+    f.render_widget(p, box_area);
+
+    // Pulsing LineGauge (indeterminate progress)
+    let gauge_width = 40.min(area.width.saturating_sub(4));
+    let gauge_area = center(chunks[3], gauge_width);
+
+    let cycle = (app.tick_count % 40) as f64 / 40.0;
+    let ratio = (std::f64::consts::PI * 2.0 * cycle).sin().abs();
+
+    let gauge_color = match (app.tick_count / 8) % 3 {
+        0 => theme::LOGO_1,
+        1 => theme::LOGO_2,
+        _ => theme::LOGO_3,
+    };
+
+    let gauge = LineGauge::default()
+        .label("")
+        .ratio(ratio)
+        .line_set(ratatui::symbols::line::THICK)
+        .filled_style(Style::default().fg(gauge_color))
+        .unfilled_style(Style::default().fg(theme::BORDER));
+    f.render_widget(gauge, gauge_area);
+
+    // Hint
+    let hint = Paragraph::new(Line::from(vec![
+        Span::styled("Scanning project structure...", Style::default().fg(theme::MUTED)),
+    ]))
+    .alignment(Alignment::Center);
+    f.render_widget(hint, chunks[5]);
+}

--- a/crates/baro-tui/src/screens/mod.rs
+++ b/crates/baro-tui/src/screens/mod.rs
@@ -1,4 +1,5 @@
 pub mod welcome;
+pub mod context;
 pub mod planning;
 pub mod review;
 pub mod execute;

--- a/crates/baro-tui/src/ui.rs
+++ b/crates/baro-tui/src/ui.rs
@@ -6,6 +6,7 @@ use crate::screens;
 pub fn render(f: &mut Frame, app: &App) {
     match app.screen {
         Screen::Welcome => screens::welcome::render(f, app),
+        Screen::Context => screens::context::render(f, app),
         Screen::Planning => screens::planning::render(f, app),
         Screen::Review => screens::review::render(f, app),
         Screen::Execute => screens::execute::render(f, app),


### PR DESCRIPTION
Add automatic CLAUDE

## Stories

| ID | Title | Duration | Status |
|:---|:------|:---------|:-------|
| S1 | Add --skip-context CLI flag | 53s | Done |
| S2 | Add context building screen to TUI | 2m 55s | Done |
| S3 | Implement project scanner and CLAUDE.md generator | 2m 39s | Done |
| S4 | Wire context builder into the startup flow | 2m 9s | Done |
| S5 | Pass CLAUDE.md content to planner and story agent prompts | 4m 31s | Done |
| S6 | Use haiku model for context generation and final build verification | 2m 48s | Done |

## Stats

- **Wall time:** 23m 29s
- **Files created:** 2
- **Files modified:** 13
- **Tokens:** 20,895 input / 43,203 output
- **Stories:** 6/6 completed, 0 skipped

## Review

- **Review cycles:** 6
- **Fixes auto-applied:** 1

---

Built with [baro](https://www.npmjs.com/package/baro-ai) — Background Agent Runtime Orchestrator
