### PR TITLE
fix(0.37.1): UTF-8 panic in goal-truncation (em-dash crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 A concise list of every published version. For full release notes, see the corresponding commit on the v* tag.
 
+## v0.37.1 — fix(0.37.1): UTF-8 panic in goal-truncation — byte-index slice `&goal[..39]` panicked when an em-dash or other multi-byte char crossed offset 39 (planning + context screens); switched to `chars().take(39)`
 ## v0.37.0 — release(0.37.0): branch-per-run isolation (every fresh run creates a new suffixed `baro/<slug>-<unix-mod-100k>` branch, never falls back to checkout — side-by-side runs from sibling clones sharing an `origin` can't collide on `git push`); suffixed slug persisted back to `prd.json` for resume + Finalizer; planner prompt gains explicit PARALLELISM block calling out the linear-chain anti-pattern (observed in Mozaik run that emitted `S1 → S2 → S3 → S4 → S5` with no symbol-level reason); `[orchestrate]` banner on `--llm openai` now truthfully says all five phases route through Mozaik's native OpenAI runner
 ## v0.36.3 — fix(0.36.3): llm-aware routed model defaults — `--llm openai` no longer passes Claude's "opus" to the OpenAI planner ("unknown model" crash); TUI planning header reads from `app.llm` so OpenAI runs sit under "OpenAI" instead of "Claude"
 ## v0.36.2 — fix(0.36.2): two production-bundle bugs — stripped duplicate shebang from `run-architect.mjs` / `run-planner.mjs` (was double-shebang from tsup banner + source-side `#!/usr/bin/env tsx`); made `OpenAIResponses` construction lazy so loading the bundle no longer requires `OPENAI_API_KEY` even on the Claude path

--- a/crates/baro-tui/Cargo.toml
+++ b/crates/baro-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baro-tui"
-version = "0.37.0"
+version = "0.37.1"
 edition = "2021"
 
 [[bin]]

--- a/crates/baro-tui/src/screens/context.rs
+++ b/crates/baro-tui/src/screens/context.rs
@@ -48,8 +48,11 @@ pub fn render(f: &mut Frame, app: &App) {
     let frame_idx = (app.tick_count / 2) as usize % SPINNER_FRAMES.len();
     let spinner = SPINNER_FRAMES[frame_idx];
 
-    let goal_display = if app.goal_input.len() > 42 {
-        format!("{}...", &app.goal_input[..39])
+    // See planning.rs: byte-index slicing panics on multi-byte chars
+    // (em-dash, etc.). Truncate by char count instead.
+    let goal_display = if app.goal_input.chars().count() > 42 {
+        let truncated: String = app.goal_input.chars().take(39).collect();
+        format!("{}...", truncated)
     } else {
         app.goal_input.clone()
     };

--- a/crates/baro-tui/src/screens/planning.rs
+++ b/crates/baro-tui/src/screens/planning.rs
@@ -157,8 +157,14 @@ pub fn render(f: &mut Frame, app: &App) {
         let spinner = SPINNER_FRAMES[frame_idx];
         let elapsed = app.planning_elapsed_secs();
 
-        let goal_display = if app.goal_input.len() > 42 {
-            format!("{}...", &app.goal_input[..39])
+        // Truncate by char count, not byte count — slicing &str at a raw
+        // byte index panics when the boundary falls inside a multi-byte
+        // character (em-dash, smart quotes, CJK, emoji). User goals
+        // routinely contain `—` which is 3 bytes, so the old `[..39]`
+        // crashed any goal where an em-dash crossed offset 39.
+        let goal_display = if app.goal_input.chars().count() > 42 {
+            let truncated: String = app.goal_input.chars().take(39).collect();
+            format!("{}...", truncated)
         } else {
             app.goal_input.clone()
         };

--- a/packages/baro-app/package.json
+++ b/packages/baro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baro-ai",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Autonomous parallel coding - plan and execute with AI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- `&app.goal_input[..39]` in \`planning.rs\` and \`context.rs\` panics when byte 39 lands inside a multi-byte UTF-8 character. User's Mozaik re-run goal started with \`Start from a clean checkout of \`main\` —\` and the em-dash (U+2014, 3 bytes) sat right across the slice boundary, taking down baro before it ever rendered the planning screen.
- Switched both spots to char-count truncation: \`chars().count() > 42\` + \`chars().take(39).collect::<String>()\`.

## Test plan

- [ ] \`baro --llm claude "$(cat ~/Desktop/mozaik-baro-test-claude/GOAL.md)"\` no longer panics on the em-dash in the new GOAL.md preamble.
- [ ] Long ASCII goal still truncates to 39 visible chars + \`...\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)