### PR TITLE
Baro TUI Forwarder Refactor (9 stories)

### DIFF
--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -31,7 +31,6 @@ import {
     safePullRebase,
 } from "./git.js"
 import { buildDag } from "./dag.js"
-import { ConductorState, type ConductorStateData } from "./semantic-events.js"
 import { Auditor } from "./participants/auditor.js"
 import {
     Conductor,
@@ -43,6 +42,7 @@ import { CriticOpenAI } from "./participants/critic-openai.js"
 import { Finalizer } from "./participants/finalizer.js"
 import { Librarian } from "./participants/librarian.js"
 import { Operator } from "./participants/operator.js"
+import { ProgressForwarder } from "./participants/forwarders/progress.js"
 import { Sentry } from "./participants/sentry.js"
 import { StoryFactory } from "./participants/story-factory.js"
 import { type StoryAgent } from "./participants/story-agent.js"
@@ -224,6 +224,7 @@ export async function orchestrate(
 
     // BaroEvent forwarder: watch the bus, translate to TUI protocol on stdout.
     if (emitTui) {
+        new ProgressForwarder().join(env)
         new BaroEventForwarder().join(env)
     }
 
@@ -533,10 +534,6 @@ class BaroEventForwarder extends BaseObserver {
         _source: Participant,
         event: SemanticEvent<unknown>,
     ): Promise<void> {
-        if (ConductorState.is(event)) {
-            this.handleConductorState(event.data)
-            return
-        }
         if (StoryResult.is(event)) {
             this.handleStoryResult(event.data)
             return
@@ -590,25 +587,6 @@ class BaroEventForwarder extends BaseObserver {
             id: item.agentId,
             line: `[critic/${item.verdict}] ${item.reasoning}`,
         })
-    }
-
-    private handleConductorState(item: ConductorStateData): void {
-        // Mirror conductor lifecycle as a `progress` event the existing
-        // Rust TUI understands — it doesn't yet know `conductor_state`.
-        if (
-            item.phase === "running_level" &&
-            item.currentLevel != null &&
-            item.totalLevels != null
-        ) {
-            emit({
-                type: "progress",
-                completed: item.currentLevel - 1,
-                total: item.totalLevels,
-                percentage: Math.round(
-                    ((item.currentLevel - 1) / Math.max(1, item.totalLevels)) * 100,
-                ),
-            })
-        }
     }
 
     private handleStoryResult(item: StoryResultData): void {

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -10,12 +10,6 @@
 import { mkdirSync } from "fs"
 import { dirname } from "path"
 
-import {
-    BaseObserver,
-    Participant,
-    SemanticEvent,
-} from "@mozaik-ai/core"
-
 import { AgenticEnvironment } from "@mozaik-ai/core"
 
 import {
@@ -41,27 +35,18 @@ import { Librarian } from "./participants/librarian.js"
 import { Operator } from "./participants/operator.js"
 import { AgentLogForwarder } from "./participants/forwarders/agent-log.js"
 import { CoordinationForwarder } from "./participants/forwarders/coordination.js"
+import { FinalizationForwarder } from "./participants/forwarders/finalization.js"
 import { ProgressForwarder } from "./participants/forwarders/progress.js"
+import { StoryLifecycleForwarder } from "./participants/forwarders/story-lifecycle.js"
+import { TokenUsageForwarder } from "./participants/forwarders/token-usage.js"
 import { Sentry } from "./participants/sentry.js"
 import { StoryFactory } from "./participants/story-factory.js"
 import { type StoryAgent } from "./participants/story-agent.js"
-import { StoryResult, type StoryResultData } from "./semantic-events.js"
 import { Surgeon, type PrdSnapshot } from "./participants/surgeon.js"
 import { SurgeonCodex } from "./participants/surgeon-codex.js"
 import { SurgeonOpenAI } from "./participants/surgeon-openai.js"
 import { PrdFile, loadPrd } from "./prd.js"
-import {
-    AgentResult,
-    AgentState,
-    ClaudeSystem,
-    CodexTurnEvent,
-    FinalizeStarted,
-    PrCreated,
-    RunStartRequest,
-    type AgentResultData,
-    type AgentStateData,
-    type CodexTurnEventData,
-} from "./semantic-events.js"
+import { RunStartRequest } from "./semantic-events.js"
 import { emit } from "./tui-protocol.js"
 
 export interface OrchestrateConfig {
@@ -219,10 +204,16 @@ export async function orchestrate(
 
     // BaroEvent forwarder: watch the bus, translate to TUI protocol on stdout.
     if (emitTui) {
-        new CoordinationForwarder().join(env)
-        new ProgressForwarder().join(env)
-        new AgentLogForwarder().join(env)
-        new BaroEventForwarder().join(env)
+        for (const forwarder of [
+            new StoryLifecycleForwarder(),
+            new TokenUsageForwarder(),
+            new ProgressForwarder(),
+            new CoordinationForwarder(),
+            new FinalizationForwarder(),
+            new AgentLogForwarder(),
+        ]) {
+            forwarder.join(env)
+        }
     }
 
     // Operator listens for external commands (wired from caller).
@@ -500,159 +491,6 @@ export async function orchestrate(
 }
 
 /**
- * Translates bus events into the legacy BaroEvent shape consumed by the
- * Rust TUI. Lives inside this module so callers don't have to wire
- * sinks themselves.
- */
-class BaroEventForwarder extends BaseObserver {
-    /** Story IDs that have already received a `story_start`. */
-    private startedStories = new Set<string>()
-    /** Number of in-flight retry attempts per story (for `story_retry`). */
-    private retryCounts = new Map<string, number>()
-    /** Token-usage tally per story (incrementally updated from results). */
-    private tokensByStory = new Map<string, { input: number; output: number }>()
-
-
-    override async onExternalEvent(
-        _source: Participant,
-        event: SemanticEvent<unknown>,
-    ): Promise<void> {
-        if (StoryResult.is(event)) {
-            this.handleStoryResult(event.data)
-            return
-        }
-        if (AgentResult.is(event)) {
-            this.handleClaudeResult(event.data)
-            return
-        }
-        if (CodexTurnEvent.is(event)) {
-            this.handleCodexTurnEvent(event.data)
-            return
-        }
-        if (AgentState.is(event)) {
-            this.handleAgentState(event.data)
-            return
-        }
-        if (ClaudeSystem.is(event)) {
-            // Mostly noise; emit only init transitions (already covered
-            // by AgentState) — skip.
-            return
-        }
-        if (FinalizeStarted.is(event)) {
-            emit({ type: "finalize_start" })
-            return
-        }
-        if (PrCreated.is(event)) {
-            emit({ type: "finalize_complete", pr_url: event.data.url })
-            return
-        }
-    }
-
-    private handleStoryResult(item: StoryResultData): void {
-        if (item.success) {
-            emit({
-                type: "story_complete",
-                id: item.storyId,
-                duration_secs: item.durationSecs,
-                files_created: 0,
-                files_modified: 0,
-            })
-        } else {
-            emit({
-                type: "story_error",
-                id: item.storyId,
-                error: item.error ?? "unknown error",
-                attempt: item.attempts,
-                max_retries: item.attempts,
-            })
-        }
-    }
-
-    private handleClaudeResult(item: AgentResultData): void {
-        const usage = item.usage as
-            | { input_tokens?: number; output_tokens?: number }
-            | null
-        const inputTokens =
-            typeof usage?.input_tokens === "number" ? usage.input_tokens : 0
-        const outputTokens =
-            typeof usage?.output_tokens === "number"
-                ? usage.output_tokens
-                : 0
-        const tally = this.tokensByStory.get(item.agentId) ?? { input: 0, output: 0 }
-        tally.input += inputTokens
-        tally.output += outputTokens
-        this.tokensByStory.set(item.agentId, tally)
-        emit({
-            type: "token_usage",
-            id: item.agentId,
-            input_tokens: inputTokens,
-            output_tokens: outputTokens,
-        })
-    }
-
-    /**
-     * Codex emits its usage stats inside `turn.completed` envelopes
-     * (shape: `{type:"turn.completed", usage:{input_tokens,
-     * cached_input_tokens, output_tokens, reasoning_output_tokens}}`).
-     * Translate to the same `token_usage` BaroEvent shape Claude uses
-     * so the TUI's existing counter works without backend-specific
-     * branching. `cached_input_tokens` is rolled into `input_tokens`
-     * (Codex reports both — Claude only reports the combined total —
-     * so we surface the same number here for parity). Reasoning
-     * tokens are billed as output tokens by OpenAI so we lump them
-     * with output_tokens.
-     */
-    private handleCodexTurnEvent(item: CodexTurnEventData): void {
-        if (item.phase !== "completed") return
-        const raw = item.raw as Record<string, unknown>
-        const usage = raw.usage as
-            | {
-                  input_tokens?: number
-                  cached_input_tokens?: number
-                  output_tokens?: number
-                  reasoning_output_tokens?: number
-              }
-            | undefined
-        if (!usage) return
-        const inputTokens =
-            typeof usage.input_tokens === "number" ? usage.input_tokens : 0
-        const outputBase =
-            typeof usage.output_tokens === "number" ? usage.output_tokens : 0
-        const reasoning =
-            typeof usage.reasoning_output_tokens === "number"
-                ? usage.reasoning_output_tokens
-                : 0
-        const outputTokens = outputBase + reasoning
-        const tally = this.tokensByStory.get(item.agentId) ?? {
-            input: 0,
-            output: 0,
-        }
-        tally.input += inputTokens
-        tally.output += outputTokens
-        this.tokensByStory.set(item.agentId, tally)
-        emit({
-            type: "token_usage",
-            id: item.agentId,
-            input_tokens: inputTokens,
-            output_tokens: outputTokens,
-        })
-    }
-
-    private handleAgentState(item: AgentStateData): void {
-        if (item.phase === "running" && !this.startedStories.has(item.agentId)) {
-            this.startedStories.add(item.agentId)
-            emit({ type: "story_start", id: item.agentId, title: item.agentId })
-        }
-        if (item.phase === "waiting" && item.detail?.includes("retrying")) {
-            const count = (this.retryCounts.get(item.agentId) ?? 0) + 1
-            this.retryCounts.set(item.agentId, count)
-            emit({ type: "story_retry", id: item.agentId, attempt: count })
-        }
-    }
-
-}
-
-/**
  * Pull a few keyword-shaped tokens out of free text for Librarian
  * relevance hints. Lowercased, alphanumeric runs ≥ 3 chars.
  */
@@ -667,4 +505,3 @@ function tokenizeForHints(text: string): string[] {
     }
     return out
 }
-

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -12,9 +12,6 @@ import { dirname } from "path"
 
 import {
     BaseObserver,
-    FunctionCallItem,
-    FunctionCallOutputItem,
-    ModelMessageItem,
     Participant,
     SemanticEvent,
 } from "@mozaik-ai/core"
@@ -42,6 +39,7 @@ import { CriticOpenAI } from "./participants/critic-openai.js"
 import { Finalizer } from "./participants/finalizer.js"
 import { Librarian } from "./participants/librarian.js"
 import { Operator } from "./participants/operator.js"
+import { AgentLogForwarder } from "./participants/forwarders/agent-log.js"
 import { CoordinationForwarder } from "./participants/forwarders/coordination.js"
 import { ProgressForwarder } from "./participants/forwarders/progress.js"
 import { Sentry } from "./participants/sentry.js"
@@ -223,6 +221,7 @@ export async function orchestrate(
     if (emitTui) {
         new CoordinationForwarder().join(env)
         new ProgressForwarder().join(env)
+        new AgentLogForwarder().join(env)
         new BaroEventForwarder().join(env)
     }
 
@@ -513,20 +512,6 @@ class BaroEventForwarder extends BaseObserver {
     /** Token-usage tally per story (incrementally updated from results). */
     private tokensByStory = new Map<string, { input: number; output: number }>()
 
-    override async onExternalModelMessage(source: Participant, item: ModelMessageItem): Promise<void> {
-        this.handleModelMessage(source, item)
-    }
-
-    override async onExternalFunctionCall(source: Participant, item: FunctionCallItem): Promise<void> {
-        this.handleToolCall(source, item)
-    }
-
-    override async onExternalFunctionCallOutput(
-        source: Participant,
-        item: FunctionCallOutputItem,
-    ): Promise<void> {
-        this.handleToolResult(source, item)
-    }
 
     override async onExternalEvent(
         _source: Participant,
@@ -665,52 +650,6 @@ class BaroEventForwarder extends BaseObserver {
         }
     }
 
-    private handleModelMessage(source: Participant, item: ModelMessageItem): void {
-        const agentId = (source as unknown as { agentId?: string }).agentId
-        if (typeof agentId !== "string") return
-        const json = item.toJSON() as { content: Array<{ text: string }> }
-        const text = json.content?.[0]?.text ?? ""
-        if (!text.trim()) return
-        emitMultiline(agentId, text)
-    }
-
-    private handleToolCall(source: Participant, item: FunctionCallItem): void {
-        const agentId = (source as unknown as { agentId?: string }).agentId
-        if (typeof agentId !== "string") return
-        // Tool args can themselves contain newlines (multi-line file
-        // contents in a Write call, embedded code blocks, etc). Split.
-        emitMultiline(agentId, `[tool_call] ${item.name} ${item.args}`)
-    }
-
-    private handleToolResult(
-        source: Participant,
-        item: FunctionCallOutputItem,
-    ): void {
-        const agentId = (source as unknown as { agentId?: string }).agentId
-        if (typeof agentId !== "string") return
-        const json = item.toJSON() as {
-            call_id: string
-            output: Array<{ text: string }>
-        }
-        const text = json.output?.[0]?.text ?? ""
-        emitMultiline(agentId, `[tool_result ${json.call_id}] ${text}`)
-    }
-}
-
-/**
- * Emit a story_log per source line. Keeps the TUI clean (no embedded
- * `\n` rendered as ⏎ literals) and lets the log scrollbar work as
- * intended on long tool outputs.
- */
-function emitMultiline(agentId: string, text: string): void {
-    if (!text) return
-    const lines = text.split("\n")
-    for (const line of lines) {
-        // Skip purely empty trailing lines but keep blank rows mid-block
-        // so structure (e.g. paragraph breaks) survives.
-        if (line.length === 0 && lines.length === 1) continue
-        emit({ type: "story_log", id: agentId, line })
-    }
 }
 
 /**

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -42,6 +42,7 @@ import { CriticOpenAI } from "./participants/critic-openai.js"
 import { Finalizer } from "./participants/finalizer.js"
 import { Librarian } from "./participants/librarian.js"
 import { Operator } from "./participants/operator.js"
+import { CoordinationForwarder } from "./participants/forwarders/coordination.js"
 import { ProgressForwarder } from "./participants/forwarders/progress.js"
 import { Sentry } from "./participants/sentry.js"
 import { StoryFactory } from "./participants/story-factory.js"
@@ -56,16 +57,12 @@ import {
     AgentState,
     ClaudeSystem,
     CodexTurnEvent,
-    Coordination,
-    Critique,
     FinalizeStarted,
     PrCreated,
     RunStartRequest,
     type AgentResultData,
     type AgentStateData,
     type CodexTurnEventData,
-    type CoordinationData,
-    type CritiqueData,
 } from "./semantic-events.js"
 import { emit } from "./tui-protocol.js"
 
@@ -224,6 +221,7 @@ export async function orchestrate(
 
     // BaroEvent forwarder: watch the bus, translate to TUI protocol on stdout.
     if (emitTui) {
+        new CoordinationForwarder().join(env)
         new ProgressForwarder().join(env)
         new BaroEventForwarder().join(env)
     }
@@ -555,14 +553,6 @@ class BaroEventForwarder extends BaseObserver {
             // by AgentState) — skip.
             return
         }
-        if (Coordination.is(event)) {
-            this.handleCoordination(event.data)
-            return
-        }
-        if (Critique.is(event)) {
-            this.handleCritique(event.data)
-            return
-        }
         if (FinalizeStarted.is(event)) {
             emit({ type: "finalize_start" })
             return
@@ -571,22 +561,6 @@ class BaroEventForwarder extends BaseObserver {
             emit({ type: "finalize_complete", pr_url: event.data.url })
             return
         }
-    }
-
-    private handleCoordination(item: CoordinationData): void {
-        emit({
-            type: "story_log",
-            id: item.recipientId,
-            line: `[sentry/${item.kind}] ${item.reason}`,
-        })
-    }
-
-    private handleCritique(item: CritiqueData): void {
-        emit({
-            type: "story_log",
-            id: item.agentId,
-            line: `[critic/${item.verdict}] ${item.reasoning}`,
-        })
     }
 
     private handleStoryResult(item: StoryResultData): void {

--- a/packages/baro-orchestrator/src/participants/OBSERVERS.md
+++ b/packages/baro-orchestrator/src/participants/OBSERVERS.md
@@ -1,9 +1,10 @@
 # Observer participants
 
-This cheat sheet documents the six TypeScript-side observer participants
-in the orchestrator: passive bus listeners that watch bus traffic and
-(optionally) emit their own events back onto the bus. Cartographer is
-**not** covered here — it lives Rust-side under `crates/baro-tui/`.
+This cheat sheet documents the TypeScript-side observer participants in
+the orchestrator: passive bus listeners that watch bus traffic and
+(optionally) emit their own events back onto the bus or stdout protocol.
+Cartographer is **not** covered here — it lives Rust-side under
+`crates/baro-tui/`.
 
 Every observer extends Mozaik's `BaseObserver`. They subscribe via
 `onExternalEvent(source, event: SemanticEvent<unknown>)` and gate per
@@ -125,3 +126,33 @@ defined in [../semantic-events.ts](../semantic-events.ts).
 - Emits: `FinalizeStarted`, `PrCreated`
 
 Source: [finalizer.ts](./finalizer.ts)
+
+---
+
+## TUI Forwarders
+
+Stdout protocol adapters that translate Mozaik bus events and LLM item
+callbacks into Rust TUI `BaroEvent` JSON. They are split by event family
+under [forwarders/](./forwarders/) so each file owns one responsibility
+and one set of mutable state. The old aggregate forwarder kept a
+`tokensByStory` map, but that state was written and never read, so the
+split drops it.
+
+- [story-lifecycle.ts](./forwarders/story-lifecycle.ts): subscribes to
+  `AgentState` and `StoryResult`; emits story start, retry, completion,
+  and error events.
+- [token-usage.ts](./forwarders/token-usage.ts): subscribes to
+  `AgentResult` and completed `CodexTurnEvent`; emits token usage
+  events.
+- [progress.ts](./forwarders/progress.ts): subscribes to
+  `ConductorState`; emits level progress events.
+- [coordination.ts](./forwarders/coordination.ts): subscribes to
+  `Coordination` and `Critique`; emits story log lines.
+- [finalization.ts](./forwarders/finalization.ts): subscribes to
+  `FinalizeStarted` and `PrCreated`; emits finalization lifecycle
+  events.
+- [agent-log.ts](./forwarders/agent-log.ts): subscribes to
+  `ModelMessageItem`, `FunctionCallItem`, and `FunctionCallOutputItem`
+  through Mozaik item hooks; emits model and tool story log lines.
+
+These forwarders emit nothing back onto the Mozaik bus.

--- a/packages/baro-orchestrator/src/participants/forwarders/agent-log.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/agent-log.ts
@@ -1,0 +1,74 @@
+import {
+    BaseObserver,
+    type FunctionCallItem,
+    type FunctionCallOutputItem,
+    type ModelMessageItem,
+    type Participant,
+} from "@mozaik-ai/core"
+
+import { emit } from "../../tui-protocol.js"
+
+export class AgentLogForwarder extends BaseObserver {
+    override async onExternalModelMessage(
+        source: Participant,
+        item: ModelMessageItem,
+    ): Promise<void> {
+        this.handleModelMessage(source, item)
+    }
+
+    override async onExternalFunctionCall(
+        source: Participant,
+        item: FunctionCallItem,
+    ): Promise<void> {
+        this.handleToolCall(source, item)
+    }
+
+    override async onExternalFunctionCallOutput(
+        source: Participant,
+        item: FunctionCallOutputItem,
+    ): Promise<void> {
+        this.handleToolResult(source, item)
+    }
+
+    private handleModelMessage(source: Participant, item: ModelMessageItem): void {
+        const agentId = (source as unknown as { agentId?: string }).agentId
+        if (typeof agentId !== "string") return
+
+        const json = item.toJSON() as { content?: Array<{ text?: string }> }
+        const text = json.content?.[0]?.text ?? ""
+        if (!text.trim()) return
+
+        emitMultiline(agentId, text)
+    }
+
+    private handleToolCall(source: Participant, item: FunctionCallItem): void {
+        const agentId = (source as unknown as { agentId?: string }).agentId
+        if (typeof agentId !== "string") return
+
+        emitMultiline(agentId, `[tool_call] ${item.name} ${item.args}`)
+    }
+
+    private handleToolResult(
+        source: Participant,
+        item: FunctionCallOutputItem,
+    ): void {
+        const agentId = (source as unknown as { agentId?: string }).agentId
+        if (typeof agentId !== "string") return
+
+        const json = item.toJSON() as {
+            call_id: string
+            output?: Array<{ text?: string }>
+        }
+        const text = json.output?.[0]?.text ?? ""
+        emitMultiline(agentId, `[tool_result ${json.call_id}] ${text}`)
+    }
+}
+
+function emitMultiline(agentId: string, text: string): void {
+    if (!text) return
+    const lines = text.split("\n")
+    for (const line of lines) {
+        if (line.length === 0 && lines.length === 1) continue
+        emit({ type: "story_log", id: agentId, line })
+    }
+}

--- a/packages/baro-orchestrator/src/participants/forwarders/coordination.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/coordination.ts
@@ -1,0 +1,41 @@
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import {
+    Coordination,
+    Critique,
+    type CoordinationData,
+    type CritiqueData,
+} from "../../semantic-events.js"
+import { emit } from "../../tui-protocol.js"
+
+export class CoordinationForwarder extends BaseObserver {
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (Coordination.is(event)) {
+            this.handleCoordination(event.data)
+            return
+        }
+        if (Critique.is(event)) {
+            this.handleCritique(event.data)
+            return
+        }
+    }
+
+    private handleCoordination(item: CoordinationData): void {
+        emit({
+            type: "story_log",
+            id: item.recipientId,
+            line: `[sentry/${item.kind}] ${item.reason}`,
+        })
+    }
+
+    private handleCritique(item: CritiqueData): void {
+        emit({
+            type: "story_log",
+            id: item.agentId,
+            line: `[critic/${item.verdict}] ${item.reasoning}`,
+        })
+    }
+}

--- a/packages/baro-orchestrator/src/participants/forwarders/finalization.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/finalization.ts
@@ -1,0 +1,19 @@
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import { FinalizeStarted, PrCreated } from "../../semantic-events.js"
+import { emit } from "../../tui-protocol.js"
+
+export class FinalizationForwarder extends BaseObserver {
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (FinalizeStarted.is(event)) {
+            emit({ type: "finalize_start" })
+            return
+        }
+        if (PrCreated.is(event)) {
+            emit({ type: "finalize_complete", pr_url: event.data.url })
+        }
+    }
+}

--- a/packages/baro-orchestrator/src/participants/forwarders/progress.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/progress.ts
@@ -1,0 +1,35 @@
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import {
+    ConductorState,
+    type ConductorStateData,
+} from "../../semantic-events.js"
+import { emit } from "../../tui-protocol.js"
+
+export class ProgressForwarder extends BaseObserver {
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (ConductorState.is(event)) {
+            this.handleConductorState(event.data)
+        }
+    }
+
+    private handleConductorState(item: ConductorStateData): void {
+        if (
+            item.phase === "running_level" &&
+            item.currentLevel != null &&
+            item.totalLevels != null
+        ) {
+            emit({
+                type: "progress",
+                completed: item.currentLevel - 1,
+                total: item.totalLevels,
+                percentage: Math.round(
+                    ((item.currentLevel - 1) / Math.max(1, item.totalLevels)) * 100,
+                ),
+            })
+        }
+    }
+}

--- a/packages/baro-orchestrator/src/participants/forwarders/story-lifecycle.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/story-lifecycle.ts
@@ -1,0 +1,59 @@
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import {
+    AgentState,
+    type AgentStateData,
+    StoryResult,
+    type StoryResultData,
+} from "../../semantic-events.js"
+import { emit } from "../../tui-protocol.js"
+
+export class StoryLifecycleForwarder extends BaseObserver {
+    private startedStories = new Set<string>()
+    private retryCounts = new Map<string, number>()
+
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (StoryResult.is(event)) {
+            this.handleStoryResult(event.data)
+            return
+        }
+        if (AgentState.is(event)) {
+            this.handleAgentState(event.data)
+        }
+    }
+
+    private handleStoryResult(item: StoryResultData): void {
+        if (item.success) {
+            emit({
+                type: "story_complete",
+                id: item.storyId,
+                duration_secs: item.durationSecs,
+                files_created: 0,
+                files_modified: 0,
+            })
+        } else {
+            emit({
+                type: "story_error",
+                id: item.storyId,
+                error: item.error ?? "unknown error",
+                attempt: item.attempts,
+                max_retries: item.attempts,
+            })
+        }
+    }
+
+    private handleAgentState(item: AgentStateData): void {
+        if (item.phase === "running" && !this.startedStories.has(item.agentId)) {
+            this.startedStories.add(item.agentId)
+            emit({ type: "story_start", id: item.agentId, title: item.agentId })
+        }
+        if (item.phase === "waiting" && item.detail?.includes("retrying")) {
+            const count = (this.retryCounts.get(item.agentId) ?? 0) + 1
+            this.retryCounts.set(item.agentId, count)
+            emit({ type: "story_retry", id: item.agentId, attempt: count })
+        }
+    }
+}

--- a/packages/baro-orchestrator/src/participants/forwarders/token-usage.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/token-usage.ts
@@ -1,0 +1,72 @@
+import { BaseObserver, type Participant, type SemanticEvent } from "@mozaik-ai/core"
+
+import {
+    AgentResult,
+    CodexTurnEvent,
+    type AgentResultData,
+    type CodexTurnEventData,
+} from "../../semantic-events.js"
+import { emit } from "../../tui-protocol.js"
+
+export class TokenUsageForwarder extends BaseObserver {
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (AgentResult.is(event)) {
+            this.handleAgentResult(event.data)
+            return
+        }
+        if (CodexTurnEvent.is(event)) {
+            this.handleCodexTurnEvent(event.data)
+            return
+        }
+    }
+
+    private handleAgentResult(item: AgentResultData): void {
+        const usage = item.usage as
+            | { input_tokens?: number; output_tokens?: number }
+            | null
+        const inputTokens =
+            typeof usage?.input_tokens === "number" ? usage.input_tokens : 0
+        const outputTokens =
+            typeof usage?.output_tokens === "number"
+                ? usage.output_tokens
+                : 0
+        emit({
+            type: "token_usage",
+            id: item.agentId,
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+        })
+    }
+
+    private handleCodexTurnEvent(item: CodexTurnEventData): void {
+        if (item.phase !== "completed") return
+
+        const raw = item.raw as Record<string, unknown>
+        const usage = raw.usage as
+            | {
+                  input_tokens?: number
+                  output_tokens?: number
+                  reasoning_output_tokens?: number
+              }
+            | undefined
+        if (!usage) return
+
+        const inputTokens =
+            typeof usage.input_tokens === "number" ? usage.input_tokens : 0
+        const outputBase =
+            typeof usage.output_tokens === "number" ? usage.output_tokens : 0
+        const reasoning =
+            typeof usage.reasoning_output_tokens === "number"
+                ? usage.reasoning_output_tokens
+                : 0
+        emit({
+            type: "token_usage",
+            id: item.agentId,
+            input_tokens: inputTokens,
+            output_tokens: outputBase + reasoning,
+        })
+    }
+}

--- a/packages/baro-orchestrator/src/participants/story-agent.ts
+++ b/packages/baro-orchestrator/src/participants/story-agent.ts
@@ -448,8 +448,12 @@ function raceWithTimeout<T>(
     ms: number,
     label: string,
 ): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>
+    const timeout = new Promise<T>((_, rej) => {
+        timer = setTimeout(() => rej(new Error(label)), ms)
+    })
     return Promise.race([
         p,
-        new Promise<T>((_, rej) => setTimeout(() => rej(new Error(label)), ms)),
-    ])
+        timeout,
+    ]).finally(() => clearTimeout(timer))
 }


### PR DESCRIPTION
> Opened by [baro](https://baro.rs) — Mozaik-orchestrated parallel coding agents.

## Goal

Split the monolithic BaroEventForwarder into focused observer forwarders without changing emitted BaroEvent JSON.

## Plan

```
Level 1 ─── S1, S2, S3, S4, S5, S6
Level 2 ─── S7, S8
Level 3 ─── S9
```

## Stories

| # | Story | Status | Duration | Commit |
|---|-------|--------|----------|--------|
| S1 | Extract story lifecycle forwarder | ✓ | 3:32 | `c4111d8` |
| S2 | Extract token usage forwarder | ✓ | 1:43 | `5fb8f61` |
| S3 | Extract progress forwarder | ✓ | 4:48 | `21694ec` |
| S4 | Extract coordination forwarder | ✓ | 5:53 | `ed82779` |
| S5 | Extract finalization forwarder | ✓ | 3:01 | `f48e033` |
| S6 | Extract agent log forwarder | ✓ | 6:53 | `9ca5109` |
| S7 | Wire focused forwarders | ✓ | 2:02 | `fabe4c4` |
| S8 | Document TUI forwarders | ✓ | 1:06 | — |
| S9 | Run orchestrator verification | ✓ | 4:54 | — |

## Diff stats

- **Files created**: 6
- **Files modified**: 3
- **Total commits**: 9

## Run summary

- **Wall time**: 14:51
- **Sequential time**: 33:52
- **Parallel speedup**: 2.28×
- **Stories passed**: 9/9
- **Stories failed**: 0
- **Total story attempts**: 9

---

🤖 Plan. Parallelize. Review. Ship. — opened by baro

Co-Authored-By: baro <285254893+baro-rs@users.noreply.github.com>