### PR TITLE
baro-live-token-counter

### DIFF
--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -11,6 +11,7 @@ use tokio::time::timeout;
 use crate::app::ReviewStory;
 use crate::dag::build_dag;
 use crate::events::BaroEvent;
+use crate::utils::format_commas;
 
 // ─── PRD types (for reading/writing prd.json) ───────────────
 
@@ -125,17 +126,6 @@ fn build_prompt(story: &PrdStory, cwd: &Path, context: Option<&str>) -> String {
 
 // ─── Claude stream-json parser ──────────────────────────────
 
-fn format_with_commas(n: u64) -> String {
-    let s = n.to_string();
-    let mut result = String::new();
-    for (i, c) in s.chars().rev().enumerate() {
-        if i > 0 && i % 3 == 0 {
-            result.push(',');
-        }
-        result.push(c);
-    }
-    result.chars().rev().collect()
-}
 
 struct ParseResult {
     logs: Vec<String>,
@@ -1476,8 +1466,8 @@ pub async fn run_executor(
             parallelism_stats,
             total_files_created,
             total_files_modified,
-            format_with_commas(total_input_tokens),
-            format_with_commas(total_output_tokens),
+            format_commas(total_input_tokens),
+            format_commas(total_output_tokens),
             completed,
             current_prd.user_stories.len(),
             skipped

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -7,6 +7,7 @@ mod git;
 mod screens;
 mod theme;
 mod ui;
+mod utils;
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};

--- a/crates/baro-tui/src/screens/execute_completion.rs
+++ b/crates/baro-tui/src/screens/execute_completion.rs
@@ -8,6 +8,7 @@ use ratatui::{
 
 use crate::app::App;
 use crate::theme;
+use crate::utils::format_token_display;
 
 pub fn render_completion(f: &mut Frame, app: &App) {
     let area = f.area();
@@ -201,26 +202,10 @@ pub fn render_completion(f: &mut Frame, app: &App) {
         ),
     ]));
 
-    let format_commas = |n: u64| -> String {
-        let s = n.to_string();
-        let mut result = String::new();
-        for (i, c) in s.chars().rev().enumerate() {
-            if i > 0 && i % 3 == 0 {
-                result.push(',');
-            }
-            result.push(c);
-        }
-        result.chars().rev().collect()
-    };
-
     lines.push(Line::from(vec![
-        Span::styled("  Tokens:         ", Style::default().fg(theme::MUTED)),
+        Span::styled("  ", Style::default()),
         Span::styled(
-            format!(
-                "{} in / {} out",
-                format_commas(app.total_input_tokens),
-                format_commas(app.total_output_tokens)
-            ),
+            format_token_display(app.total_input_tokens, app.total_output_tokens),
             Style::default().fg(theme::ACCENT),
         ),
     ]));

--- a/crates/baro-tui/src/screens/execute_completion.rs
+++ b/crates/baro-tui/src/screens/execute_completion.rs
@@ -8,7 +8,6 @@ use ratatui::{
 
 use crate::app::App;
 use crate::theme;
-use crate::utils::format_token_display;
 
 pub fn render_completion(f: &mut Frame, app: &App) {
     let area = f.area();
@@ -203,9 +202,13 @@ pub fn render_completion(f: &mut Frame, app: &App) {
     ]));
 
     lines.push(Line::from(vec![
-        Span::styled("  ", Style::default()),
+        Span::styled("  Tokens:         ", Style::default().fg(theme::MUTED)),
         Span::styled(
-            format_token_display(app.total_input_tokens, app.total_output_tokens),
+            format!(
+                "{} in / {} out",
+                crate::utils::format_commas(app.total_input_tokens),
+                crate::utils::format_commas(app.total_output_tokens)
+            ),
             Style::default().fg(theme::ACCENT),
         ),
     ]));

--- a/crates/baro-tui/src/screens/execute_dashboard.rs
+++ b/crates/baro-tui/src/screens/execute_dashboard.rs
@@ -11,6 +11,7 @@ use ratatui::{
 
 use crate::app::{App, StoryStatus};
 use crate::theme;
+use crate::utils::format_token_display;
 
 pub fn render_dashboard(f: &mut Frame, app: &App, area: Rect) {
     let main_chunks = Layout::default()
@@ -26,6 +27,11 @@ pub fn render_dashboard(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_story_list(f: &mut Frame, app: &App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(4), Constraint::Length(2)])
+        .split(area);
+
     let mut items: Vec<ListItem> = Vec::new();
 
     if app.dag_levels.is_empty() {
@@ -73,7 +79,18 @@ fn render_story_list(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD),
             )),
     );
-    f.render_widget(list, area);
+    f.render_widget(list, chunks[0]);
+
+    // Stats area: wall time + token counter
+    let elapsed = app.total_time_secs;
+    let wall_time = format!(" ⏱ {}:{:02}", elapsed / 60, elapsed % 60);
+    let token_line = format!(" {}", format_token_display(app.total_input_tokens, app.total_output_tokens));
+
+    let stats = Paragraph::new(vec![
+        Line::from(Span::styled(wall_time, Style::default().fg(theme::MUTED))),
+        Line::from(Span::styled(token_line, Style::default().fg(theme::MUTED))),
+    ]);
+    f.render_widget(stats, chunks[1]);
 }
 
 fn story_list_item(

--- a/crates/baro-tui/src/screens/execute_dashboard.rs
+++ b/crates/baro-tui/src/screens/execute_dashboard.rs
@@ -83,7 +83,7 @@ fn render_story_list(f: &mut Frame, app: &App, area: Rect) {
 
     // Stats area: wall time + token counter
     let elapsed = app.total_time_secs;
-    let wall_time = format!(" ⏱ {}:{:02}", elapsed / 60, elapsed % 60);
+    let wall_time = format!(" {}:{:02}", elapsed / 60, elapsed % 60);
     let token_line = format!(" {}", format_token_display(app.total_input_tokens, app.total_output_tokens));
 
     let stats = Paragraph::new(vec![

--- a/crates/baro-tui/src/screens/execute_stats.rs
+++ b/crates/baro-tui/src/screens/execute_stats.rs
@@ -8,6 +8,7 @@ use ratatui::{
 
 use crate::app::{App, StoryStatus};
 use crate::theme;
+use crate::utils::format_commas;
 
 pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
     let has_bar_data = app.stories.iter().any(|s| s.duration_secs.is_some());
@@ -47,18 +48,6 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
     let total_files_created: u32 = app.stories.iter().map(|s| s.files_created).sum();
     let total_files_modified: u32 = app.stories.iter().map(|s| s.files_modified).sum();
     let final_stats = app.final_stats.as_ref();
-
-    let format_commas = |n: u64| -> String {
-        let s = n.to_string();
-        let mut result = String::new();
-        for (i, c) in s.chars().rev().enumerate() {
-            if i > 0 && i % 3 == 0 {
-                result.push(',');
-            }
-            result.push(c);
-        }
-        result.chars().rev().collect()
-    };
 
     // -- Time saved calculation (per-level parallelism gain) --
     let (level_saved, sequential_time) = {

--- a/crates/baro-tui/src/screens/execute_stats.rs
+++ b/crates/baro-tui/src/screens/execute_stats.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use crate::app::{App, StoryStatus};
 use crate::theme;
-use crate::utils::{calculate_cost, format_commas};
+use crate::utils::format_commas;
 
 pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
     let has_bar_data = app.stories.iter().any(|s| s.duration_secs.is_some());
@@ -162,7 +162,6 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
 
     // Tokens line
     if app.total_input_tokens > 0 || app.total_output_tokens > 0 {
-        let cost = calculate_cost(app.total_input_tokens, app.total_output_tokens);
         summary_lines.push(Line::from(vec![
             Span::styled("  Tokens: ", Style::default().fg(theme::MUTED)),
             Span::styled(
@@ -178,14 +177,6 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
                     .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" (~", Style::default().fg(theme::MUTED)),
-            Span::styled(
-                format!("${:.2}", cost),
-                Style::default()
-                    .fg(theme::ACCENT)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(")", Style::default().fg(theme::MUTED)),
         ]));
     }
 

--- a/crates/baro-tui/src/screens/execute_stats.rs
+++ b/crates/baro-tui/src/screens/execute_stats.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use crate::app::{App, StoryStatus};
 use crate::theme;
-use crate::utils::format_commas;
+use crate::utils::{calculate_cost, format_commas};
 
 pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
     let has_bar_data = app.stories.iter().any(|s| s.duration_secs.is_some());
@@ -162,6 +162,7 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
 
     // Tokens line
     if app.total_input_tokens > 0 || app.total_output_tokens > 0 {
+        let cost = calculate_cost(app.total_input_tokens, app.total_output_tokens);
         summary_lines.push(Line::from(vec![
             Span::styled("  Tokens: ", Style::default().fg(theme::MUTED)),
             Span::styled(
@@ -177,6 +178,14 @@ pub fn render_stats_full(f: &mut Frame, app: &App, area: Rect) {
                     .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             ),
+            Span::styled(" (~", Style::default().fg(theme::MUTED)),
+            Span::styled(
+                format!("${:.2}", cost),
+                Style::default()
+                    .fg(theme::ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(")", Style::default().fg(theme::MUTED)),
         ]));
     }
 

--- a/crates/baro-tui/src/utils.rs
+++ b/crates/baro-tui/src/utils.rs
@@ -11,22 +11,12 @@ pub fn format_commas(n: u64) -> String {
     result.chars().rev().collect()
 }
 
-/// Calculate estimated USD cost from token counts using Sonnet pricing:
-/// $3.00 per million input tokens, $15.00 per million output tokens.
-pub fn calculate_cost(input_tokens: u64, output_tokens: u64) -> f64 {
-    let input_cost = input_tokens as f64 * 3.0 / 1_000_000.0;
-    let output_cost = output_tokens as f64 * 15.0 / 1_000_000.0;
-    input_cost + output_cost
-}
-
 /// Produce a combined token display string:
-/// "Tokens: 12,345 in / 23,456 out (~$0.42)"
+/// "Tokens: 12,345 in / 23,456 out"
 pub fn format_token_display(input_tokens: u64, output_tokens: u64) -> String {
-    let cost = calculate_cost(input_tokens, output_tokens);
     format!(
-        "Tokens: {} in / {} out (~${:.2})",
+        "Tokens: {} in / {} out",
         format_commas(input_tokens),
         format_commas(output_tokens),
-        cost
     )
 }

--- a/crates/baro-tui/src/utils.rs
+++ b/crates/baro-tui/src/utils.rs
@@ -1,0 +1,32 @@
+/// Format a number with comma separators (e.g. 1234567 -> "1,234,567").
+pub fn format_commas(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+/// Calculate estimated USD cost from token counts using Sonnet pricing:
+/// $3.00 per million input tokens, $15.00 per million output tokens.
+pub fn calculate_cost(input_tokens: u64, output_tokens: u64) -> f64 {
+    let input_cost = input_tokens as f64 * 3.0 / 1_000_000.0;
+    let output_cost = output_tokens as f64 * 15.0 / 1_000_000.0;
+    input_cost + output_cost
+}
+
+/// Produce a combined token display string:
+/// "Tokens: 12,345 in / 23,456 out (~$0.42)"
+pub fn format_token_display(input_tokens: u64, output_tokens: u64) -> String {
+    let cost = calculate_cost(input_tokens, output_tokens);
+    format!(
+        "Tokens: {} in / {} out (~${:.2})",
+        format_commas(input_tokens),
+        format_commas(output_tokens),
+        cost
+    )
+}


### PR DESCRIPTION
Add live token counter with cost estimate to the TUI execute dashboard

## Stories

| ID | Title | Duration | Status |
|:---|:------|:---------|:-------|
| S1 | Add token formatting and cost calculation helpers | 2m 25s | Done |
| S2 | Display live token counter on execute dashboard | 2m 54s | Done |
| S3 | Update stats screen to use shared formatting helpers | 56s | Done |

## Stats

- **Wall time:** 5m 57s
- **Time saved:** 56s (parallelism)
- **Speedup:** 1.2x
- **Files created:** 1
- **Files modified:** 6
- **Tokens:** 307 input / 11,606 output
- **Stories:** 3/3 completed, 0 skipped

## Review

- **Review cycles:** 2
- **Fixes auto-applied:** 0

---

Built with [baro](https://www.npmjs.com/package/baro-ai) — Background Agent Runtime Orchestrator
