### PR TITLE
fix(debuggability): baro --doctor, persisted planner logs, real error UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 A concise list of every published version. For full release notes, see the corresponding commit on the v* tag.
 
+## v0.25.1 — fix(debuggability): baro --doctor, persisted planner logs, real error UI (#17)
 ## v0.25.0 — release(0.25.0): Architect phase — one mind decides, many hands execute
 ## v0.24.0 — release(0.24.0): Librarian mid-flight broadcasts + intra-level stagger
 ## v0.23.6 — release(0.23.6): pin @mozaik-ai/core to 3.6.5

--- a/crates/baro-tui/Cargo.toml
+++ b/crates/baro-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baro-tui"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 
 [[bin]]
@@ -15,6 +15,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
+which = "6"
 
 [target.'cfg(unix)'.dependencies]
 crossterm = { version = "0.28", features = ["use-dev-tty"] }

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -164,6 +164,11 @@ pub struct App {
     // Planning screen
     pub planning_start: Option<Instant>,
     pub planning_error: Option<String>,
+    /// When the planner / architect fails, the path to the full
+    /// stdout+stderr log we persisted at the call site (see
+    /// claude_runner). Surfaced in the planning screen so users have
+    /// somewhere to look when the in-TUI error excerpt isn't enough.
+    pub planning_log_path: Option<std::path::PathBuf>,
 
     // Review screen
     pub branch_name: String,
@@ -259,6 +264,7 @@ impl App {
 
             planning_start: None,
             planning_error: None,
+            planning_log_path: None,
 
             branch_name: String::new(),
             description: String::new(),

--- a/crates/baro-tui/src/claude_runner.rs
+++ b/crates/baro-tui/src/claude_runner.rs
@@ -1,11 +1,17 @@
 //! Thin wrapper around `claude --print --output-format json` for the
-//! non-streaming planner step in main.rs (Claude planner).
+//! non-streaming planner / architect steps in main.rs.
 //!
 //! The streaming-json variant lived here too, but the TS Mozaik
 //! orchestrator now owns story execution end-to-end so the streaming
 //! half is gone. This file is a single-shot run helper.
+//!
+//! Persists stdout + stderr to a timestamped log file under
+//! `~/.baro/runs/` before returning, so even when Claude exits non-
+//! zero with empty stderr (the issue #17 scenario — unauthenticated
+//! CLI), the user has somewhere to look for the actual failure detail.
 
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::process::Command;
 
@@ -16,17 +22,57 @@ pub struct ClaudeRunConfig {
     pub prompt: String,
     pub cwd: PathBuf,
     pub model: Option<String>,
+    /// Short tag used in the persisted log filename, e.g. "planner"
+    /// or "architect". Always lowercase-kebab. If None, defaults to
+    /// "claude" and the log goes to `claude-<ts>.log`.
+    pub log_tag: Option<&'static str>,
 }
 
-/// Output from a non-streaming (JSON mode) Claude invocation.
+/// Output from a non-streaming (JSON mode) Claude invocation. The log
+/// file is persisted as a side effect of spawn_claude_json; we don't
+/// surface its path on the success path because nothing in the TUI
+/// reads it. If a caller ever needs it, add the field then.
 pub struct ClaudeJsonOutput {
     pub stdout: String,
 }
 
+/// Error returned by spawn_claude_json. Carries the rendered message
+/// (for the TUI's error box) and the path to the persisted stdout+
+/// stderr log file (for the "full log: …" hint). Other detail (raw
+/// stdout / stderr / exit code) lives in the log file on disk; we
+/// deliberately don't keep duplicate copies in memory.
+#[derive(Debug)]
+pub struct ClaudeRunError {
+    pub message: String,
+    pub log_path: Option<PathBuf>,
+}
+
+impl std::fmt::Display for ClaudeRunError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ClaudeRunError {}
+
 /// Spawn Claude with `--print --output-format json`, wait for completion,
-/// return the raw stdout. The caller is responsible for parsing the
-/// JSON wrapper Claude emits.
+/// return the raw stdout. Writes both stdout and stderr to
+/// `~/.baro/runs/<tag>-<unix_secs>.log` before returning so a failed
+/// run leaves a forensic trail even when stderr was empty.
 pub async fn spawn_claude_json(config: &ClaudeRunConfig) -> BaroResult<ClaudeJsonOutput> {
+    // Preflight: confirm `claude` is reachable before we build a 20kB
+    // prompt and start a subprocess that will explode with a less
+    // helpful "No such file or directory" if it isn't. Pure PATH
+    // lookup, no subprocess.
+    if which::which("claude").is_err() {
+        return Err(
+            "`claude` CLI not found on PATH. Install Claude Code from \
+             https://claude.com/code, then run `baro --doctor` to confirm \
+             the install is healthy before retrying."
+                .into(),
+        );
+    }
+
     let mut cmd = Command::new("claude");
     cmd.args([
         "--print",
@@ -50,17 +96,61 @@ pub async fn spawn_claude_json(config: &ClaudeRunConfig) -> BaroResult<ClaudeJso
         .await
         .map_err(|e| format!("Claude process error: {}", e))?;
 
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let log_path = persist_log(config.log_tag.unwrap_or("claude"), &stdout, &stderr);
+
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!(
-            "Claude exited with code {}: {}",
-            output.status.code().unwrap_or(-1),
-            stderr
-        )
-        .into());
+        let code = output.status.code();
+        let detail_tail = build_detail(&stdout, &stderr);
+        let message = format!(
+            "Claude exited with code {}{}",
+            code.map(|c| c.to_string()).unwrap_or_else(|| "?".into()),
+            detail_tail,
+        );
+        return Err(Box::new(ClaudeRunError { message, log_path }));
     }
 
-    Ok(ClaudeJsonOutput {
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-    })
+    Ok(ClaudeJsonOutput { stdout })
+}
+
+/// Build the human-readable bit that follows "Claude exited with code N"
+/// in the error message. Prefers stderr if present, falls back to stdout
+/// (some Claude CLI versions write auth errors there), and surfaces the
+/// "empty output" case explicitly because that's the case where the old
+/// error message was useless.
+fn build_detail(stdout: &str, stderr: &str) -> String {
+    let stderr_trim = stderr.trim();
+    let stdout_trim = stdout.trim();
+    if !stderr_trim.is_empty() {
+        format!(": {}", stderr_trim)
+    } else if !stdout_trim.is_empty() {
+        format!(": (no stderr) stdout: {}", stdout_trim)
+    } else {
+        " with empty output (typically means `claude` is not authenticated — run `baro --doctor` to verify)".to_string()
+    }
+}
+
+/// Append stdout + stderr to a timestamped log file under
+/// `~/.baro/runs/`. Returns the path on success, None if the write
+/// failed (we'd rather lose the log than crash the run).
+fn persist_log(tag: &str, stdout: &str, stderr: &str) -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    let dir = home.join(".baro").join("runs");
+    if std::fs::create_dir_all(&dir).is_err() {
+        return None;
+    }
+    let unix_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let path = dir.join(format!("{}-{}.log", tag, unix_secs));
+    let body = format!(
+        "=== STDOUT ===\n{}\n\n=== STDERR ===\n{}\n",
+        stdout, stderr,
+    );
+    if std::fs::write(&path, body).is_err() {
+        return None;
+    }
+    Some(path)
 }

--- a/crates/baro-tui/src/doctor.rs
+++ b/crates/baro-tui/src/doctor.rs
@@ -1,0 +1,294 @@
+//! `baro doctor` — quick self-diagnostic that verifies the moving parts
+//! baro depends on before a real run starts. Run when a run fails in
+//! a way that doesn't make it clear which piece broke (e.g. issue #17,
+//! where the planner exited with code 1 and an empty stderr because
+//! `claude` wasn't authenticated).
+//!
+//! Exits 0 if every check passes, 1 if any fail. Prints a colored
+//! report to stderr with concrete remediation hints per failure.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::time::timeout;
+
+const ANSI_RESET: &str = "\x1b[0m";
+const ANSI_DIM: &str = "\x1b[2m";
+const ANSI_BOLD: &str = "\x1b[1m";
+const ANSI_GREEN: &str = "\x1b[32m";
+const ANSI_RED: &str = "\x1b[31m";
+const ANSI_YELLOW: &str = "\x1b[33m";
+
+/// Result of one check.
+struct CheckResult {
+    name: &'static str,
+    ok: bool,
+    detail: String,
+    hint: Option<&'static str>,
+}
+
+impl CheckResult {
+    fn pass(name: &'static str, detail: impl Into<String>) -> Self {
+        Self { name, ok: true, detail: detail.into(), hint: None }
+    }
+    fn fail(name: &'static str, detail: impl Into<String>, hint: &'static str) -> Self {
+        Self { name, ok: false, detail: detail.into(), hint: Some(hint) }
+    }
+}
+
+/// Entry point. Returns Ok(0) if every check passed, Ok(1) if any failed.
+/// Never returns an Err — every error becomes a fail row in the report.
+pub async fn run() -> i32 {
+    let mut results: Vec<CheckResult> = Vec::new();
+
+    results.push(check_claude_on_path().await);
+    results.push(check_claude_version().await);
+    results.push(check_claude_print_call().await);
+    results.push(check_gh_on_path().await);
+    results.push(check_audit_dir_writable().await);
+
+    print_report(&results);
+    if results.iter().all(|r| r.ok) { 0 } else { 1 }
+}
+
+// ─── Individual checks ─────────────────────────────────────────────
+
+/// Verify `claude` binary is reachable. Resolves PATH lookup and
+/// returns the full path if found.
+async fn check_claude_on_path() -> CheckResult {
+    match which::which("claude") {
+        Ok(path) => CheckResult::pass(
+            "claude on PATH",
+            format!("{}", path.display()),
+        ),
+        Err(_) => CheckResult::fail(
+            "claude on PATH",
+            "binary not found",
+            "Install Claude Code from https://claude.com/code (or run `which claude` to see why your shell can't find it).",
+        ),
+    }
+}
+
+/// Run `claude --version`. Hard timeout 5s so a hung install can't
+/// freeze the doctor.
+async fn check_claude_version() -> CheckResult {
+    let mut cmd = Command::new("claude");
+    cmd.arg("--version");
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let spawn_then_wait = async {
+        let child = cmd.spawn().map_err(|e| format!("spawn failed: {}", e))?;
+        let output = child
+            .wait_with_output()
+            .await
+            .map_err(|e| format!("wait failed: {}", e))?;
+        Ok::<_, String>(output)
+    };
+
+    match timeout(Duration::from_secs(5), spawn_then_wait).await {
+        Err(_) => CheckResult::fail(
+            "claude --version",
+            "timed out after 5s",
+            "`claude --version` hung. Try running it manually; if it still hangs, reinstall Claude Code.",
+        ),
+        Ok(Err(e)) => CheckResult::fail(
+            "claude --version",
+            e,
+            "Reinstall Claude Code or check that the binary on PATH is actually claude.",
+        ),
+        Ok(Ok(output)) => {
+            if output.status.success() {
+                let v = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                CheckResult::pass("claude --version", v)
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                CheckResult::fail(
+                    "claude --version",
+                    format!("exit {}: {}", output.status.code().unwrap_or(-1), stderr),
+                    "Claude binary is on PATH but returned an error on a trivial call. Try `claude doctor` (Claude's own check), then reinstall.",
+                )
+            }
+        }
+    }
+}
+
+/// Run a trivial authenticated `claude --print` call. This is the
+/// real test — if this succeeds, the planner will run. If it fails,
+/// the user is almost certainly not logged in (which is the issue
+/// #17 scenario: empty stderr, exit 1, no clue why).
+async fn check_claude_print_call() -> CheckResult {
+    let mut cmd = Command::new("claude");
+    cmd.args([
+        "--print",
+        "--dangerously-skip-permissions",
+        "--output-format",
+        "json",
+        "-p",
+        "Say the single word OK and nothing else.",
+    ]);
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let spawn_then_wait = async {
+        let child = cmd.spawn().map_err(|e| format!("spawn failed: {}", e))?;
+        let output = child
+            .wait_with_output()
+            .await
+            .map_err(|e| format!("wait failed: {}", e))?;
+        Ok::<_, String>(output)
+    };
+
+    match timeout(Duration::from_secs(30), spawn_then_wait).await {
+        Err(_) => CheckResult::fail(
+            "claude --print authenticated call",
+            "timed out after 30s",
+            "Trivial `claude --print` hung for 30s. Network problem, or Claude CLI is stuck waiting on auth.",
+        ),
+        Ok(Err(e)) => CheckResult::fail(
+            "claude --print authenticated call",
+            e,
+            "Could not invoke claude. See `claude on PATH` check above.",
+        ),
+        Ok(Ok(output)) => {
+            if output.status.success() {
+                CheckResult::pass(
+                    "claude --print authenticated call",
+                    "ok (got JSON response)",
+                )
+            } else {
+                let code = output.status.code().unwrap_or(-1);
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                let detail = if stderr.is_empty() && stdout.is_empty() {
+                    format!("exit {}, no output (auth failure is the common cause)", code)
+                } else if stderr.is_empty() {
+                    format!("exit {}, stdout: {}", code, truncate(&stdout, 200))
+                } else {
+                    format!("exit {}, stderr: {}", code, truncate(&stderr, 200))
+                };
+                CheckResult::fail(
+                    "claude --print authenticated call",
+                    detail,
+                    "Run `claude` (no args) once interactively to authenticate. If you've logged in but still see this, your subscription may be expired or rate-limited. See https://docs.baro.rs/docs/troubleshooting.",
+                )
+            }
+        }
+    }
+}
+
+/// `gh` is only required for the Finalizer (PR creation). A failing
+/// gh check is a warning, not a fatal error — the run will still
+/// complete, the user just won't get an auto-PR.
+async fn check_gh_on_path() -> CheckResult {
+    match which::which("gh") {
+        Ok(path) => CheckResult::pass(
+            "gh on PATH (optional, used for PR creation)",
+            format!("{}", path.display()),
+        ),
+        Err(_) => CheckResult::fail(
+            "gh on PATH (optional, used for PR creation)",
+            "not found",
+            "Optional but recommended: install GitHub CLI from https://cli.github.com to let baro auto-open a PR after every run. Without it, baro will push the branch but you'll open the PR yourself.",
+        ),
+    }
+}
+
+/// Verify we can write to ~/.baro/runs/. Audit logs and stderr
+/// sidecars from real runs land here. If it's root-owned (sudo
+/// install accident) we want to know now, not mid-run.
+async fn check_audit_dir_writable() -> CheckResult {
+    let home = match std::env::var_os("HOME") {
+        Some(h) => PathBuf::from(h),
+        None => {
+            return CheckResult::fail(
+                "audit dir writable",
+                "$HOME is unset",
+                "baro writes audit logs to $HOME/.baro/runs. Set HOME and re-run.",
+            );
+        }
+    };
+    let dir = home.join(".baro").join("runs");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        return CheckResult::fail(
+            "audit dir writable",
+            format!("create_dir_all({}) failed: {}", dir.display(), e),
+            "Try `sudo chown -R $(id -u):$(id -g) ~/.baro` if you ever installed baro with sudo.",
+        );
+    }
+    let probe = dir.join(".doctor-write-probe");
+    match std::fs::write(&probe, b"baro doctor probe") {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&probe);
+            CheckResult::pass(
+                "audit dir writable",
+                format!("{}", dir.display()),
+            )
+        }
+        Err(e) => CheckResult::fail(
+            "audit dir writable",
+            format!("write probe failed: {}", e),
+            "Try `sudo chown -R $(id -u):$(id -g) ~/.baro` if you ever installed baro with sudo.",
+        ),
+    }
+}
+
+// ─── Reporting ─────────────────────────────────────────────────────
+
+fn print_report(results: &[CheckResult]) {
+    eprintln!();
+    eprintln!("{}baro doctor{}", ANSI_BOLD, ANSI_RESET);
+    eprintln!("{}{}{}", ANSI_DIM, "─".repeat(60), ANSI_RESET);
+    eprintln!();
+
+    for r in results {
+        let (mark, color) = if r.ok {
+            ("\u{2713}", ANSI_GREEN)
+        } else {
+            ("\u{2717}", ANSI_RED)
+        };
+        eprintln!(
+            "  {}{}{}  {}{}{}",
+            color, mark, ANSI_RESET, ANSI_BOLD, r.name, ANSI_RESET,
+        );
+        eprintln!("      {}{}{}", ANSI_DIM, r.detail, ANSI_RESET);
+        if let Some(hint) = r.hint {
+            eprintln!("      {}{}\u{2192}{} {}{}{}", ANSI_YELLOW, ANSI_BOLD, ANSI_RESET, ANSI_YELLOW, hint, ANSI_RESET);
+        }
+        eprintln!();
+    }
+
+    eprintln!("{}{}{}", ANSI_DIM, "─".repeat(60), ANSI_RESET);
+    let passed = results.iter().filter(|r| r.ok).count();
+    let total = results.len();
+    if passed == total {
+        eprintln!(
+            "  {}{}{} {}all checks passed ({}/{}){}",
+            ANSI_GREEN, ANSI_BOLD, "\u{2713}", ANSI_BOLD, passed, total, ANSI_RESET,
+        );
+    } else {
+        let failed = total - passed;
+        eprintln!(
+            "  {}{}{} {}{} of {} checks failed{}",
+            ANSI_RED, ANSI_BOLD, "\u{2717}", ANSI_BOLD, failed, total, ANSI_RESET,
+        );
+        eprintln!();
+        eprintln!(
+            "  {}Full troubleshooting guide: https://docs.baro.rs/docs/troubleshooting{}",
+            ANSI_DIM, ANSI_RESET,
+        );
+    }
+    eprintln!();
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(n).collect();
+        format!("{}\u{2026}", truncated)
+    }
+}

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -3,6 +3,7 @@ mod claude_runner;
 mod config;
 mod constants;
 mod context;
+mod doctor;
 mod events;
 mod executor;
 mod git;
@@ -178,6 +179,13 @@ struct Cli {
     /// repeat the same Reads/Greps. Default: 10. Set to 0 to disable.
     #[arg(long = "intra-level-delay")]
     intra_level_delay: Option<u64>,
+
+    /// Run a self-diagnostic and exit. Verifies the `claude` CLI is on
+    /// PATH, can return a version, can complete a trivial authenticated
+    /// call, plus checks for `gh` and a writable audit directory.
+    /// Use this when a baro run fails before any agents start.
+    #[arg(long)]
+    doctor: bool,
 }
 
 enum AppEvent {
@@ -186,7 +194,10 @@ enum AppEvent {
     ContextReady(String),
     ContextError(String),
     PlanReady(Vec<ReviewStory>, String, String, String),
-    PlanError(String),
+    /// Planner or Architect failed. Second tuple element is the path
+    /// to the full stdout+stderr log on disk (if claude_runner managed
+    /// to persist one). The planning screen surfaces both.
+    PlanError(String, Option<std::path::PathBuf>),
     RefineReady(Vec<ReviewStory>, String, String, String),
     RefineError(String),
     BranchError(String),
@@ -331,6 +342,14 @@ struct PrdStoryOutput {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
+
+    // `baro --doctor` short-circuits before any TUI setup. It's a
+    // diagnostic command, not a run, and it has to work even when the
+    // things a real run depends on (e.g. claude CLI auth) are broken
+    // — that's the whole point of it existing.
+    if cli.doctor {
+        std::process::exit(doctor::run().await);
+    }
 
     // Resolve cwd early so we can acquire the session lock before entering the TUI
     let cwd = std::fs::canonicalize(&cli.cwd)?;
@@ -557,8 +576,9 @@ async fn run_app(
                 app.description = description;
                 app.show_review(stories);
             }
-            Some(AppEvent::PlanError(err)) => {
+            Some(AppEvent::PlanError(err, log_path)) => {
                 app.planning_error = Some(err);
+                app.planning_log_path = log_path;
             }
             Some(AppEvent::RefineReady(stories, project, branch, description)) => {
                 app.refining = false;
@@ -965,7 +985,14 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
                     .await;
             }
             Err(e) => {
-                let _ = tx.send(AppEvent::PlanError(e.to_string())).await;
+                // If the error came from claude_runner, it carries the
+                // path to the persisted stdout+stderr log — surface it
+                // so the user can see the full diagnostic, not just the
+                // truncated headline.
+                let log_path = e
+                    .downcast_ref::<claude_runner::ClaudeRunError>()
+                    .and_then(|err| err.log_path.clone());
+                let _ = tx.send(AppEvent::PlanError(e.to_string(), log_path)).await;
             }
         }
     });
@@ -1028,6 +1055,7 @@ fn spawn_refiner(app: &App, feedback: &str, cwd: &Path, tx: mpsc::Sender<AppEven
                 prompt: prompt.clone(),
                 cwd: cwd.clone(),
                 model: model.clone(),
+                log_tag: Some("refine"),
             };
 
             let output = claude_runner::spawn_claude_json(&config).await?;
@@ -1209,6 +1237,7 @@ async fn run_claude_architect(
         prompt,
         cwd: cwd.to_path_buf(),
         model: model.map(|s| s.to_string()),
+        log_tag: Some("architect"),
     };
 
     let output = claude_runner::spawn_claude_json(&config).await?;
@@ -1254,6 +1283,7 @@ async fn run_claude_planner(
         prompt,
         cwd: cwd.to_path_buf(),
         model: model.map(|s| s.to_string()),
+        log_tag: Some("planner"),
     };
 
     let output = claude_runner::spawn_claude_json(&config).await?;

--- a/crates/baro-tui/src/screens/planning.rs
+++ b/crates/baro-tui/src/screens/planning.rs
@@ -27,12 +27,19 @@ fn dots(tick: u64) -> &'static str {
 
 pub fn render(f: &mut Frame, app: &App) {
     let area = f.area();
+    let in_error = app.planning_error.is_some();
+
+    // When showing an error we need a much taller box for the full
+    // message + the troubleshooting links. Pre-existing layout used a
+    // fixed 7-row central area which is the source of the truncated
+    // error in issue #17 — bump it to 18 in the error path.
+    let central_height: u16 = if in_error { 18 } else { 7 };
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(2),
-            Constraint::Length(7),   // Central box
+            Constraint::Length(central_height),
             Constraint::Length(1),   // Spacer
             Constraint::Length(1),   // LineGauge
             Constraint::Length(1),   // Spacer
@@ -53,7 +60,13 @@ pub fn render(f: &mut Frame, app: &App) {
             .split(area)[1]
     };
 
-    let box_width = 50.min(area.width.saturating_sub(4));
+    // Error box is wider (80 cols) than the spinner box (50 cols) so
+    // long error lines don't soft-wrap into illegibility.
+    let box_width = if in_error {
+        80.min(area.width.saturating_sub(4))
+    } else {
+        50.min(area.width.saturating_sub(4))
+    };
     let box_area = center(chunks[1], box_width);
 
     let planner_name = match app.planner {
@@ -62,8 +75,11 @@ pub fn render(f: &mut Frame, app: &App) {
     };
 
     if let Some(ref err) = app.planning_error {
-        // Error state
-        let lines = vec![
+        // Header row + blank + wrapped error body + blank + actionable
+        // hints (doctor command, log path, docs link). Paragraph::wrap
+        // handles the multi-line case so we don't need to slice the
+        // string ourselves (no more `&err[..44]` UTF-8 panic risk).
+        let mut lines: Vec<Line> = vec![
             Line::from(""),
             Line::from(vec![
                 Span::styled(
@@ -76,11 +92,39 @@ pub fn render(f: &mut Frame, app: &App) {
                 ),
             ]),
             Line::from(""),
-            Line::from(Span::styled(
-                format!(" {}", if err.len() > 44 { &err[..44] } else { err }),
-                Style::default().fg(theme::TEXT_DIM),
-            )),
         ];
+        // Render the full error body, line by line. ratatui's Paragraph
+        // will wrap each Line as needed.
+        for body_line in err.lines() {
+            lines.push(Line::from(Span::styled(
+                format!(" {}", body_line),
+                Style::default().fg(theme::TEXT_DIM),
+            )));
+        }
+        lines.push(Line::from(""));
+        if let Some(ref log) = app.planning_log_path {
+            lines.push(Line::from(vec![
+                Span::styled(" full log: ", Style::default().fg(theme::MUTED)),
+                Span::styled(
+                    log.display().to_string(),
+                    Style::default().fg(theme::ACCENT),
+                ),
+            ]));
+        }
+        lines.push(Line::from(vec![
+            Span::styled(" diagnose: ", Style::default().fg(theme::MUTED)),
+            Span::styled(
+                "baro --doctor",
+                Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD),
+            ),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(" docs:     ", Style::default().fg(theme::MUTED)),
+            Span::styled(
+                "https://docs.baro.rs/docs/troubleshooting",
+                Style::default().fg(theme::ACCENT),
+            ),
+        ]));
 
         let block = Block::default()
             .borders(Borders::ALL)
@@ -90,7 +134,9 @@ pub fn render(f: &mut Frame, app: &App) {
                 Style::default().fg(theme::ERROR).add_modifier(Modifier::BOLD),
             ));
 
-        let p = Paragraph::new(lines).block(block);
+        let p = Paragraph::new(lines)
+            .block(block)
+            .wrap(ratatui::widgets::Wrap { trim: false });
         f.render_widget(p, box_area);
 
         let hint = Paragraph::new(Line::from(vec![

--- a/packages/baro-app/package.json
+++ b/packages/baro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baro-ai",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Autonomous parallel coding - plan and execute with AI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Fixes #17.

A user reported that when baro fails before any agent starts, the
TUI shows `Claude exited with code 1:` with nothing useful after the
colon, and there's no way to find out what actually went wrong. This
PR makes the failure path debuggable end-to-end.

### What changed

1. **`baro --doctor`** — new self-diagnostic. Runs five checks
   sequentially and prints a pass/fail report with remediation hints
   for each failure:
   - \`claude\` on PATH (resolve + display path)
   - \`claude --version\` returns (5s timeout)
   - Trivial \`claude --print\` round-trip succeeds (30s timeout) —
     the check that catches the most common failure mode (the actual
     scenario in #17: unauthenticated CLI, empty stderr, exit 1)
   - \`gh\` on PATH (optional, used by Finalizer)
   - \`~/.baro/runs/\` is writable

2. **Persisted log files**. The planner, the Architect, and the
   refine call now each write their full stdout + stderr to
   \`~/.baro/runs/<tag>-<unix_secs>.log\` before the error reaches the
   caller — so a failed run leaves a forensic trail on disk even when
   the in-TUI error is empty.

3. **Real error UI**. The planning-screen error block:
   - Drops the byte-sliced 44-char preview (UTF-8 panic risk on top
     of being useless). Uses \`Paragraph::wrap\` now.
   - Grows the box to 18×80 in the error path so the full message
     fits.
   - Shows three actionable hints below the body: the log file path,
     \`baro --doctor\`, and a link to
     https://docs.baro.rs/docs/troubleshooting.

4. **Preflight \`which::which("claude")\`** inside
   \`spawn_claude_json\` so a missing binary fails fast with a
   specific message instead of bubbling up as a generic spawn error.

### Bumped to v0.25.1

CHANGELOG entry added. CI will publish on tag once this merges.

### Pairing PR

Companion documentation lives in
https://github.com/Lotus015/baro-docs (new repo, Vercel-bound at
docs.baro.rs). The troubleshooting page that the error UI links to
walks through the exact scenario reported in #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)