### PR TITLE
feat: Codex CLI as third subscription-arbitrage backend (Story phase)

### DIFF
--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -113,6 +113,14 @@ pub enum ArchitectStatus {
 pub enum LlmProvider {
     Claude,
     OpenAI,
+    /// OpenAI Codex CLI subprocess. Same subscription-arbitrage shape
+    /// as Claude (subprocess wrapping a vendor CLI billed against a
+    /// consumer ChatGPT plan rather than per-token API), but a
+    /// different binary, different JSONL event schema, and one-shot
+    /// non-interactive invocation per turn (no stdin streaming).
+    /// Implementation: `packages/baro-orchestrator/src/participants/
+    /// codex-cli-participant.ts`.
+    Codex,
 }
 
 impl LlmProvider {
@@ -120,6 +128,7 @@ impl LlmProvider {
         match self {
             Self::Claude => "claude",
             Self::OpenAI => "openai",
+            Self::Codex => "codex",
         }
     }
 
@@ -127,6 +136,7 @@ impl LlmProvider {
         match raw {
             "claude" => Some(Self::Claude),
             "openai" => Some(Self::OpenAI),
+            "codex" => Some(Self::Codex),
             _ => None,
         }
     }

--- a/crates/baro-tui/src/doctor.rs
+++ b/crates/baro-tui/src/doctor.rs
@@ -45,6 +45,7 @@ pub async fn run() -> i32 {
     results.push(check_claude_on_path().await);
     results.push(check_claude_version().await);
     results.push(check_claude_print_call().await);
+    results.push(check_codex_on_path().await);
     results.push(check_gh_on_path().await);
     results.push(check_audit_dir_writable().await);
 
@@ -183,6 +184,24 @@ async fn check_claude_print_call() -> CheckResult {
 /// `gh` is only required for the Finalizer (PR creation). A failing
 /// gh check is a warning, not a fatal error — the run will still
 /// complete, the user just won't get an auto-PR.
+/// Verify `codex` binary is reachable (optional — only needed for
+/// `baro --llm codex`). Soft failure: codex is optional infrastructure
+/// for the third backend; not having it doesn't block Claude or
+/// OpenAI workflows.
+async fn check_codex_on_path() -> CheckResult {
+    match which::which("codex") {
+        Ok(path) => CheckResult::pass(
+            "codex on PATH (optional, used for --llm codex)",
+            format!("{}", path.display()),
+        ),
+        Err(_) => CheckResult::fail(
+            "codex on PATH (optional, used for --llm codex)",
+            "binary not found",
+            "Install OpenAI Codex CLI from https://developers.openai.com/codex/cli if you want the `--llm codex` subscription path; otherwise this check is informational and Claude / OpenAI routes still work.",
+        ),
+    }
+}
+
 async fn check_gh_on_path() -> CheckResult {
     match which::which("gh") {
         Ok(path) => CheckResult::pass(

--- a/crates/baro-tui/src/screens/planning.rs
+++ b/crates/baro-tui/src/screens/planning.rs
@@ -76,6 +76,7 @@ pub fn render(f: &mut Frame, app: &App) {
     let planner_name = match app.llm {
         crate::app::LlmProvider::Claude => "Claude",
         crate::app::LlmProvider::OpenAI => "OpenAI",
+        crate::app::LlmProvider::Codex => "Codex",
     };
 
     if let Some(ref err) = app.planning_error {

--- a/packages/baro-app/scripts/probe-codex.ts
+++ b/packages/baro-app/scripts/probe-codex.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env tsx
+/**
+ * Probe: Codex CLI as a Mozaik Participant.
+ *
+ * Validates milestones M1–M3 of the codex backend plan:
+ *
+ *   M1  — `codex exec --json` runs against a context-free cwd, JSONL
+ *          stream lands on stdout (no Mozaik wiring; pure CLI smoke).
+ *
+ *   M2  — same, but run from inside the baro repo so we measure the
+ *          incremental cost of Codex indexing a non-trivial repo.
+ *
+ *   M3  — CodexCliParticipant spawns `codex exec --json` and the
+ *          codex-stream-mapper translates JSONL → Mozaik items, with
+ *          every emitted event captured to `spike-logs/codex-<ts>.jsonl`
+ *          for offline analysis.
+ *
+ * This script implements M3. M1 and M2 are one-liner shell commands the
+ * user runs directly (no orchestrator wiring needed); see the comments
+ * at the bottom of this file.
+ *
+ * Usage:
+ *   tsx packages/baro-app/scripts/probe-codex.ts \
+ *     --prompt "list files in packages/baro-orchestrator/src/participants/ and output their count" \
+ *     [--cwd <path>] [--model gpt-5.5] [--full-auto]
+ *
+ * Output:
+ *   - Every Mozaik bus event printed to stdout with a brief one-liner
+ *     summary so you can see the run unfold.
+ *   - Full raw JSONL audit log written to
+ *     packages/baro-app/scripts/spike-logs/codex-<unix-ts>.jsonl. Compare
+ *     side-by-side with the Claude spike logs in the same directory
+ *     to verify the mapper produces the same Mozaik shape from both
+ *     backends.
+ *
+ * Budget caution: each invocation costs ~3% of the ChatGPT Free weekly
+ * cap (per Codex documentation; observed 2026-05-22). Don't run this
+ * casually.
+ */
+
+import { appendFileSync, mkdirSync, writeFileSync } from "fs"
+import { join } from "path"
+
+import {
+    AgenticEnvironment,
+    BaseObserver,
+    FunctionCallItem,
+    FunctionCallOutputItem,
+    ModelMessageItem,
+    Participant,
+    ReasoningItem,
+    SemanticEvent,
+} from "@mozaik-ai/core"
+
+import { CodexCliParticipant } from "@baro/orchestrator"
+
+type Loggable =
+    | SemanticEvent<unknown>
+    | ModelMessageItem
+    | FunctionCallItem
+    | FunctionCallOutputItem
+    | ReasoningItem
+
+interface ProbeArgs {
+    prompt: string
+    cwd: string
+    model?: string
+    fullAuto: boolean
+}
+
+function parseArgs(): ProbeArgs {
+    const argv = process.argv.slice(2)
+    let prompt: string | undefined
+    let cwd = process.cwd()
+    let model: string | undefined
+    let fullAuto = false
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i]
+        switch (a) {
+            case "--prompt":
+                prompt = argv[++i]
+                break
+            case "--cwd":
+                cwd = argv[++i]!
+                break
+            case "--model":
+                model = argv[++i]
+                break
+            case "--full-auto":
+                fullAuto = true
+                break
+            case "--help":
+            case "-h":
+                process.stdout.write(
+                    `usage: probe-codex.ts --prompt <text> [--cwd <path>] [--model <name>] [--full-auto]\n`,
+                )
+                process.exit(0)
+        }
+    }
+    if (!prompt) {
+        process.stderr.write("error: --prompt is required\n")
+        process.exit(2)
+    }
+    return { prompt, cwd, model, fullAuto }
+}
+
+function summarize(item: Loggable): string {
+    if (item instanceof SemanticEvent) {
+        const type = item.type
+        const data = item.data as Record<string, unknown>
+        const hints: string[] = []
+        if (typeof data.subtype === "string") hints.push(`subtype=${data.subtype}`)
+        if (typeof data.phase === "string") hints.push(`phase=${data.phase}`)
+        if (typeof data.itemType === "string") hints.push(`item=${data.itemType}`)
+        return `[${type}] ${hints.join(" ")}`
+    }
+    const json = (item as { toJSON: () => Record<string, unknown> }).toJSON()
+    const type = typeof json.type === "string" ? json.type : "item"
+    const text =
+        typeof json.text === "string"
+            ? `"${(json.text as string).slice(0, 80)}${
+                  (json.text as string).length > 80 ? "…" : ""
+              }"`
+            : typeof (json as { name?: unknown }).name === "string"
+                ? `name=${(json as { name?: string }).name}`
+                : ""
+    return `[${type}] ${text}`
+}
+
+class LoggingObserver extends BaseObserver {
+    constructor(private readonly logPath: string) {
+        super()
+    }
+
+    private write(source: Participant, item: Loggable): void {
+        const entry = {
+            ts: new Date().toISOString(),
+            source: source.constructor.name,
+            item: (item as { toJSON: () => Record<string, unknown> }).toJSON(),
+        }
+        appendFileSync(this.logPath, JSON.stringify(entry) + "\n")
+        process.stdout.write(`${entry.ts.slice(11, 23)}  ${summarize(item)}\n`)
+    }
+
+    override async onExternalEvent(
+        source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        this.write(source, event)
+    }
+
+    override async onExternalModelMessage(
+        source: Participant,
+        item: ModelMessageItem,
+    ): Promise<void> {
+        this.write(source, item)
+    }
+
+    override async onExternalFunctionCall(
+        source: Participant,
+        item: FunctionCallItem,
+    ): Promise<void> {
+        this.write(source, item)
+    }
+
+    override async onExternalFunctionCallOutput(
+        source: Participant,
+        item: FunctionCallOutputItem,
+    ): Promise<void> {
+        this.write(source, item)
+    }
+}
+
+async function main(): Promise<void> {
+    const { prompt, cwd, model, fullAuto } = parseArgs()
+
+    const logsDir = join(process.cwd(), "packages/baro-app/scripts/spike-logs")
+    mkdirSync(logsDir, { recursive: true })
+    const logPath = join(logsDir, `codex-${Date.now()}.jsonl`)
+    writeFileSync(logPath, "")
+    process.stdout.write(`probe-codex: log file ${logPath}\n`)
+    process.stdout.write(`probe-codex: cwd ${cwd}\n`)
+    process.stdout.write(`probe-codex: prompt ${prompt}\n\n`)
+
+    const env = new AgenticEnvironment()
+    const observer = new LoggingObserver(logPath)
+    observer.join(env)
+
+    const codex = new CodexCliParticipant("probe", {
+        cwd,
+        prompt,
+        model,
+        fullAuto,
+    })
+    codex.join(env)
+    codex.start(env)
+
+    const summary = await codex.done
+    process.stdout.write(
+        `\nprobe-codex: done. threadId=${summary.threadId} exitCode=${summary.exitCode} error=${summary.error?.message ?? "—"}\n`,
+    )
+    process.stdout.write(`probe-codex: log persisted at ${logPath}\n`)
+}
+
+main().catch((err) => {
+    process.stderr.write(`probe-codex: fatal — ${err?.stack ?? err}\n`)
+    process.exit(1)
+})
+
+/* ─── M1 & M2: one-liner shell commands (no Node wiring needed) ──────
+ *
+ * M1 — context-free baseline (run from /tmp/empty):
+ *   mkdir -p /tmp/codex-probe && cd /tmp/codex-probe
+ *   codex exec --json "print the word hello and exit" \
+ *     | tee ~/Desktop/codex-probe-M1.jsonl
+ *
+ * M2 — baro-repo indexing cost:
+ *   cd ~/Desktop/baro
+ *   codex exec --json "print the word hello and exit" \
+ *     | tee ~/Desktop/codex-probe-M2.jsonl
+ *
+ * Diff the resulting JSONLs to measure repo-indexing overhead. Both
+ * runs cost weekly-cap units even on success, so plan carefully.
+ * ─────────────────────────────────────────────────────────────────── */

--- a/packages/baro-app/scripts/probe-codex.ts
+++ b/packages/baro-app/scripts/probe-codex.ts
@@ -66,6 +66,7 @@ interface ProbeArgs {
     cwd: string
     model?: string
     fullAuto: boolean
+    skipGitRepoCheck: boolean
 }
 
 function parseArgs(): ProbeArgs {
@@ -74,6 +75,7 @@ function parseArgs(): ProbeArgs {
     let cwd = process.cwd()
     let model: string | undefined
     let fullAuto = false
+    let skipGitRepoCheck = false
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i]
         switch (a) {
@@ -89,10 +91,13 @@ function parseArgs(): ProbeArgs {
             case "--full-auto":
                 fullAuto = true
                 break
+            case "--skip-git-repo-check":
+                skipGitRepoCheck = true
+                break
             case "--help":
             case "-h":
                 process.stdout.write(
-                    `usage: probe-codex.ts --prompt <text> [--cwd <path>] [--model <name>] [--full-auto]\n`,
+                    `usage: probe-codex.ts --prompt <text> [--cwd <path>] [--model <name>] [--full-auto] [--skip-git-repo-check]\n`,
                 )
                 process.exit(0)
         }
@@ -101,7 +106,7 @@ function parseArgs(): ProbeArgs {
         process.stderr.write("error: --prompt is required\n")
         process.exit(2)
     }
-    return { prompt, cwd, model, fullAuto }
+    return { prompt, cwd, model, fullAuto, skipGitRepoCheck }
 }
 
 function summarize(item: Loggable): string {
@@ -172,7 +177,7 @@ class LoggingObserver extends BaseObserver {
 }
 
 async function main(): Promise<void> {
-    const { prompt, cwd, model, fullAuto } = parseArgs()
+    const { prompt, cwd, model, fullAuto, skipGitRepoCheck } = parseArgs()
 
     const logsDir = join(process.cwd(), "packages/baro-app/scripts/spike-logs")
     mkdirSync(logsDir, { recursive: true })
@@ -191,6 +196,7 @@ async function main(): Promise<void> {
         prompt,
         model,
         fullAuto,
+        skipGitRepoCheck,
     })
     codex.join(env)
     codex.start(env)
@@ -209,12 +215,15 @@ main().catch((err) => {
 
 /* ─── M1 & M2: one-liner shell commands (no Node wiring needed) ──────
  *
- * M1 — context-free baseline (run from /tmp/empty):
+ * M1 — context-free baseline (non-repo dir needs --skip-git-repo-check
+ *      because Codex refuses to run outside a trusted git repo by
+ *      default):
  *   mkdir -p /tmp/codex-probe && cd /tmp/codex-probe
- *   codex exec --json "print the word hello and exit" \
+ *   codex exec --json --skip-git-repo-check \
+ *     "print the word hello and exit" \
  *     | tee ~/Desktop/codex-probe-M1.jsonl
  *
- * M2 — baro-repo indexing cost:
+ * M2 — baro-repo indexing cost (no flag needed; baro is a git repo):
  *   cd ~/Desktop/baro
  *   codex exec --json "print the word hello and exit" \
  *     | tee ~/Desktop/codex-probe-M2.jsonl

--- a/packages/baro-orchestrator/scripts/cli.ts
+++ b/packages/baro-orchestrator/scripts/cli.ts
@@ -42,7 +42,7 @@ interface CliArgs {
     surgeonModel?: string
     storyModel?: string
     intraLevelDelaySecs?: number
-    llm: "claude" | "openai"
+    llm: "claude" | "openai" | "codex"
     help: boolean
 }
 
@@ -125,8 +125,10 @@ function parseArgs(argv: string[]): CliArgs {
                 break
             case "--llm": {
                 const v = required(argv, ++i, "--llm")
-                if (v !== "claude" && v !== "openai") {
-                    process.stderr.write(`[cli] --llm must be 'claude' or 'openai', got '${v}'\n`)
+                if (v !== "claude" && v !== "openai" && v !== "codex") {
+                    process.stderr.write(
+                        `[cli] --llm must be 'claude' | 'openai' | 'codex', got '${v}'\n`,
+                    )
                     process.exit(2)
                 }
                 args.llm = v

--- a/packages/baro-orchestrator/scripts/run-architect.ts
+++ b/packages/baro-orchestrator/scripts/run-architect.ts
@@ -25,7 +25,14 @@ import { runArchitectOpenAI } from "../src/planning/architect-openai.js"
 interface Args {
     goal: string
     cwd: string
-    llm: "claude" | "openai"
+    /**
+     * "codex" is accepted at the boundary but currently routes through
+     * the Claude architect path — codex-architect.ts is a planned v2
+     * follow-up to the codex story-agent backend. v1's positioning is:
+     * Codex covers the Story phase (which dominates token spend);
+     * Architect and Planner stay on Claude.
+     */
+    llm: "claude" | "openai" | "codex"
     model?: string
     contextFile?: string
 }
@@ -33,7 +40,7 @@ interface Args {
 function parseArgs(argv: string[]): Args {
     let goal: string | undefined
     let cwd: string | undefined
-    let llm: "claude" | "openai" | undefined
+    let llm: "claude" | "openai" | "codex" | undefined
     let model: string | undefined
     let contextFile: string | undefined
 
@@ -48,10 +55,10 @@ function parseArgs(argv: string[]): Args {
                 break
             case "--llm": {
                 const v = required(argv, ++i, "--llm")
-                if (v !== "claude" && v !== "openai") {
-                    fatal(`--llm must be 'claude' or 'openai', got '${v}'`)
+                if (v !== "claude" && v !== "openai" && v !== "codex") {
+                    fatal(`--llm must be 'claude' | 'openai' | 'codex', got '${v}'`)
                 }
-                llm = v as "claude" | "openai"
+                llm = v as "claude" | "openai" | "codex"
                 break
             }
             case "--model":
@@ -95,12 +102,21 @@ async function main(): Promise<void> {
         }
     }
 
-    process.stderr.write(`[run-architect] llm=${args.llm} model=${args.model ?? "(default)"}\n`)
+    // Codex is accepted at the boundary but routes to the Claude
+    // architect path in v1 — codex-architect.ts is a follow-up. Log
+    // explicitly so it's clear from the audit log which backend
+    // actually ran the architect phase, even when `--llm codex` was
+    // requested at the CLI.
+    const architectBackend =
+        args.llm === "openai" ? "openai" : "claude"
+    process.stderr.write(
+        `[run-architect] requested=${args.llm} → architect-backend=${architectBackend} model=${args.model ?? "(default)"}\n`,
+    )
 
     let doc: string
     const t0 = Date.now()
     try {
-        if (args.llm === "openai") {
+        if (architectBackend === "openai") {
             if (!process.env.OPENAI_API_KEY) {
                 fatal("--llm openai requires OPENAI_API_KEY to be set")
             }

--- a/packages/baro-orchestrator/scripts/run-planner.ts
+++ b/packages/baro-orchestrator/scripts/run-planner.ts
@@ -26,7 +26,13 @@ import { runPlannerOpenAI } from "../src/planning/planner-openai.js"
 interface Args {
     goal: string
     cwd: string
-    llm: "claude" | "openai"
+    /**
+     * "codex" is accepted at the boundary but currently routes through
+     * the Claude planner path — codex-planner.ts is a v2 follow-up.
+     * v1 positioning: Codex covers the Story phase; Architect and
+     * Planner stay on Claude.
+     */
+    llm: "claude" | "openai" | "codex"
     model?: string
     contextFile?: string
     decisionFile?: string
@@ -36,7 +42,7 @@ interface Args {
 function parseArgs(argv: string[]): Args {
     let goal: string | undefined
     let cwd: string | undefined
-    let llm: "claude" | "openai" | undefined
+    let llm: "claude" | "openai" | "codex" | undefined
     let model: string | undefined
     let contextFile: string | undefined
     let decisionFile: string | undefined
@@ -53,10 +59,10 @@ function parseArgs(argv: string[]): Args {
                 break
             case "--llm": {
                 const v = required(argv, ++i, "--llm")
-                if (v !== "claude" && v !== "openai") {
-                    fatal(`--llm must be 'claude' or 'openai', got '${v}'`)
+                if (v !== "claude" && v !== "openai" && v !== "codex") {
+                    fatal(`--llm must be 'claude' | 'openai' | 'codex', got '${v}'`)
                 }
-                llm = v as "claude" | "openai"
+                llm = v as "claude" | "openai" | "codex"
                 break
             }
             case "--model":
@@ -117,14 +123,19 @@ async function main(): Promise<void> {
     const projectContext = tryRead(args.contextFile)
     const decisionDocument = tryRead(args.decisionFile)
 
+    // Codex is accepted at the boundary but routes to the Claude
+    // planner path in v1 — codex-planner.ts is a v2 follow-up. v1
+    // positioning: Codex covers the Story phase (the token-heavy
+    // one); Architect + Planner stay on Claude.
+    const plannerBackend = args.llm === "openai" ? "openai" : "claude"
     process.stderr.write(
-        `[run-planner] llm=${args.llm} model=${args.model ?? "(default)"} quick=${args.quick}\n`,
+        `[run-planner] requested=${args.llm} → planner-backend=${plannerBackend} model=${args.model ?? "(default)"} quick=${args.quick}\n`,
     )
 
     let prdJson: string
     const t0 = Date.now()
     try {
-        if (args.llm === "openai") {
+        if (plannerBackend === "openai") {
             if (!process.env.OPENAI_API_KEY) {
                 fatal("--llm openai requires OPENAI_API_KEY to be set")
             }

--- a/packages/baro-orchestrator/src/codex-stream-mapper.ts
+++ b/packages/baro-orchestrator/src/codex-stream-mapper.ts
@@ -3,24 +3,37 @@
  * for bus delivery. Sibling of `stream-json-mapper.ts` (the Claude
  * mapper).
  *
- * Codex stream shape (per OpenAI's docs at developers.openai.com/codex):
+ * Codex stream shape — observed against real `codex exec --json` output
+ * (M1 probe 2026-05-22, codex v0.133.0 on gpt-5.5). The docs use
+ * `item.<type>` envelope names in prose, but the actual wire format is:
  *
- *   {"type":"thread.started", "thread_id":"…", …}
- *   {"type":"turn.started",   "turn_id":"…", …}
- *   {"type":"item.agent_message",     "text":"…", …}
- *   {"type":"item.reasoning",         "text":"…", …}
- *   {"type":"item.command_execution", "command":"…", "exit_code":0, …}
- *   {"type":"item.file_change",       "path":"…", "diff":"…", …}
- *   {"type":"item.mcp_tool_call",     "tool_name":"…", "arguments":{…}, …}
- *   {"type":"item.web_search",        "query":"…", "results":[…], …}
- *   {"type":"item.plan_update",       "plan":[…], …}
- *   {"type":"turn.completed",         …}
- *   {"type":"turn.failed",            "error":"…", …}
- *   {"type":"thread.completed",       …}
- *   {"type":"error",                  "message":"…", …}
+ *   {"type":"thread.started", "thread_id":"…"}
+ *   {"type":"turn.started"}
+ *   {"type":"item.started",   "item":{"id":"…","type":"<itemtype>", …}}
+ *   {"type":"item.updated",   "item":{"id":"…", …}}        — for streaming
+ *   {"type":"item.completed", "item":{"id":"…","type":"agent_message",
+ *                                      "text":"…"}}
+ *   {"type":"turn.completed", "usage":{
+ *      "input_tokens":N,"cached_input_tokens":N,
+ *      "output_tokens":N,"reasoning_output_tokens":N}}
+ *   {"type":"thread.completed"}  — observed only on multi-turn sessions;
+ *                                  one-shot exec ends at turn.completed
+ *   {"type":"turn.failed",    "error":"…"}
+ *   {"type":"error",          "message":"…"}
  *
- * Mapping strategy (intentionally conservative for first pass — refined
- * as real Codex output is captured during M1–M3 probes):
+ * The real `item.type` lives at `event.item.type`, not at envelope-level.
+ * Inner item shape (per observed agent_message, plus inferred from docs
+ * for the other subtypes — refined as we capture each kind):
+ *
+ *   agent_message:     {id, type, text}
+ *   reasoning:         {id, type, text}                       (per docs)
+ *   command_execution: {id, type, command, exit_code?, output?, aggregated_output?}
+ *   file_change:       {id, type, path, diff?}
+ *   mcp_tool_call:     {id, type, tool_name, arguments?, result?}
+ *   web_search:        {id, type, query, results?}
+ *   plan_update:       {id, type, plan: […]}
+ *
+ * Mapping strategy:
  *
  *   - Assistant-side messages map to Mozaik's `ModelMessageItem`.
  *   - Tool-shaped items (command_execution, file_change, mcp_tool_call,
@@ -121,63 +134,81 @@ export function mapCodexEvent(
     }
 
     // ─── item.* family ─────────────────────────────────────────────
-    if (type.startsWith("item.")) {
-        const itemType = type.slice("item.".length)
+    // Envelopes: item.started | item.updated | item.completed.
+    // The inner item carries the real subtype + content.
+    //
+    // Mapping policy: emit Mozaik typed channels (ModelMessageItem,
+    // FunctionCallItem, FunctionCallOutputItem) ONLY on item.completed.
+    // item.started / item.updated are fired during streaming and either
+    // carry partial state or just the envelope shell; we'd double-count
+    // if we mapped them to typed channels too. They still go through
+    // CodexItemEvent so observers see the streaming lifecycle.
+    if (type === "item.started" || type === "item.updated") {
+        const inner =
+            event.item && typeof event.item === "object"
+                ? (event.item as Record<string, unknown>)
+                : {}
+        const innerType =
+            typeof inner.type === "string" ? inner.type : "unknown"
+        items.push(
+            CodexItemEvent.create({
+                agentId,
+                itemType: `${type.slice("item.".length)}:${innerType}`,
+                raw: event,
+            }),
+        )
+        return { items, threadId }
+    }
+
+    if (type === "item.completed") {
+        const inner =
+            event.item && typeof event.item === "object"
+                ? (event.item as Record<string, any>)
+                : {}
+        const innerType =
+            typeof inner.type === "string" ? inner.type : "unknown"
 
         // Assistant message → ModelMessageItem.
-        if (itemType === "agent_message" || itemType === "message") {
-            const text = typeof event.text === "string" ? event.text : ""
+        if (innerType === "agent_message" || innerType === "message") {
+            const text = typeof inner.text === "string" ? inner.text : ""
             if (text) {
                 items.push(ModelMessageItem.rehydrate({ text }))
             }
-            // Always emit the raw event too so observers see the full
-            // envelope (metadata, role, etc.) — Mozaik's typed message
-            // channel intentionally narrows the payload.
             items.push(
                 CodexItemEvent.create({
                     agentId,
-                    itemType,
+                    itemType: innerType,
                     raw: event,
                 }),
             )
             return { items, threadId }
         }
 
-        // Reasoning chunks. Could map to ModelMessageItem with a
-        // distinguishing flag, but Mozaik doesn't yet have a "reasoning"
-        // semantic channel. For first pass: emit as a typed item event
-        // and let observers decide. Future: introduce a ReasoningItem
-        // upstream.
-        if (itemType === "reasoning") {
+        // Reasoning. No Mozaik ReasoningItem yet — surface as typed event.
+        if (innerType === "reasoning") {
             items.push(
                 CodexItemEvent.create({
                     agentId,
-                    itemType,
+                    itemType: innerType,
                     raw: event,
                 }),
             )
             return { items, threadId }
         }
 
-        // Tool-shaped items. Codex represents shell exec, file edits,
-        // MCP calls, and web searches as item.* envelopes. We model each
-        // as a FunctionCallItem (invocation) optionally followed by a
-        // FunctionCallOutputItem (result). Whether one envelope carries
-        // both, or they arrive as two separate envelopes, is something
-        // M1–M3 probes will pin down — for now we treat each as a self-
-        // contained invocation+result and hand the raw event along.
+        // Tool-shaped items.
         if (
-            itemType === "command_execution" ||
-            itemType === "file_change" ||
-            itemType === "mcp_tool_call" ||
-            itemType === "web_search"
+            innerType === "command_execution" ||
+            innerType === "file_change" ||
+            innerType === "mcp_tool_call" ||
+            innerType === "web_search"
         ) {
-            const callId = stringifyId(event)
-            const name = inferToolName(itemType, event)
-            const args = inferToolArgs(event)
+            const callId = stringifyId(inner)
+            const name = inferToolName(innerType, inner)
+            const args = inferToolArgs(inner)
             items.push(FunctionCallItem.rehydrate({ callId, name, args }))
 
-            const output = inferToolOutput(itemType, event)
+            const output = inferToolOutput(innerType, inner)
             if (output !== null) {
                 items.push(FunctionCallOutputItem.create(callId, output))
             }
@@ -185,20 +216,18 @@ export function mapCodexEvent(
             items.push(
                 CodexItemEvent.create({
                     agentId,
-                    itemType,
+                    itemType: innerType,
                     raw: event,
                 }),
             )
             return { items, threadId }
         }
 
-        // plan_update and any other item.* subtype → generic
-        // CodexItemEvent so observers can react without us claiming we
-        // understand the structure yet.
+        // plan_update and anything else → typed CodexItemEvent.
         items.push(
             CodexItemEvent.create({
                 agentId,
-                itemType,
+                itemType: innerType,
                 raw: event,
             }),
         )

--- a/packages/baro-orchestrator/src/codex-stream-mapper.ts
+++ b/packages/baro-orchestrator/src/codex-stream-mapper.ts
@@ -1,0 +1,290 @@
+/**
+ * Map OpenAI Codex CLI `codex exec --json` stream events to typed items
+ * for bus delivery. Sibling of `stream-json-mapper.ts` (the Claude
+ * mapper).
+ *
+ * Codex stream shape (per OpenAI's docs at developers.openai.com/codex):
+ *
+ *   {"type":"thread.started", "thread_id":"…", …}
+ *   {"type":"turn.started",   "turn_id":"…", …}
+ *   {"type":"item.agent_message",     "text":"…", …}
+ *   {"type":"item.reasoning",         "text":"…", …}
+ *   {"type":"item.command_execution", "command":"…", "exit_code":0, …}
+ *   {"type":"item.file_change",       "path":"…", "diff":"…", …}
+ *   {"type":"item.mcp_tool_call",     "tool_name":"…", "arguments":{…}, …}
+ *   {"type":"item.web_search",        "query":"…", "results":[…], …}
+ *   {"type":"item.plan_update",       "plan":[…], …}
+ *   {"type":"turn.completed",         …}
+ *   {"type":"turn.failed",            "error":"…", …}
+ *   {"type":"thread.completed",       …}
+ *   {"type":"error",                  "message":"…", …}
+ *
+ * Mapping strategy (intentionally conservative for first pass — refined
+ * as real Codex output is captured during M1–M3 probes):
+ *
+ *   - Assistant-side messages map to Mozaik's `ModelMessageItem`.
+ *   - Tool-shaped items (command_execution, file_change, mcp_tool_call,
+ *     web_search) emit a `FunctionCallItem` for the invocation and, when
+ *     the same envelope carries a result (exit code, output text), a
+ *     paired `FunctionCallOutputItem`. Codex sometimes splits these into
+ *     two events; the participant doesn't need them paired — both
+ *     channels arrive on the bus and downstream observers (Critic,
+ *     Librarian, kaleidoskop) reassemble.
+ *   - thread.* and turn.* lifecycle events become typed `SemanticEvent`s
+ *     (CodexSystem / CodexTurnEvent) carrying the raw envelope. The
+ *     CodexCliParticipant uses these to drive AgentState transitions
+ *     (idle → starting → running → done/failed).
+ *   - Unknown / future event types fall through to CodexUnknownEvent so
+ *     nothing is silently dropped — downstream tooling sees every
+ *     envelope Codex produces.
+ *
+ * Every input event still maps to a non-empty array — we never silently
+ * drop data. Once we capture a real Codex JSONL probe (M1–M3), this
+ * mapper is updated to match exact field names from observed output.
+ */
+
+import {
+    FunctionCallItem,
+    FunctionCallOutputItem,
+    ModelMessageItem,
+    SemanticEvent,
+} from "@mozaik-ai/core"
+
+import {
+    CodexItemEvent,
+    CodexSystem,
+    CodexTurnEvent,
+    CodexUnknownEvent,
+} from "./semantic-events.js"
+
+export type MappedCodexItem =
+    | ModelMessageItem
+    | FunctionCallItem
+    | FunctionCallOutputItem
+    | SemanticEvent<unknown>
+
+export interface CodexMapResult {
+    items: MappedCodexItem[]
+    /** Codex `thread_id` observed on this event, if any. Used by the
+     *  participant for session-id correlation (same role as Claude's
+     *  `session_id`). */
+    threadId: string | null
+}
+
+export function mapCodexEvent(
+    agentId: string,
+    event: Record<string, any>,
+): CodexMapResult {
+    const threadId =
+        typeof event.thread_id === "string" ? event.thread_id : null
+    const items: MappedCodexItem[] = []
+    const type = typeof event.type === "string" ? event.type : ""
+
+    // ─── thread.* lifecycle ────────────────────────────────────────
+    if (type === "thread.started" || type === "thread.completed") {
+        items.push(
+            CodexSystem.create({
+                agentId,
+                subtype: type,
+                raw: event,
+            }),
+        )
+        return { items, threadId }
+    }
+
+    // ─── turn.* lifecycle ──────────────────────────────────────────
+    if (
+        type === "turn.started" ||
+        type === "turn.completed" ||
+        type === "turn.failed"
+    ) {
+        items.push(
+            CodexTurnEvent.create({
+                agentId,
+                phase: type.slice("turn.".length),
+                raw: event,
+            }),
+        )
+        return { items, threadId }
+    }
+
+    // ─── error envelope ────────────────────────────────────────────
+    if (type === "error") {
+        items.push(
+            CodexSystem.create({
+                agentId,
+                subtype: "error",
+                raw: event,
+            }),
+        )
+        return { items, threadId }
+    }
+
+    // ─── item.* family ─────────────────────────────────────────────
+    if (type.startsWith("item.")) {
+        const itemType = type.slice("item.".length)
+
+        // Assistant message → ModelMessageItem.
+        if (itemType === "agent_message" || itemType === "message") {
+            const text = typeof event.text === "string" ? event.text : ""
+            if (text) {
+                items.push(ModelMessageItem.rehydrate({ text }))
+            }
+            // Always emit the raw event too so observers see the full
+            // envelope (metadata, role, etc.) — Mozaik's typed message
+            // channel intentionally narrows the payload.
+            items.push(
+                CodexItemEvent.create({
+                    agentId,
+                    itemType,
+                    raw: event,
+                }),
+            )
+            return { items, threadId }
+        }
+
+        // Reasoning chunks. Could map to ModelMessageItem with a
+        // distinguishing flag, but Mozaik doesn't yet have a "reasoning"
+        // semantic channel. For first pass: emit as a typed item event
+        // and let observers decide. Future: introduce a ReasoningItem
+        // upstream.
+        if (itemType === "reasoning") {
+            items.push(
+                CodexItemEvent.create({
+                    agentId,
+                    itemType,
+                    raw: event,
+                }),
+            )
+            return { items, threadId }
+        }
+
+        // Tool-shaped items. Codex represents shell exec, file edits,
+        // MCP calls, and web searches as item.* envelopes. We model each
+        // as a FunctionCallItem (invocation) optionally followed by a
+        // FunctionCallOutputItem (result). Whether one envelope carries
+        // both, or they arrive as two separate envelopes, is something
+        // M1–M3 probes will pin down — for now we treat each as a self-
+        // contained invocation+result and hand the raw event along.
+        if (
+            itemType === "command_execution" ||
+            itemType === "file_change" ||
+            itemType === "mcp_tool_call" ||
+            itemType === "web_search"
+        ) {
+            const callId = stringifyId(event)
+            const name = inferToolName(itemType, event)
+            const args = inferToolArgs(event)
+            items.push(FunctionCallItem.rehydrate({ callId, name, args }))
+
+            const output = inferToolOutput(itemType, event)
+            if (output !== null) {
+                items.push(FunctionCallOutputItem.create(callId, output))
+            }
+
+            items.push(
+                CodexItemEvent.create({
+                    agentId,
+                    itemType,
+                    raw: event,
+                }),
+            )
+            return { items, threadId }
+        }
+
+        // plan_update and any other item.* subtype → generic
+        // CodexItemEvent so observers can react without us claiming we
+        // understand the structure yet.
+        items.push(
+            CodexItemEvent.create({
+                agentId,
+                itemType,
+                raw: event,
+            }),
+        )
+        return { items, threadId }
+    }
+
+    // ─── unknown / future event type ───────────────────────────────
+    items.push(
+        CodexUnknownEvent.create({
+            agentId,
+            codexType: type || "unspecified",
+            raw: event,
+        }),
+    )
+    return { items, threadId }
+}
+
+/** Best-effort stable id for tool-call envelopes. */
+function stringifyId(event: Record<string, any>): string {
+    if (typeof event.id === "string") return event.id
+    if (typeof event.call_id === "string") return event.call_id
+    if (typeof event.item_id === "string") return event.item_id
+    // Fall back to a synthetic id derived from type + a fragment of the
+    // command/path so multiple FunctionCallOutputItem reattach to the
+    // same FunctionCallItem when Codex doesn't supply one.
+    const hint =
+        typeof event.command === "string"
+            ? event.command.slice(0, 32)
+            : typeof event.path === "string"
+                ? event.path
+                : typeof event.tool_name === "string"
+                    ? event.tool_name
+                    : "anon"
+    return `codex:${event.type ?? "item"}:${hint}`
+}
+
+function inferToolName(itemType: string, event: Record<string, any>): string {
+    if (typeof event.tool_name === "string") return event.tool_name
+    switch (itemType) {
+        case "command_execution":
+            return "shell"
+        case "file_change":
+            return "edit"
+        case "web_search":
+            return "web_search"
+        default:
+            return itemType
+    }
+}
+
+function inferToolArgs(event: Record<string, any>): string {
+    if (event.arguments !== undefined) {
+        return typeof event.arguments === "string"
+            ? event.arguments
+            : JSON.stringify(event.arguments)
+    }
+    // Construct the args object from likely fields, falling back to the
+    // whole envelope minus the type tag.
+    const candidate: Record<string, unknown> = {}
+    for (const key of ["command", "path", "diff", "query"]) {
+        if (event[key] !== undefined) candidate[key] = event[key]
+    }
+    if (Object.keys(candidate).length > 0) return JSON.stringify(candidate)
+    const { type: _t, ...rest } = event
+    return JSON.stringify(rest)
+}
+
+function inferToolOutput(
+    itemType: string,
+    event: Record<string, any>,
+): string | null {
+    // Codex sometimes carries the result in the same envelope as the
+    // invocation; sometimes it comes later. We emit a paired
+    // FunctionCallOutputItem only when the result is present, otherwise
+    // return null and rely on the next envelope.
+    if (typeof event.output === "string") return event.output
+    if (typeof event.aggregated_output === "string") {
+        return event.aggregated_output
+    }
+    if (typeof event.result === "string") return event.result
+    if (itemType === "command_execution" && typeof event.exit_code === "number") {
+        // command_execution envelopes can lack the captured stdout
+        // (per openai/codex#10141) but still carry an exit code. Surface
+        // that as the output so the FunctionCallOutputItem is non-empty
+        // and downstream Critic/Surgeon see "this command ran".
+        return `exit_code=${event.exit_code}`
+    }
+    return null
+}

--- a/packages/baro-orchestrator/src/main.ts
+++ b/packages/baro-orchestrator/src/main.ts
@@ -39,6 +39,12 @@ export {
     type CodexRunSummary,
 } from "./participants/codex-cli-participant.js"
 
+export {
+    CodexStoryAgent,
+    type CodexStorySpec,
+    type CodexStoryOutcome,
+} from "./participants/codex-story-agent.js"
+
 export { Auditor, type AuditorOptions } from "./participants/auditor.js"
 
 export {

--- a/packages/baro-orchestrator/src/main.ts
+++ b/packages/baro-orchestrator/src/main.ts
@@ -22,10 +22,22 @@ export {
 export { mapClaudeEvent, type MapResult } from "./stream-json-mapper.js"
 
 export {
+    mapCodexEvent,
+    type CodexMapResult,
+    type MappedCodexItem,
+} from "./codex-stream-mapper.js"
+
+export {
     ClaudeCliParticipant,
     type ClaudeCliParticipantOptions,
     type ClaudeRunSummary,
 } from "./participants/claude-cli-participant.js"
+
+export {
+    CodexCliParticipant,
+    type CodexCliParticipantOptions,
+    type CodexRunSummary,
+} from "./participants/codex-cli-participant.js"
 
 export { Auditor, type AuditorOptions } from "./participants/auditor.js"
 

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -141,8 +141,13 @@ export interface OrchestrateConfig {
      * OpenAI runner — each subsequent phase replaces one fallback with
      * a real OpenAI sibling. Until then, `"openai"` is a no-op
      * placeholder that runs the Claude flow.
+     *
+     * `"codex"` is the subscription-arbitrage path via OpenAI Codex CLI
+     * (ChatGPT Plus/Pro billing). v1: covers the Story phase; Architect
+     * + Planner + Critic + Surgeon fall back to Claude (codex-* siblings
+     * for those phases are a v2 follow-up).
      */
-    llm?: "claude" | "openai"
+    llm?: "claude" | "openai" | "codex"
     /**
      * Per-phase model override for StoryAgent. When set, wins over
      * each story's individual `model` field in the PRD as well as
@@ -179,7 +184,7 @@ export async function orchestrate(
 ): Promise<OrchestrateResult> {
     const env = new AgenticEnvironment()
     const emitTui = config.emitTuiEvents ?? true
-    const llm: "claude" | "openai" = config.llm ?? "claude"
+    const llm: "claude" | "openai" | "codex" = config.llm ?? "claude"
 
     // Provider banner so the stderr / audit log makes the actual
     // routing obvious. As of 0.33 every LLM-using phase (Architect,
@@ -189,6 +194,12 @@ export async function orchestrate(
         process.stderr.write(
             "[orchestrate] llm=openai: Architect, Planner, Critic, Surgeon, StoryAgent " +
             "all running through Mozaik's native OpenAI runner (gpt-5.x).\n",
+        )
+    } else if (llm === "codex") {
+        process.stderr.write(
+            "[orchestrate] llm=codex: Story phase shells out to `codex exec --json` " +
+            "(ChatGPT subscription path). Architect / Planner / Critic / Surgeon " +
+            "fall back to Claude in v1 — codex-* siblings for those phases are a v2 follow-up.\n",
         )
     } else {
         process.stderr.write(

--- a/packages/baro-orchestrator/src/participants/codex-cli-participant.ts
+++ b/packages/baro-orchestrator/src/participants/codex-cli-participant.ts
@@ -1,0 +1,339 @@
+/**
+ * CodexCliParticipant — wraps an OpenAI Codex CLI process as a
+ * first-class Mozaik Participant. Sibling of `ClaudeCliParticipant`.
+ *
+ * Spawned with `codex exec --json <prompt>`. Codex exec is one-shot
+ * non-interactive: takes a single prompt as argv, streams JSONL events
+ * to stdout, exits when the agent finishes. There is no stdin event
+ * loop (unlike Claude Code's stream-json input). That makes this
+ * participant simpler than ClaudeCliParticipant in one respect —
+ * `onExternalEvent` doesn't forward AgentTargetedMessage to a running
+ * process; new prompts mean a new Codex invocation.
+ *
+ * Library-grade: knows nothing about baro, PRD, or stories. Only knows
+ * about agent IDs, working directories, and Codex.
+ */
+
+import { ChildProcess, spawn } from "child_process"
+
+import {
+    BaseObserver,
+    FunctionCallItem,
+    FunctionCallOutputItem,
+    ModelMessageItem,
+    Participant,
+    SemanticEvent,
+} from "@mozaik-ai/core"
+
+import { AgenticEnvironment } from "@mozaik-ai/core"
+import {
+    AgentState,
+    AgentTargetedMessage,
+    CodexSystem,
+    CodexTurnEvent,
+    type AgentPhase,
+} from "../semantic-events.js"
+import { mapCodexEvent } from "../codex-stream-mapper.js"
+
+export interface CodexCliParticipantOptions {
+    /** Working directory for the Codex process. Required. */
+    cwd: string
+    /** Initial prompt — passed as the final argv to `codex exec`. */
+    prompt: string
+    /**
+     * Model identifier. Codex defaults to gpt-5.5 on accounts that have
+     * Plus+ access; on Free it routes to whatever Codex Mini variant the
+     * promo is currently exposing. Pass undefined to let Codex pick.
+     */
+    model?: string
+    /**
+     * Permission flag for Codex. Codex's flags differ from Claude's —
+     * `--full-auto` is the closest analogue to Claude's
+     * `bypassPermissions`. Default: undefined (let Codex use its own
+     * default, which prompts on first invocation).
+     */
+    fullAuto?: boolean
+    /** Extra CLI arguments appended after the standard set. */
+    extraArgs?: string[]
+    /** Path to the `codex` binary. Default: "codex" (resolved via PATH). */
+    codexBin?: string
+}
+
+export interface CodexRunSummary {
+    threadId: string | null
+    exitCode: number | null
+    error: Error | null
+}
+
+export class CodexCliParticipant extends BaseObserver {
+    /**
+     * Process-wide registry of every Codex child currently running. Used
+     * by the orchestrator's SIGINT/SIGTERM handlers to nuke orphans so a
+     * killed baro doesn't leave a swarm of background agents burning
+     * quota.
+     */
+    private static readonly active = new Set<CodexCliParticipant>()
+
+    /** Send a signal to every active Codex child. Idempotent. */
+    static killAll(signal: NodeJS.Signals = "SIGTERM"): void {
+        for (const p of CodexCliParticipant.active) {
+            try {
+                p.proc?.kill(signal)
+            } catch {
+                // best-effort
+            }
+        }
+    }
+
+    private readonly options: Required<
+        Pick<CodexCliParticipantOptions, "codexBin" | "fullAuto">
+    > &
+        CodexCliParticipantOptions
+
+    private proc: ChildProcess | null = null
+    private buffer = ""
+    private envRef: AgenticEnvironment | null = null
+    private currentPhase: AgentPhase = "idle"
+    private threadId: string | null = null
+    private exitCode: number | null = null
+    private spawnError: Error | null = null
+    private resolveDone!: (summary: CodexRunSummary) => void
+    private resolveReady!: () => void
+    private rejectReady!: (e: Error) => void
+
+    /** Resolves once Codex emits its first `thread.started` event. */
+    public readonly ready: Promise<void>
+    /** Resolves once the Codex process exits (regardless of success). */
+    public readonly done: Promise<CodexRunSummary>
+
+    constructor(
+        public readonly agentId: string,
+        opts: CodexCliParticipantOptions,
+    ) {
+        super()
+        this.options = {
+            codexBin: "codex",
+            fullAuto: false,
+            ...opts,
+        }
+        this.ready = new Promise<void>((res, rej) => {
+            this.resolveReady = res
+            this.rejectReady = rej
+        })
+        this.done = new Promise<CodexRunSummary>((res) => {
+            this.resolveDone = res
+        })
+    }
+
+    getThreadId(): string | null {
+        return this.threadId
+    }
+
+    getPhase(): AgentPhase {
+        return this.currentPhase
+    }
+
+    /**
+     * Spawn the Codex process and start streaming its events into the
+     * environment. Idempotent: subsequent calls are a no-op.
+     */
+    start(environment: AgenticEnvironment): void {
+        if (this.proc) return
+        this.envRef = environment
+
+        const args = this.buildArgs()
+        let proc: ChildProcess
+        try {
+            proc = spawn(this.options.codexBin, args, {
+                cwd: this.options.cwd,
+                stdio: ["ignore", "pipe", "pipe"],
+            })
+        } catch (e) {
+            this.spawnError = e instanceof Error ? e : new Error(String(e))
+            this.transition("failed", this.spawnError.message)
+            this.rejectReady(this.spawnError)
+            this.resolveDone({
+                threadId: null,
+                exitCode: null,
+                error: this.spawnError,
+            })
+            return
+        }
+
+        this.proc = proc
+        CodexCliParticipant.active.add(this)
+        this.transition("starting")
+
+        proc.stdout!.setEncoding("utf8")
+        proc.stderr!.setEncoding("utf8")
+        proc.stdout!.on("data", (chunk: string) => this.handleStdout(chunk))
+        proc.stderr!.on("data", (chunk: string) => this.handleStderr(chunk))
+        proc.on("error", (err) => {
+            this.spawnError = err
+            this.rejectReady(err)
+        })
+        proc.on("exit", (code) => {
+            CodexCliParticipant.active.delete(this)
+            this.exitCode = code
+            const finalPhase: AgentPhase =
+                this.spawnError != null || (code != null && code !== 0)
+                    ? "failed"
+                    : "done"
+            this.transition(
+                finalPhase,
+                code != null ? `exit code ${code}` : "no exit code",
+            )
+            this.resolveDone({
+                threadId: this.threadId,
+                exitCode: code,
+                error: this.spawnError,
+            })
+        })
+    }
+
+    /** Kill the Codex process. Resolves once exit fires. */
+    abort(signal: NodeJS.Signals = "SIGTERM"): void {
+        this.transition("aborted")
+        this.proc?.kill(signal)
+    }
+
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        // No-op for now. Codex exec is one-shot: it doesn't have a stdin
+        // user-message channel like Claude Code. AgentTargetedMessage
+        // delivery to a running Codex would require either a new
+        // invocation or future Codex SDK support for session resumption.
+        // Surface this as a noisy warning during M3/M4 so we catch any
+        // assumption from the orchestrator that messages route the way
+        // they do for Claude.
+        if (
+            AgentTargetedMessage.is(event) &&
+            event.data.recipientId === this.agentId
+        ) {
+            process.stderr.write(
+                `[codex:${this.agentId}] received AgentTargetedMessage but Codex exec is one-shot — dropped\n`,
+            )
+        }
+    }
+
+    private buildArgs(): string[] {
+        // `codex exec --json` — non-interactive JSONL stream.
+        const args = ["exec", "--json"]
+        if (this.options.fullAuto) args.push("--full-auto")
+        if (this.options.model) args.push("--model", this.options.model)
+        if (this.options.extraArgs?.length) args.push(...this.options.extraArgs)
+        // Prompt is the final positional. Codex expects it as a single
+        // shell arg; spawn() passes argv directly so no quoting needed.
+        args.push(this.options.prompt)
+        return args
+    }
+
+    private handleStdout(chunk: string): void {
+        this.buffer += chunk
+        let nl: number
+        while ((nl = this.buffer.indexOf("\n")) >= 0) {
+            const line = this.buffer.slice(0, nl).trim()
+            this.buffer = this.buffer.slice(nl + 1)
+            if (!line) continue
+            this.processLine(line)
+        }
+    }
+
+    private handleStderr(chunk: string): void {
+        const trimmed = chunk.trimEnd()
+        if (!trimmed) return
+        process.stderr.write(`[codex:${this.agentId}/stderr] ${trimmed}\n`)
+    }
+
+    private processLine(line: string): void {
+        let parsed: Record<string, any>
+        try {
+            parsed = JSON.parse(line)
+        } catch {
+            process.stderr.write(
+                `[codex:${this.agentId}] non-JSON stdout: ${line.slice(0, 200)}\n`,
+            )
+            return
+        }
+
+        const { items, threadId } = mapCodexEvent(this.agentId, parsed)
+        if (threadId && !this.threadId) {
+            this.threadId = threadId
+        }
+
+        for (const item of items) {
+            if (item instanceof SemanticEvent) {
+                // Lifecycle signals: ready when we see thread.started,
+                // done/failed when we see a terminal turn or thread
+                // event. The participant doesn't try to be clever about
+                // success/failure beyond this — Critic + Surgeon
+                // observers downstream do the verdict work.
+                if (
+                    CodexSystem.is(item) &&
+                    item.data.subtype === "thread.started"
+                ) {
+                    this.transition("running", "codex thread started")
+                    this.resolveReady()
+                }
+                if (CodexTurnEvent.is(item)) {
+                    const phase = item.data.phase
+                    if (phase === "failed") {
+                        this.transition("failed", "codex turn failed")
+                    }
+                }
+                if (
+                    CodexSystem.is(item) &&
+                    item.data.subtype === "thread.completed"
+                ) {
+                    // Don't transition to "done" yet — wait for the
+                    // process exit to confirm clean shutdown.
+                }
+            }
+            this.dispatch(item)
+        }
+    }
+
+    /**
+     * Route a mapped event to the right Mozaik delivery channel.
+     * Mirror of ClaudeCliParticipant.dispatch — assistant-side LLM items
+     * use Mozaik's typed channels; everything else goes through
+     * deliverSemanticEvent.
+     */
+    private dispatch(
+        item:
+            | ModelMessageItem
+            | FunctionCallItem
+            | FunctionCallOutputItem
+            | SemanticEvent<unknown>,
+    ): void {
+        if (!this.envRef) return
+        if (item instanceof ModelMessageItem) {
+            this.envRef.deliverModelMessage(this, item)
+            return
+        }
+        if (item instanceof FunctionCallItem) {
+            this.envRef.deliverFunctionCall(this, item)
+            return
+        }
+        if (item instanceof FunctionCallOutputItem) {
+            this.envRef.deliverFunctionCallOutput(this, item)
+            return
+        }
+        this.envRef.deliverSemanticEvent(this, item)
+    }
+
+    private transition(next: AgentPhase, detail?: string): void {
+        if (next === this.currentPhase) return
+        this.currentPhase = next
+        this.envRef?.deliverSemanticEvent(
+            this,
+            AgentState.create({
+                agentId: this.agentId,
+                phase: next,
+                detail,
+            }),
+        )
+    }
+}

--- a/packages/baro-orchestrator/src/participants/codex-cli-participant.ts
+++ b/packages/baro-orchestrator/src/participants/codex-cli-participant.ts
@@ -53,6 +53,14 @@ export interface CodexCliParticipantOptions {
      * default, which prompts on first invocation).
      */
     fullAuto?: boolean
+    /**
+     * If true, pass `--skip-git-repo-check`. Required when the cwd is
+     * not a git repo (Codex refuses to run otherwise). baro's
+     * story workers always run inside per-story git worktrees, so the
+     * default is false — set this only when wiring up tests or one-off
+     * runs from /tmp.
+     */
+    skipGitRepoCheck?: boolean
     /** Extra CLI arguments appended after the standard set. */
     extraArgs?: string[]
     /** Path to the `codex` binary. Default: "codex" (resolved via PATH). */
@@ -86,7 +94,10 @@ export class CodexCliParticipant extends BaseObserver {
     }
 
     private readonly options: Required<
-        Pick<CodexCliParticipantOptions, "codexBin" | "fullAuto">
+        Pick<
+            CodexCliParticipantOptions,
+            "codexBin" | "fullAuto" | "skipGitRepoCheck"
+        >
     > &
         CodexCliParticipantOptions
 
@@ -114,6 +125,7 @@ export class CodexCliParticipant extends BaseObserver {
         this.options = {
             codexBin: "codex",
             fullAuto: false,
+            skipGitRepoCheck: false,
             ...opts,
         }
         this.ready = new Promise<void>((res, rej) => {
@@ -221,6 +233,7 @@ export class CodexCliParticipant extends BaseObserver {
     private buildArgs(): string[] {
         // `codex exec --json` — non-interactive JSONL stream.
         const args = ["exec", "--json"]
+        if (this.options.skipGitRepoCheck) args.push("--skip-git-repo-check")
         if (this.options.fullAuto) args.push("--full-auto")
         if (this.options.model) args.push("--model", this.options.model)
         if (this.options.extraArgs?.length) args.push(...this.options.extraArgs)

--- a/packages/baro-orchestrator/src/participants/codex-cli-participant.ts
+++ b/packages/baro-orchestrator/src/participants/codex-cli-participant.ts
@@ -278,11 +278,15 @@ export class CodexCliParticipant extends BaseObserver {
 
         for (const item of items) {
             if (item instanceof SemanticEvent) {
-                // Lifecycle signals: ready when we see thread.started,
-                // done/failed when we see a terminal turn or thread
-                // event. The participant doesn't try to be clever about
-                // success/failure beyond this — Critic + Surgeon
-                // observers downstream do the verdict work.
+                // Lifecycle signals. Real Codex stream shape (observed
+                // 2026-05-22, codex v0.133.0):
+                //   thread.started   → ready
+                //   turn.started     → no-op (we're already running)
+                //   turn.completed   → success terminal for one-shot
+                //                      exec (thread.completed is only
+                //                      emitted on multi-turn sessions)
+                //   turn.failed      → failure terminal
+                //   thread.completed → process is shutting down cleanly
                 if (
                     CodexSystem.is(item) &&
                     item.data.subtype === "thread.started"
@@ -296,13 +300,9 @@ export class CodexCliParticipant extends BaseObserver {
                         this.transition("failed", "codex turn failed")
                     }
                 }
-                if (
-                    CodexSystem.is(item) &&
-                    item.data.subtype === "thread.completed"
-                ) {
-                    // Don't transition to "done" yet — wait for the
-                    // process exit to confirm clean shutdown.
-                }
+                // Don't transition to "done" on thread.completed either —
+                // the process-exit listener owns that, so we observe the
+                // real exit code before locking in the AgentPhase.
             }
             this.dispatch(item)
         }

--- a/packages/baro-orchestrator/src/participants/codex-story-agent.ts
+++ b/packages/baro-orchestrator/src/participants/codex-story-agent.ts
@@ -1,0 +1,347 @@
+/**
+ * CodexStoryAgent — story-level wrapper that drives a
+ * CodexCliParticipant through a single piece of work, with retries
+ * and per-attempt timeout. Sibling of `story-agent.ts` (Claude) and
+ * `openai-story-agent.ts` (OpenAI API).
+ *
+ * Lifecycle is simpler than the Claude variant because Codex exec is
+ * one-shot: each attempt spawns a fresh `codex exec --json` process,
+ * which streams events and exits when the agent finishes. There is no
+ * multi-turn quiet-timer / stdin-injection dance.
+ *
+ *   idle ─► starting ─► running ─► done | failed
+ *                              ╰► retrying ─► running ─► …
+ *
+ * Outer retry budget and hard timeout match StoryAgent's defaults so
+ * the orchestrator-level semantics are uniform across backends.
+ */
+
+import { setTimeout as setTimeoutPromise } from "timers/promises"
+
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import { AgenticEnvironment } from "@mozaik-ai/core"
+import {
+    AgentState,
+    StoryResult,
+    type AgentPhase,
+} from "../semantic-events.js"
+import {
+    CodexCliParticipant,
+    CodexRunSummary,
+} from "./codex-cli-participant.js"
+
+export interface CodexStorySpec {
+    /** Story ID, used as agentId for observer attribution. */
+    id: string
+    /** The prompt sent to Codex as the initial user message. */
+    prompt: string
+    /** Working directory for Codex. Must be a git repo (Codex enforces). */
+    cwd: string
+    /** Optional model override (e.g. "gpt-5.5"). */
+    model?: string
+    /** Retry budget (number of *additional* attempts after the first). */
+    retries?: number
+    /** Per-attempt timeout in seconds. Default: 600. */
+    timeoutSecs?: number
+    /** Delay between retries in milliseconds. Default: 1500. */
+    retryDelayMs?: number
+    /**
+     * Hard cap in seconds for the entire story across all attempts. The
+     * Codex process is aborted unconditionally when this fires. <= 0
+     * disables the absolute kill timer. Default: 0 (matches StoryAgent).
+     */
+    hardTimeoutSecs?: number
+    /**
+     * Pass `--full-auto` to Codex so it does not prompt for permission
+     * on every shell command / edit. Required for autonomous baro runs.
+     * Default: true.
+     */
+    fullAuto?: boolean
+    /**
+     * Pass `--skip-git-repo-check`. baro story workers always run inside
+     * per-story git worktrees, so the default is false; set this only
+     * when wiring up tests or one-off runs.
+     */
+    skipGitRepoCheck?: boolean
+}
+
+export interface CodexStoryOutcome {
+    storyId: string
+    success: boolean
+    attempts: number
+    durationSecs: number
+    finalSummary: CodexRunSummary | null
+    error: string | null
+}
+
+export class CodexStoryAgent extends BaseObserver {
+    private readonly spec: Required<
+        Pick<
+            CodexStorySpec,
+            | "retries"
+            | "timeoutSecs"
+            | "retryDelayMs"
+            | "hardTimeoutSecs"
+            | "fullAuto"
+            | "skipGitRepoCheck"
+        >
+    > &
+        CodexStorySpec
+
+    private envRef: AgenticEnvironment | null = null
+    private currentCodex: CodexCliParticipant | null = null
+    private currentPhase: AgentPhase = "idle"
+    private startedAt: number | null = null
+    private resolveDone!: (outcome: CodexStoryOutcome) => void
+    public readonly done: Promise<CodexStoryOutcome>
+
+    constructor(spec: CodexStorySpec) {
+        super()
+        this.spec = {
+            retries: 2,
+            timeoutSecs: 600,
+            retryDelayMs: 1500,
+            hardTimeoutSecs: 0,
+            fullAuto: true,
+            skipGitRepoCheck: false,
+            ...spec,
+        }
+        this.done = new Promise<CodexStoryOutcome>((res) => {
+            this.resolveDone = res
+        })
+    }
+
+    get id(): string {
+        return this.spec.id
+    }
+
+    get agentId(): string {
+        return this.spec.id
+    }
+
+    getPhase(): AgentPhase {
+        return this.currentPhase
+    }
+
+    getCurrentCodex(): CodexCliParticipant | null {
+        return this.currentCodex
+    }
+
+    /**
+     * Begin executing the story. Idempotent. Returns the `done` promise
+     * for the caller's convenience.
+     */
+    run(environment: AgenticEnvironment): Promise<CodexStoryOutcome> {
+        if (this.startedAt != null) {
+            return this.done
+        }
+        this.envRef = environment
+        this.startedAt = Date.now()
+        this.transition("starting", "story queued")
+        void this.executeAllAttempts()
+        return this.done
+    }
+
+    /**
+     * No-op: Codex exec is one-shot, there's no stdin channel to forward
+     * mid-flight messages to. Logged at the participant level if we ever
+     * see an AgentTargetedMessage addressed here.
+     */
+    override async onExternalEvent(
+        _source: Participant,
+        _event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        // Intentionally empty — Codex exec doesn't have the multi-turn
+        // stdin lifecycle that StoryAgent uses for Claude.
+    }
+
+    /** Abort the story, killing the running Codex (if any). */
+    abort(): void {
+        this.currentCodex?.abort()
+        this.transition("aborted", "external abort")
+    }
+
+    private async executeAllAttempts(): Promise<void> {
+        const maxAttempts = this.spec.retries + 1
+        let lastSummary: CodexRunSummary | null = null
+        let lastError: string | null = null
+        let hardTimedOut = false
+
+        const hardTimer =
+            this.spec.hardTimeoutSecs > 0
+                ? setTimeout(() => {
+                      hardTimedOut = true
+                      this.currentCodex?.abort()
+                  }, this.spec.hardTimeoutSecs * 1000)
+                : null
+
+        try {
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+                if (hardTimedOut) {
+                    lastError = `hard timeout after ${this.spec.hardTimeoutSecs}s`
+                    break
+                }
+
+                if (attempt > 1) {
+                    this.transition(
+                        "waiting",
+                        `retrying (attempt ${attempt}/${maxAttempts})`,
+                    )
+                    await setTimeoutPromise(this.spec.retryDelayMs)
+                    if (hardTimedOut) {
+                        lastError = `hard timeout after ${this.spec.hardTimeoutSecs}s`
+                        break
+                    }
+                }
+
+                const result = await this.runOneAttempt(attempt)
+                lastSummary = result.summary
+                lastError = result.error
+
+                if (result.success) {
+                    const durationSecs = Math.round(
+                        (Date.now() - (this.startedAt ?? Date.now())) / 1000,
+                    )
+                    this.transition("done", `success on attempt ${attempt}`)
+                    this.emitStoryResult(true, attempt, durationSecs, null)
+                    this.resolveDone({
+                        storyId: this.spec.id,
+                        success: true,
+                        attempts: attempt,
+                        durationSecs,
+                        finalSummary: result.summary,
+                        error: null,
+                    })
+                    return
+                }
+
+                if (hardTimedOut) {
+                    lastError = `hard timeout after ${this.spec.hardTimeoutSecs}s`
+                    break
+                }
+            }
+        } finally {
+            if (hardTimer !== null) clearTimeout(hardTimer)
+        }
+
+        const durationSecs = Math.round(
+            (Date.now() - (this.startedAt ?? Date.now())) / 1000,
+        )
+        this.transition("failed", `exhausted ${maxAttempts} attempts`)
+        this.emitStoryResult(false, maxAttempts, durationSecs, lastError)
+        this.resolveDone({
+            storyId: this.spec.id,
+            success: false,
+            attempts: maxAttempts,
+            durationSecs,
+            finalSummary: lastSummary,
+            error: lastError,
+        })
+    }
+
+    private async runOneAttempt(
+        attempt: number,
+    ): Promise<{
+        success: boolean
+        summary: CodexRunSummary | null
+        error: string | null
+    }> {
+        if (!this.envRef) {
+            return { success: false, summary: null, error: "no environment" }
+        }
+
+        this.transition("running", `attempt ${attempt}`)
+
+        const codex = new CodexCliParticipant(this.spec.id, {
+            cwd: this.spec.cwd,
+            prompt: this.spec.prompt,
+            model: this.spec.model,
+            fullAuto: this.spec.fullAuto,
+            skipGitRepoCheck: this.spec.skipGitRepoCheck,
+        })
+        this.currentCodex = codex
+        codex.join(this.envRef)
+        codex.start(this.envRef)
+
+        let summary: CodexRunSummary
+        try {
+            summary = await raceWithTimeout(
+                codex.done,
+                this.spec.timeoutSecs * 1000,
+                `attempt ${attempt} timeout after ${this.spec.timeoutSecs}s`,
+            )
+        } catch (e) {
+            codex.abort()
+            const error = e instanceof Error ? e.message : String(e)
+            try {
+                await codex.done
+            } catch {
+                // ignore
+            }
+            codex.leave(this.envRef)
+            this.currentCodex = null
+            return { success: false, summary: null, error }
+        }
+
+        codex.leave(this.envRef)
+        this.currentCodex = null
+
+        const success =
+            summary.exitCode === 0 && summary.error == null
+
+        if (!success) {
+            const reason = summary.error
+                ? summary.error.message
+                : `non-zero exit ${summary.exitCode}`
+            return { success: false, summary, error: reason }
+        }
+
+        return { success: true, summary, error: null }
+    }
+
+    private emitStoryResult(
+        success: boolean,
+        attempts: number,
+        durationSecs: number,
+        error: string | null,
+    ): void {
+        if (!this.envRef) return
+        this.envRef.deliverSemanticEvent(
+            this,
+            StoryResult.create({
+                storyId: this.spec.id,
+                success,
+                attempts,
+                durationSecs,
+                error,
+            }),
+        )
+    }
+
+    private transition(next: AgentPhase, detail?: string): void {
+        if (next === this.currentPhase) return
+        this.currentPhase = next
+        if (this.envRef) {
+            this.envRef.deliverSemanticEvent(
+                this,
+                AgentState.create({
+                    agentId: this.spec.id,
+                    phase: next,
+                    detail,
+                }),
+            )
+        }
+    }
+}
+
+function raceWithTimeout<T>(
+    p: Promise<T>,
+    ms: number,
+    label: string,
+): Promise<T> {
+    return Promise.race([
+        p,
+        new Promise<T>((_, rej) => setTimeout(() => rej(new Error(label)), ms)),
+    ])
+}

--- a/packages/baro-orchestrator/src/participants/story-factory.ts
+++ b/packages/baro-orchestrator/src/participants/story-factory.ts
@@ -23,20 +23,23 @@ import {
     StorySpawned,
     type StorySpawnRequestData,
 } from "../semantic-events.js"
+import { CodexStoryAgent } from "./codex-story-agent.js"
 import { OpenAIStoryAgent } from "./openai-story-agent.js"
 import { StoryAgent } from "./story-agent.js"
 
 export interface StoryFactoryOptions {
     cwd: string
     /**
-     * Which LLM provider every story uses. When `"openai"`, spawned
-     * agents are `OpenAIStoryAgent`-s driving Mozaik's native OpenAI
-     * runner with our codebase tool layer. When `"claude"` (default),
-     * agents are the legacy `StoryAgent` wrapping a `claude` CLI
-     * subprocess. Same bus contract either way — Conductor, Critic,
-     * Surgeon, Sentry, Librarian, Cartographer don't notice the swap.
+     * Which LLM provider every story uses.
+     *   "claude"  — StoryAgent wrapping a `claude` CLI subprocess
+     *   "openai"  — OpenAIStoryAgent driving Mozaik's native OpenAI
+     *               runner with our codebase tool layer
+     *   "codex"   — CodexStoryAgent wrapping a `codex exec --json`
+     *               subprocess (ChatGPT subscription billing path)
+     * Same bus contract for all three — Conductor, Critic, Surgeon,
+     * Sentry, Librarian, Cartographer don't notice the swap.
      */
-    llm?: "claude" | "openai"
+    llm?: "claude" | "openai" | "codex"
     /**
      * Optional model name to pass to OpenAI agents. Default
      * `gpt-5.5` — StoryAgent's coding loop benefits from the largest
@@ -59,7 +62,10 @@ export class StoryFactory extends BaseObserver {
     // expect the old environment type. Once StoryAgent migrates, this
     // narrows to vanilla AgenticEnvironment.
     private envRef: AgenticEnvironment | null = null
-    private readonly active: Map<string, StoryAgent | OpenAIStoryAgent> = new Map()
+    private readonly active: Map<
+        string,
+        StoryAgent | OpenAIStoryAgent | CodexStoryAgent
+    > = new Map()
 
     constructor(private readonly opts: StoryFactoryOptions) {
         super()
@@ -104,28 +110,41 @@ export class StoryFactory extends BaseObserver {
         const claudeModel = this.opts.storyModelOverride ?? req.model
         const openaiModel =
             this.opts.storyModelOverride ?? this.opts.openaiModel ?? "gpt-5.5"
+        // Codex uses its own model nomenclature (gpt-5.5 by default on
+        // accounts with Plus+ access). Honour storyModelOverride first;
+        // otherwise let Codex pick.
+        const codexModel = this.opts.storyModelOverride
 
-        const agent: StoryAgent | OpenAIStoryAgent =
-            llm === "openai"
-                ? new OpenAIStoryAgent(
-                      {
-                          id: req.storyId,
-                          prompt: req.prompt,
-                          cwd: this.opts.cwd,
-                          model: req.model,
-                          retries: req.retries,
-                          timeoutSecs: req.timeoutSecs,
-                      },
-                      { model: openaiModel },
-                  )
-                : new StoryAgent({
+        const agent: StoryAgent | OpenAIStoryAgent | CodexStoryAgent =
+            llm === "codex"
+                ? new CodexStoryAgent({
                       id: req.storyId,
                       prompt: req.prompt,
                       cwd: this.opts.cwd,
-                      model: claudeModel,
+                      model: codexModel,
                       retries: req.retries,
                       timeoutSecs: req.timeoutSecs,
                   })
+                : llm === "openai"
+                    ? new OpenAIStoryAgent(
+                          {
+                              id: req.storyId,
+                              prompt: req.prompt,
+                              cwd: this.opts.cwd,
+                              model: req.model,
+                              retries: req.retries,
+                              timeoutSecs: req.timeoutSecs,
+                          },
+                          { model: openaiModel },
+                      )
+                    : new StoryAgent({
+                          id: req.storyId,
+                          prompt: req.prompt,
+                          cwd: this.opts.cwd,
+                          model: claudeModel,
+                          retries: req.retries,
+                          timeoutSecs: req.timeoutSecs,
+                      })
 
         agent.join(this.envRef)
         this.active.set(req.storyId, agent)

--- a/packages/baro-orchestrator/src/semantic-events.ts
+++ b/packages/baro-orchestrator/src/semantic-events.ts
@@ -176,6 +176,55 @@ export interface ClaudeRateLimitData {
 export const ClaudeRateLimit =
     defineSemanticEvent<ClaudeRateLimitData>("claude_rate_limit")
 
+// ─── Codex CLI passthrough types ──────────────────────────────────────
+// Codex emits a stream of JSONL events under three families:
+//   - thread.*  → lifecycle of the whole codex exec session
+//   - turn.*    → lifecycle of a single agent turn inside the session
+//   - item.*    → individual artefacts produced by a turn (messages,
+//                 reasoning, command executions, file changes, MCP tool
+//                 calls, plan updates …)
+//
+// All three families fall back to opaque `raw` payloads in our event
+// objects — the mapper extracts known fields (text, tool name, exit
+// code) into dedicated Mozaik typed items where it can, and otherwise
+// passes the whole event through so downstream observers (audit log,
+// kaleidoskop replay, debug consoles) still see everything.
+
+export interface CodexSystemData {
+    agentId: string
+    /** "thread.started" | "thread.completed" | "error" */
+    subtype: string
+    raw: Readonly<Record<string, unknown>>
+}
+export const CodexSystem = defineSemanticEvent<CodexSystemData>("codex_system")
+
+export interface CodexTurnEventData {
+    agentId: string
+    /** "started" | "completed" | "failed" */
+    phase: string
+    raw: Readonly<Record<string, unknown>>
+}
+export const CodexTurnEvent =
+    defineSemanticEvent<CodexTurnEventData>("codex_turn_event")
+
+export interface CodexItemEventData {
+    agentId: string
+    /** e.g. "agent_message", "reasoning", "command_execution",
+     *  "file_change", "mcp_tool_call", "web_search", "plan_update". */
+    itemType: string
+    raw: Readonly<Record<string, unknown>>
+}
+export const CodexItemEvent =
+    defineSemanticEvent<CodexItemEventData>("codex_item_event")
+
+export interface CodexUnknownEventData {
+    agentId: string
+    codexType: string
+    raw: Readonly<Record<string, unknown>>
+}
+export const CodexUnknownEvent =
+    defineSemanticEvent<CodexUnknownEventData>("codex_unknown_event")
+
 /**
  * Verdict from the Critic participant. Wire JSON uses snake_case keys
  * (`agent_id`, `violated_criteria`, `model_used`) to match the Rust TUI


### PR DESCRIPTION
Adds OpenAI Codex CLI as a third LLM backend alongside Claude Code and the native OpenAI API runner.

Token math from M1/M2 probes (2026-05-22): ~22-23K input + ~5 output per cold start, ~90 token incremental cost for indexing the baro repo — so per-story economics on ChatGPT Plus/Pro are workable. Free tier observed at ~3% weekly cap per probe.

## v1 scope

- Story phase routes through new `CodexStoryAgent` → `CodexCliParticipant` → `codex exec --json`.
- Architect, Planner, Critic, Surgeon stay on Claude (codex-* siblings for those phases are v2 follow-ups).
- `--llm codex` accepted at every CLI boundary (Rust → run-architect.ts / run-planner.ts → orchestrate.ts → story-factory.ts).
- New optional `baro doctor` row: `codex on PATH`. Soft failure; doesn't block Claude/OpenAI flows.

## Files

- new: `codex-stream-mapper.ts`, `codex-cli-participant.ts`, `codex-story-agent.ts`, `probe-codex.ts`
- new event types: `CodexSystem`, `CodexTurnEvent`, `CodexItemEvent`, `CodexUnknownEvent`
- modified: `story-factory.ts`, `orchestrate.ts`, `cli.ts`, `run-architect.ts`, `run-planner.ts`, `main.ts`, `semantic-events.ts`, Rust `LlmProvider` enum + `doctor.rs`

Mapper is grounded in real M1 wire-format capture (codex v0.133.0, gpt-5.5):

```
{"type":"thread.started","thread_id":"..."}
{"type":"turn.started"}
{"type":"item.completed","item":{"type":"agent_message","text":"hello"}}
{"type":"turn.completed","usage":{...}}
```

Item subtypes for command_execution / file_change / mcp_tool_call / web_search are mapped from docs and will be refined as we capture them in M3+ probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)