### PR TITLE
feat: --share-architect-cache (experimental flag)

### DIFF
--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -286,6 +286,12 @@ pub struct App {
     pub planner_model: Option<String>,
     pub story_model: Option<String>,
     pub intra_level_delay_secs: Option<u64>,
+    /// EXPERIMENTAL — opt-in via `--share-architect-cache`. When true,
+    /// the orchestrator passes the Architect's DecisionDocument to
+    /// every Claude Code subprocess via `--append-system-prompt` so
+    /// stories after the first one read it from Anthropic's prompt
+    /// cache rather than each paying their own cache_creation cost.
+    pub share_architect_cache: bool,
 
     /// Quick mode (`--quick`): user has told us this goal is trivial and they
     /// want a surgical run. Skips the Architect phase entirely, instructs the
@@ -384,6 +390,7 @@ impl App {
             planner_model: None,
             story_model: None,
             intra_level_delay_secs: None,
+            share_architect_cache: false,
             quick: false,
             llm: LlmProvider::Claude,
             token_usage: HashMap::new(),

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -92,6 +92,12 @@ pub struct ExecutorConfig {
     /// flow through their existing function-arg paths in spawn_planner
     /// and don't need an executor-side field.
     pub story_model: Option<String>,
+    /// EXPERIMENTAL — when true, the orchestrator pushes the Architect's
+    /// DecisionDocument into the Claude Code system prompt instead of
+    /// prepending it to the per-story user prompt. Lets all stories
+    /// after the first read the DecisionDocument from Anthropic's
+    /// org-scoped prompt cache. Default: false.
+    pub share_architect_cache: bool,
 }
 
 // ─── Helpers used by main.rs ────────────────────────────────────────

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -223,6 +223,17 @@ struct Cli {
     /// the provider-picker screen when running interactively.
     #[arg(long, default_value = "claude", value_parser = ["claude", "openai"])]
     llm: String,
+
+    /// EXPERIMENTAL — push the Architect's DecisionDocument into Claude
+    /// Code's system prompt (via `--append-system-prompt`) instead of
+    /// prepending it to each story's user prompt. Because Anthropic's
+    /// prompt cache is org-scoped and the cache key includes the entire
+    /// system prompt + tools, this lets all stories that follow story 1
+    /// READ the DecisionDocument from cache instead of each one paying
+    /// its own cache_creation. Default: off (DecisionDocument prepended
+    /// to user prompt as before). Measure before flipping.
+    #[arg(long = "share-architect-cache")]
+    share_architect_cache: bool,
 }
 
 enum AppEvent {
@@ -431,6 +442,7 @@ async fn run_app(
     if let Some(d) = cli.intra_level_delay {
         app.intra_level_delay_secs = Some(d);
     }
+    app.share_architect_cache = cli.share_architect_cache;
 
     // --quick is the user telling us "this is trivial, don't ceremony it".
     // We honour that on three fronts: skip Architect (no design doc),
@@ -870,6 +882,7 @@ async fn run_app(
                                         let ild = app.intra_level_delay_secs;
                                         let llm = app.llm;
                                         let oak = app.openai_api_key.clone();
+                                        let sac = app.share_architect_cache;
                                         let stm = app.story_model.clone();
                                         let err_tx = tx.clone();
                                         tokio::spawn(async move {
@@ -899,7 +912,7 @@ async fn run_app(
                                                     return;
                                                 }
                                             }
-                                            spawn_executor(prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, openai_api_key: oak.clone(), story_model: stm.clone() });
+                                            spawn_executor(prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, openai_api_key: oak.clone(), story_model: stm.clone(), share_architect_cache: sac });
                                         });
                                     }
                                     Err(e) => {
@@ -941,6 +954,7 @@ async fn run_app(
                                     let ild = app.intra_level_delay_secs;
                                     let llm = app.llm;
                                     let oak = app.openai_api_key.clone();
+                                    let sac = app.share_architect_cache;
                                     let stm = app.story_model.clone();
                                     let err_tx = tx.clone();
                                     tokio::spawn(async move {
@@ -990,7 +1004,7 @@ async fn run_app(
                                                 return;
                                             }
                                         }
-                                        spawn_executor(exec_prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, openai_api_key: oak.clone(), story_model: stm.clone() });
+                                        spawn_executor(exec_prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, openai_api_key: oak.clone(), story_model: stm.clone(), share_architect_cache: sac });
                                     });
                                 }
                             }
@@ -1401,6 +1415,7 @@ fn spawn_executor(
         llm: config.llm.as_str().to_string(),
         openai_api_key: config.openai_api_key,
         story_model: config.story_model,
+        share_architect_cache: config.share_architect_cache,
     };
     orchestrator_client::spawn_orchestrator(orch_cfg, exec_tx);
 }

--- a/crates/baro-tui/src/orchestrator_client.rs
+++ b/crates/baro-tui/src/orchestrator_client.rs
@@ -63,6 +63,9 @@ pub struct OrchestratorConfig {
     /// `--story-model X` to the orchestrator subprocess. Wins over
     /// the per-PRD-story `model` field and over the OpenAI default.
     pub story_model: Option<String>,
+    /// EXPERIMENTAL — forwards `--share-architect-cache` to the
+    /// orchestrator subprocess. See main.rs Cli docstring for context.
+    pub share_architect_cache: bool,
 }
 
 /// Spawn the orchestrator subprocess and return a channel that receives
@@ -280,6 +283,9 @@ fn build_command(entry: &ScriptEntry, cfg: &OrchestratorConfig) -> Command {
     }
     if let Some(m) = &cfg.story_model {
         cmd.arg("--story-model").arg(m);
+    }
+    if cfg.share_architect_cache {
+        cmd.arg("--share-architect-cache");
     }
     cmd
 }

--- a/packages/baro-orchestrator/scripts/cli.ts
+++ b/packages/baro-orchestrator/scripts/cli.ts
@@ -43,6 +43,7 @@ interface CliArgs {
     storyModel?: string
     intraLevelDelaySecs?: number
     llm: "claude" | "openai"
+    shareArchitectCache: boolean
     help: boolean
 }
 
@@ -60,6 +61,7 @@ function parseArgs(argv: string[]): CliArgs {
         withSurgeon: false,
         surgeonUseLlm: false,
         llm: "claude",
+        shareArchitectCache: false,
         help: false,
     }
     for (let i = 0; i < argv.length; i++) {
@@ -132,6 +134,9 @@ function parseArgs(argv: string[]): CliArgs {
                 args.llm = v
                 break
             }
+            case "--share-architect-cache":
+                args.shareArchitectCache = true
+                break
             default:
                 process.stderr.write(`[cli] unknown flag: ${a}\n`)
                 process.exit(2)
@@ -214,6 +219,7 @@ async function main(): Promise<void> {
         intraLevelDelaySecs: args.intraLevelDelaySecs,
         llm: args.llm,
         storyModel: args.storyModel,
+        shareArchitectCache: args.shareArchitectCache,
     }
 
     if (args.llm === "openai" && !process.env.OPENAI_API_KEY) {

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -143,6 +143,20 @@ export interface OrchestrateConfig {
      * `--story-model`.
      */
     storyModel?: string
+    /**
+     * EXPERIMENTAL — when true, the Conductor passes the Architect's
+     * DecisionDocument to every Claude Code subprocess via
+     * `--append-system-prompt` instead of prepending it to each
+     * story's user prompt. The DD becomes part of the system prompt,
+     * which Anthropic's prompt cache hashes as the cache prefix — so
+     * once story 1 has paid the `cache_creation` cost for the DD,
+     * stories 2..N read it from cache at the 10× discount instead
+     * of each one re-paying the same ~5-10K token creation cost.
+     * Default: false. Toggled by the Rust CLI flag
+     * `--share-architect-cache`. Measure with audit log totals
+     * before flipping to default.
+     */
+    shareArchitectCache?: boolean
     /** Hooks for receiving Operator commands externally (Rust TUI). */
     operatorHooks?: {
         onAbort?: (storyId: string) => void
@@ -315,6 +329,7 @@ export async function orchestrate(
         overrideModel: config.overrideModel ?? undefined,
         defaultModel: config.defaultModel ?? "opus",
         intraLevelDelaySecs: config.intraLevelDelaySecs,
+        shareArchitectCache: config.shareArchitectCache ?? false,
         onRunStart: useGit
             ? async (prd) => {
                   baseSha = await getHeadSha(config.cwd)

--- a/packages/baro-orchestrator/src/participants/claude-cli-participant.ts
+++ b/packages/baro-orchestrator/src/participants/claude-cli-participant.ts
@@ -63,6 +63,14 @@ export interface ClaudeCliParticipantOptions {
      * multi-turn agents that survive across multiple infer() calls.
      */
     resumeSessionId?: string
+    /**
+     * If provided, pass `--append-system-prompt <text>` so the spawned
+     * Claude subprocess's system prompt includes this string in its
+     * cached prefix. baro's `--share-architect-cache` flag routes the
+     * Architect's DecisionDocument through here so multiple parallel
+     * story subprocesses share the same prompt cache prefix.
+     */
+    appendSystemPrompt?: string
 }
 
 export interface ClaudeRunSummary {
@@ -267,6 +275,9 @@ export class ClaudeCliParticipant extends BaroParticipant {
         }
         if (this.options.resumeSessionId) {
             args.push("--resume", this.options.resumeSessionId)
+        }
+        if (this.options.appendSystemPrompt && this.options.appendSystemPrompt.length > 0) {
+            args.push("--append-system-prompt", this.options.appendSystemPrompt)
         }
         if (this.options.extraArgs && this.options.extraArgs.length > 0) {
             args.push(...this.options.extraArgs)

--- a/packages/baro-orchestrator/src/participants/conductor.ts
+++ b/packages/baro-orchestrator/src/participants/conductor.ts
@@ -90,6 +90,17 @@ export interface ConductorOptions {
      * Default: 10 seconds.
      */
     intraLevelDelaySecs?: number
+    /**
+     * EXPERIMENTAL — when true, `resolvePrompt` keeps the Architect's
+     * DecisionDocument OUT of the per-story user prompt and routes it
+     * to the spawned Claude CLI as `--append-system-prompt` (via the
+     * StorySpawnRequestItem.appendSystemPrompt channel + StoryFactory
+     * + StoryAgent + ClaudeCliParticipant). Lets Anthropic's
+     * org-scoped prompt cache hit on the shared system-prompt prefix
+     * across all stories. Default: false. Plumbed from the
+     * `--share-architect-cache` CLI flag.
+     */
+    shareArchitectCache?: boolean
 }
 
 export interface ConductorRunSummary {
@@ -446,7 +457,9 @@ export class Conductor extends BaroParticipant {
     private async requestStorySpawn(story: PrdStory): Promise<void> {
         const model =
             this.opts.overrideModel ?? story.model ?? this.opts.defaultModel
-        let prompt = this.resolvePrompt(story)
+        const resolved = this.resolvePrompt(story)
+        let prompt = resolved.userPrompt
+        const appendSystemPrompt = resolved.appendSystemPrompt
 
         if (this.opts.onBeforeStoryLaunch) {
             try {
@@ -472,6 +485,7 @@ export class Conductor extends BaroParticipant {
                 model,
                 story.retries,
                 this.opts.timeoutSecs,
+                appendSystemPrompt,
             ),
         )
     }
@@ -601,7 +615,10 @@ export class Conductor extends BaroParticipant {
         this.resolveDone(summary)
     }
 
-    private resolvePrompt(story: PrdStory): string {
+    private resolvePrompt(story: PrdStory): {
+        userPrompt: string
+        appendSystemPrompt?: string
+    } {
         const candidatePath =
             this.opts.promptTemplatePath ?? join(this.opts.cwd, "prompt.md")
         let prompt: string
@@ -612,32 +629,48 @@ export class Conductor extends BaroParticipant {
             prompt = buildDefaultStoryPrompt(story)
         }
 
-        // Prepend Architect's DecisionDocument so the agent sees the
-        // authoritative design spec before its task description. This
-        // is the single biggest lever against per-story decision drift
-        // (column names, file paths, API shapes, dependency choices,
-        // …): every agent receives the same upstream-pinned answers
-        // instead of each one improvising independently.
+        // Architect's DecisionDocument is the authoritative design spec.
+        // Two routing modes:
+        //
+        //   1) Default (`shareArchitectCache: false`): prepend to the
+        //      user prompt. Identical text every story sees BEFORE its
+        //      own task, but it sits in the user-message channel —
+        //      Anthropic's prompt cache prefix doesn't include user
+        //      messages, so each story pays its own cache_creation cost
+        //      for the DD on its first turn (≈5-10K tokens × N stories).
+        //
+        //   2) Cache-shared (`shareArchitectCache: true`): push the DD
+        //      to `--append-system-prompt`. It becomes part of every
+        //      Claude Code subprocess's system prompt, which IS in the
+        //      cache prefix. Story 1 pays cache_creation; stories 2..N
+        //      read it from cache at the 10× discount.
         const doc = this.prd?.decisionDocument
-        if (doc && doc.trim().length > 0) {
-            const header = [
-                "## Design spec (authoritative — already decided)",
-                "",
-                "The Architect made these decisions before any story started.",
-                "Treat them as fixed: use these exact file paths, names,",
-                "schemas, API shapes, and dependency choices. Do NOT",
-                "improvise alternatives — your siblings are working from",
-                "the same spec and divergence breaks the build.",
-                "",
-                doc.trim(),
-                "",
-                "---",
-                "",
-            ].join("\n")
-            prompt = header + prompt
+        if (!doc || doc.trim().length === 0) {
+            return { userPrompt: prompt }
         }
 
-        return prompt
+        const trimmedDoc = doc.trim()
+        const headerLines = [
+            "## Design spec (authoritative — already decided)",
+            "",
+            "The Architect made these decisions before any story started.",
+            "Treat them as fixed: use these exact file paths, names,",
+            "schemas, API shapes, and dependency choices. Do NOT",
+            "improvise alternatives — your siblings are working from",
+            "the same spec and divergence breaks the build.",
+            "",
+        ]
+
+        if (this.opts.shareArchitectCache) {
+            // Same framing text, but routed via the system prompt so
+            // it lands inside Claude Code's cached prefix. The user
+            // prompt stays per-story-unique (and uncached, but small).
+            const appendSystemPrompt = [...headerLines, trimmedDoc].join("\n")
+            return { userPrompt: prompt, appendSystemPrompt }
+        }
+
+        const header = [...headerLines, trimmedDoc, "", "---", ""].join("\n")
+        return { userPrompt: header + prompt }
     }
 
     private emit(event: BusEvent): void {

--- a/packages/baro-orchestrator/src/participants/story-agent.ts
+++ b/packages/baro-orchestrator/src/participants/story-agent.ts
@@ -70,6 +70,13 @@ export interface StorySpec {
      * Claude process is aborted unconditionally when this fires. Default: 300.
      */
     hardTimeoutSecs?: number
+    /**
+     * Optional text passed to the spawned Claude Code subprocess via
+     * `--append-system-prompt`. Used by `--share-architect-cache` to
+     * route the Architect's DecisionDocument through the cached
+     * system-prompt prefix instead of per-story user prompts.
+     */
+    appendSystemPrompt?: string
 }
 
 export interface StoryOutcome {
@@ -308,6 +315,7 @@ export class StoryAgent extends BaroParticipant {
         const claude = new ClaudeCliParticipant(this.spec.id, {
             cwd: this.spec.cwd,
             model: this.spec.model,
+            appendSystemPrompt: this.spec.appendSystemPrompt,
         })
         this.currentClaude = claude
         claude.join(this.envRef)

--- a/packages/baro-orchestrator/src/participants/story-factory.ts
+++ b/packages/baro-orchestrator/src/participants/story-factory.ts
@@ -113,6 +113,7 @@ export class StoryFactory extends BaroParticipant {
                       model: claudeModel,
                       retries: req.retries,
                       timeoutSecs: req.timeoutSecs,
+                      appendSystemPrompt: req.appendSystemPrompt,
                   })
 
         agent.join(this.envRef)

--- a/packages/baro-orchestrator/src/types.ts
+++ b/packages/baro-orchestrator/src/types.ts
@@ -507,6 +507,14 @@ export class StorySpawnRequestItem extends BusEvent {
         public readonly model: string,
         public readonly retries: number,
         public readonly timeoutSecs: number,
+        /**
+         * Optional text appended to the Claude Code system prompt via
+         * `--append-system-prompt`. Carries the Architect's
+         * DecisionDocument when `Conductor.shareArchitectCache` is on,
+         * so the spawned subprocess's cache prefix is identical across
+         * stories (Anthropic's prompt cache hits after story 1).
+         */
+        public readonly appendSystemPrompt?: string,
     ) {
         super()
     }
@@ -518,6 +526,7 @@ export class StorySpawnRequestItem extends BusEvent {
             model: this.model,
             retries: this.retries,
             timeoutSecs: this.timeoutSecs,
+            appendSystemPromptLen: this.appendSystemPrompt?.length ?? 0,
         }
     }
 }


### PR DESCRIPTION
## Summary

New opt-in CLI flag that routes the Architect's DecisionDocument through Claude Code's system prompt (via \`--append-system-prompt\`) instead of prepending it to each story's user prompt.

**Why:** Anthropic's prompt cache is org-scoped, and the cache key hashes the system prompt + tools but NOT user messages. Currently the DD lives in user-message space, so every story pays its own \`cache_creation\` for the same ~5-10K-token document. Moving it to system-prompt space lets all stories after story 1 read it from cache at the 10× discount.

**Default:** OFF. Existing prompt-shape contract preserved. Flip with \`baro --share-architect-cache "<goal>"\` to test.

## Plumbing (11 files, +144/-27)

**Rust:** \`Cli\` → \`app\` → \`ExecutorConfig\` → \`OrchestratorConfig\` → \`build_command\` (\`--share-architect-cache\`)

**TS:** \`cli.ts\` → \`OrchestrateConfig\` → \`Conductor\` (new opt + \`resolvePrompt\` split returning \`{ userPrompt, appendSystemPrompt }\`) → \`StorySpawnRequestItem.appendSystemPrompt\` → \`StoryFactory\` → \`StorySpec\` → \`StoryAgent\` → \`ClaudeCliParticipant\` → spawned \`claude --append-system-prompt <DD>\`

## Verification before flipping default

Both layers build clean (\`cargo build\` + \`tsc --noEmit\`). Functional verification requires a real run-vs-run comparison on a multi-story goal:

\`\`\`bash
# Baseline (current behavior)
baro "Add unit tests for X module"
# Audit log:  ~/.baro/runs/<project>-<ts>.jsonl
# Sum: cache_creation_input_tokens across all claude_result events

# With flag
baro --share-architect-cache "Add unit tests for X module"
# Compare cache_creation totals — should drop by ~(N-1)/N of the DD size,
# where N is the number of stories.
\`\`\`

## Test plan

- [ ] Same goal, parallel runs with vs without flag, compare \`cache_creation_input_tokens\` totals from audit log
- [ ] Verify spawned subprocess in \`ps\` shows \`--append-system-prompt\` arg when flag is on
- [ ] No regressions on a non-Architect run (Quick mode, no DD present)