### PR TITLE
docs(participants): cheat-sheet docs + --version flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 prd.json
 baro-native
 baro-native.exe
+BARO_GOAL.md

--- a/crates/baro-tui/Cargo.toml
+++ b/crates/baro-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baro-tui"
-version = "0.23.3"
+version = "0.23.4"
 edition = "2021"
 
 [[bin]]

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -87,7 +87,7 @@ use app::{App, Planner, ReviewStory, Screen};
 use events::BaroEvent;
 
 #[derive(Parser)]
-#[command(name = "baro", about = "AI-powered project execution")]
+#[command(name = "baro", version, about = "AI-powered project execution")]
 struct Cli {
     /// Project goal (if omitted, shows welcome screen)
     goal: Option<String>,

--- a/packages/baro-app/package.json
+++ b/packages/baro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baro-ai",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "Autonomous parallel coding - plan and execute with AI",
   "type": "module",
   "bin": {

--- a/packages/baro-orchestrator/src/participants/CORE.md
+++ b/packages/baro-orchestrator/src/participants/CORE.md
@@ -1,0 +1,103 @@
+# CORE Participants Cheat Sheet
+
+The four driver participants that turn a PRD into a sequence of Claude
+runs. Each one subscribes to bus events via `onContextItem` and emits
+its own `ContextItem`s back. Wire shapes for canonical events live in
+[../types.ts](../types.ts); a few items are defined alongside their
+emitter and are marked below.
+
+## Conductor
+
+Source: [conductor.ts](./conductor.ts)
+
+Pure event-driven state machine that walks the story DAG. On a
+`RunStartRequestItem` it loads the PRD; from there it self-drives
+level-by-level by emitting `LevelComputeRequestItem` ticks. Each tick
+consults `buildDag`, picks the first remaining level, fills the spawn
+queue, and emits one `StorySpawnRequestItem` per story up to the
+configured parallel cap. As `StoryResultItem`s arrive it records pass
+or fail, marks passing stories in the PRD, and refills the spawn slot.
+When every story in the level has settled it applies any `ReplanItem`s
+buffered during the level, persists the PRD, then self-ticks for the
+next level. When `buildDag` returns no levels — or when a whole level
+fails terminally with no replan — it emits `RunCompletedItem` and
+resolves its `done` promise.
+
+- Subscribes to:
+  - `RunStartRequestItem` — begins the run.
+  - `LevelComputeRequestItem` — self-tick: compute and launch the next level.
+  - `StoryResultItem` (defined in `story-agent.ts`) — settle a story in the current level.
+  - `ReplanItem` — buffered until the level boundary, then applied to the PRD.
+- Emits:
+  - `RunStartedItem`, `LevelComputeRequestItem`, `LevelStartedItem`,
+    `StorySpawnRequestItem`, `LevelCompletedItem`, `RunCompletedItem`.
+  - `ConductorStateItem` (defined in `conductor.ts`) for phase
+    transitions and hook-failure messages.
+
+## StoryFactory
+
+Source: [story-factory.ts](./story-factory.ts)
+
+Decouples Conductor from `StoryAgent` lifecycle. On a
+`StorySpawnRequestItem` it constructs a fresh `StoryAgent` with the
+requested prompt, model, retries, and timeout, joins it to the
+environment, fires its `run()` without awaiting, and emits a
+`StorySpawnedItem` so observers can see the lifecycle. When the
+matching `StoryResultItem` later arrives on the bus it calls the
+agent's `leave(env)` and drops its reference. Spawn is idempotent per
+`storyId`.
+
+- Subscribes to:
+  - `StorySpawnRequestItem` — spawn the requested agent.
+  - `StoryResultItem` (defined in `story-agent.ts`) — remove the
+    finished agent from the bus.
+- Emits:
+  - `StorySpawnedItem`.
+
+## StoryAgent
+
+Source: [story-agent.ts](./story-agent.ts)
+
+Wraps a single Claude CLI invocation for one story with retries, a
+per-attempt timeout, a quiet-timer for multi-turn sessions, and an
+optional hard cap. Each attempt spawns a fresh `ClaudeCliParticipant`,
+writes the prompt to stdin (leaving stdin open), then watches the bus
+for `ClaudeResultItem`s addressed to this story so it can count turns
+and reset the quiet timer. Stdin is closed when either `maxTurns`
+`ClaudeResultItem`s have arrived or `quietTimeoutMs` of silence has
+elapsed. On success the retry loop exits early; otherwise it retries
+up to `retries + 1` attempts before giving up. Phase changes are
+broadcast as `AgentStateItem`s; the final verdict is broadcast as a
+`StoryResultItem`. Note: `AgentTargetedMessageItem` → Claude stdin
+forwarding is owned by `ClaudeCliParticipant`, not by `StoryAgent`;
+`StoryAgent` only observes those items for quiet-timer purposes.
+
+- Subscribes to:
+  - `AgentTargetedMessageItem` (when `recipientId` matches this story)
+    — resets the multi-turn quiet timer.
+  - `ClaudeResultItem` (when `agentId` matches this story) —
+    increments the turn counter and resets the quiet timer.
+- Emits:
+  - `AgentStateItem` on every phase transition.
+  - `StoryResultItem` (defined in `story-agent.ts`) — final outcome of
+    the story, success or failure.
+
+## Operator
+
+Source: [operator.ts](./operator.ts)
+
+Bridge from external command sources (the Rust TUI today, a web UI
+later) onto the bus. Operator is push-only: its `onContextItem` is a
+no-op and it never reacts to bus events. Callers invoke
+`dispatch(cmd)` when a command arrives over the TUI protocol, and
+Operator translates it. A `redirect` command becomes an
+`AgentTargetedMessageItem` on the bus addressed to the named story; the
+`abort`, `abort_all`, and `shutdown` commands invoke the corresponding
+hook callbacks supplied at construction (no bus event is emitted for
+those three).
+
+- Subscribes to: nothing — `onContextItem` is intentionally empty.
+- Emits:
+  - `AgentTargetedMessageItem` (only in response to a `redirect`
+    dispatch; `abort` / `abort_all` / `shutdown` go to hooks instead of
+    the bus).

--- a/packages/baro-orchestrator/src/participants/OBSERVERS.md
+++ b/packages/baro-orchestrator/src/participants/OBSERVERS.md
@@ -1,0 +1,123 @@
+# Observer participants
+
+This cheat sheet documents the six TypeScript-side observer participants
+in the orchestrator: passive bus listeners that watch ContextItem traffic
+and (optionally) emit their own ContextItem-s back onto the bus.
+Cartographer is **not** covered here — it lives Rust-side under
+`crates/baro-tui/`.
+
+Each observer below lists the ContextItem types that gate its
+`onContextItem` method (via `instanceof`) under **Subscribes to**, and the
+ContextItem types it constructs and delivers under **Emits**.
+
+---
+
+## Critic
+
+A live acceptance-criteria evaluator. For every watched agent that
+completes a turn without error, the Critic spawns a short-lived
+`claude --print --model <model>` subprocess to ask whether the agent's
+output satisfies the acceptance criteria associated with its `agentId`.
+The verdict is always published as a `CritiqueItem` (audit trail). On a
+"fail" verdict, the Critic also sends an `AgentTargetedMessageItem` back
+to the agent as its next conversational turn, up to
+`maxEmissionsPerAgent` times, after which corrective messages are
+suppressed but critiques keep accumulating.
+
+- Subscribes to: `ClaudeResultItem`
+- Emits: `CritiqueItem`, `AgentTargetedMessageItem`
+
+Source: [critic.ts](./critic.ts)
+
+---
+
+## Surgeon
+
+An adaptive DAG mutation participant. It watches terminal story failures
+and emits `ReplanItem`-s that the Conductor applies at the next level
+boundary. In the default deterministic mode it removes the failing story
+so dependents either run with one fewer prerequisite or get
+cascade-removed. In LLM mode it shells out to `claude --print` with a
+compact PRD snapshot and the failure reason and asks for a structured
+replan (split / prereq / rewire / skip / abort), falling back to the
+deterministic strategy on any subprocess or parsing error.
+
+- Subscribes to: `StoryResultItem` (defined in `story-agent.ts`)
+- Emits: `ReplanItem`
+
+Source: [surgeon.ts](./surgeon.ts)
+
+---
+
+## Librarian
+
+A cross-agent runtime memory observer. It watches tool calls and their
+outputs for a fixed set of exploration tools (Read, Grep, Glob, Bash,
+LSP, WebFetch, WebSearch), records each call's tags and a truncated copy
+of its output, and exposes the resulting index through both a
+`gatherContext(storyId, hints)` RPC (used to prepend findings to a new
+story's prompt) and a `KnowledgeItem` emission on the bus so other
+observers can react. `FunctionCallItem` and `FunctionCallOutputItem` come
+from `@mozaik-ai/core`.
+
+- Subscribes to: `FunctionCallItem`, `FunctionCallOutputItem`
+- Emits: `KnowledgeItem`
+
+Source: [librarian.ts](./librarian.ts)
+
+---
+
+## Sentry
+
+A file-touch conflict detector. It tracks the `Edit`, `Write`,
+`MultiEdit`, and `NotebookEdit` tool calls each agent issues and the
+phase each agent has reached. When two agents touch the same path, it
+calls the optional `onOverlap` callback and — at most once per path —
+emits a `CoordinationItem` with `kind="notice"` so the overlap shows up
+in the audit log. Phase-2 scope: detect and notify only, no
+tool-execution preemption. `FunctionCallItem` comes from
+`@mozaik-ai/core`.
+
+- Subscribes to: `AgentStateItem`, `FunctionCallItem`
+- Emits: `CoordinationItem`
+
+Source: [sentry.ts](./sentry.ts)
+
+---
+
+## Auditor
+
+A passive persistence observer. It serializes every ContextItem it sees
+to a JSONL file for replay and post-mortem debugging. By default it
+skips `ClaudeStreamChunkItem` (partial-message chunks dominate volume
+and rarely add audit value) and it honors an optional `filter` callback
+that runs after the stream-chunk skip. If the very first `mkdir` or any
+subsequent `append` fails, the Auditor disables itself for the rest of
+the run, prints a single stderr warning, and silently drops further
+items so the orchestrator keeps running.
+
+- Subscribes to: every ContextItem (no `instanceof` gate); only
+  `ClaudeStreamChunkItem` is explicitly filtered out
+- Emits: nothing (writes to a JSONL file)
+
+Source: [auditor.ts](./auditor.ts)
+
+---
+
+## Finalizer
+
+The "Ship" half of `Plan. Parallelize. Review. Ship.` It collects
+run-level events from the bus, and when a `RunCompletedItem` arrives it
+composes a pull-request body — DAG plan, stories table with durations
+and best-effort commit SHAs, diff stats, wall/sequential/speedup
+numbers — and opens the PR via `gh pr create`. It degrades to "no PR,
+log the reason" when the `gh` binary is missing, the branch matches the
+base, no commits exist ahead of the base SHA, or all stories failed.
+`StoryResultItem` is defined in `story-agent.ts`; the rest come from
+`types.ts`.
+
+- Subscribes to: `RunStartedItem`, `LevelStartedItem`, `StoryResultItem`,
+  `RunCompletedItem`
+- Emits: `FinalizeStartedItem`, `PrCreatedItem`
+
+Source: [finalizer.ts](./finalizer.ts)

--- a/packages/baro-orchestrator/src/participants/finalizer.ts
+++ b/packages/baro-orchestrator/src/participants/finalizer.ts
@@ -75,7 +75,14 @@ export class Finalizer extends Participant {
     private startedAtMs: number | null = null
     private baseSha: string | null
     private branchName: string | null = null
-    private levels: string[][] = []
+    /**
+     * DAG levels keyed by their ordinal as emitted in
+     * LevelStartedItem. We use a Map rather than an array because
+     * Conductor's ordinals are 1-based and would otherwise leave a
+     * `levels[0] = undefined` hole that crashes any `for...of`
+     * iteration (it walks holes too).
+     */
+    private readonly levels = new Map<number, string[]>()
     private readonly stories = new Map<string, StoryRecord>()
     /**
      * Resolves once finalize() has completed (or been short-circuited).
@@ -114,7 +121,7 @@ export class Finalizer extends Participant {
         }
 
         if (item instanceof LevelStartedItem) {
-            this.levels[item.ordinal] = [...item.storyIds]
+            this.levels.set(item.ordinal, [...item.storyIds])
             for (const id of item.storyIds) {
                 if (!this.stories.has(id)) {
                     this.stories.set(id, {
@@ -150,11 +157,25 @@ export class Finalizer extends Participant {
         }
 
         if (item instanceof RunCompletedItem) {
-            // Track the in-flight finalize call so orchestrate.ts can
-            // await it before emitting the TUI `done` event.
-            this.finalizePromise = this.finalize(item)
+            // Wrap finalize() so a bug inside this participant never
+            // takes down the orchestrator. The whole run has already
+            // succeeded by the time we get here — losing the PR is a
+            // recoverable annoyance, killing the process and orphaning
+            // Claude children is not.
+            this.finalizePromise = this.safeFinalize(item)
             await this.finalizePromise
             return
+        }
+    }
+
+    private async safeFinalize(item: RunCompletedItem): Promise<void> {
+        try {
+            await this.finalize(item)
+        } catch (e) {
+            const msg = (e as Error)?.stack ?? String(e)
+            this.log(`[finalizer] internal error, skipping PR: ${msg.split("\n")[0]}`)
+            process.stderr.write(`[finalizer] crash: ${msg}\n`)
+            this.emit(new PrCreatedItem(null, this.branchName ?? "", ""))
         }
     }
 
@@ -279,14 +300,17 @@ export class Finalizer extends Participant {
 
     /**
      * Stories returned in DAG order so the table reads top-down the same
-     * way the run executed: level 0 first, then level 1, etc. Within a
-     * level we sort by id (stable) to keep the table deterministic.
+     * way the run executed: lowest-ordinal level first. Within a level
+     * we sort by id (stable) to keep the table deterministic.
      */
     private orderStories(): StoryRecord[] {
         const seen = new Set<string>()
         const ordered: StoryRecord[] = []
-        for (const lvl of this.levels) {
-            const sorted = [...lvl].sort()
+        const ordinals = [...this.levels.keys()].sort((a, b) => a - b)
+        for (const ord of ordinals) {
+            const ids = this.levels.get(ord)
+            if (!ids) continue
+            const sorted = [...ids].sort()
             for (const id of sorted) {
                 const rec = this.stories.get(id)
                 if (rec && !seen.has(id)) {
@@ -455,13 +479,14 @@ export class Finalizer extends Participant {
         }
 
         // DAG plan
-        if (this.levels.length > 0) {
+        if (this.levels.size > 0) {
             lines.push("## Plan")
             lines.push("")
             lines.push("```")
-            for (let i = 0; i < this.levels.length; i++) {
-                const ids = this.levels[i]
-                lines.push(`Level ${i} ─── ${ids.join(", ")}`)
+            const ordinals = [...this.levels.keys()].sort((a, b) => a - b)
+            for (const ord of ordinals) {
+                const ids = this.levels.get(ord) ?? []
+                lines.push(`Level ${ord} ─── ${ids.join(", ")}`)
             }
             lines.push("```")
             lines.push("")


### PR DESCRIPTION
> Generated by baro 0.23.3 — baro working on itself. _(Finalizer crashed at PR-create time due to a sparse-array bug; opening manually while I ship 0.23.4 to fix it.)_

## Goal

Document the cast of bus participants for readers landing in the
repo cold. Before this PR, anyone opening
\`packages/baro-orchestrator/src/participants/\` had to read 11 files
of 200–500 lines each to understand what subscribes to what. Now
there's a short, factual cheat sheet sitting next to the code.

Also: fix \`baro --version\` so it actually prints the version
instead of erroring out with \`unexpected argument '--version'\`.

## Plan

Three independent stories on Level 0, all run 3-wide in parallel:

\`\`\`
Level 0 ──┬── S1: CORE.md cheat sheet for driver participants
          ├── S2: OBSERVERS.md cheat sheet for observer participants
          └── S3: enable --version flag on baro CLI
\`\`\`

## Stories

| # | Story | Duration | Commit |
|---|-------|----------|--------|
| S3 | Enable \`--version\` flag on baro CLI | 1:11 | \`aff788b\` |
| S2 | Add OBSERVERS.md cheat sheet | 2:27 | \`40d4869\` |
| S1 | Add CORE.md cheat sheet for driver participants | 2:40 | \`3519df8\` |

## Run summary

- **Wall time**: 2:44
- **Sequential time**: 6:18
- **Parallel speedup**: 2.30×
- **Stories passed**: 3/3
- **Stories failed**: 0
- **Total story attempts**: 3
- **Model**: routed
- **Branch**: docs-participants-cheat-sheet

## What you can do after merging

- Open \`packages/baro-orchestrator/src/participants/CORE.md\` to see who drives the run.
- Open \`packages/baro-orchestrator/src/participants/OBSERVERS.md\` to see who watches the bus.
- Run \`baro --version\` and get \`baro 0.23.3\` instead of an error.

---

🤖 Plan. Parallelize. Review. Ship. — opened by baro (with a hand from the Finalizer bug fix in 0.23.4)