### PR TITLE
Baro Orchestrator Forwarders (7 stories)

### DIFF
--- a/packages/baro-orchestrator/src/forwarders/coordination-forwarder.ts
+++ b/packages/baro-orchestrator/src/forwarders/coordination-forwarder.ts
@@ -1,0 +1,45 @@
+import {
+    BaseObserver,
+    Participant,
+    SemanticEvent,
+} from "@mozaik-ai/core"
+
+import {
+    Coordination,
+    Critique,
+    type CoordinationData,
+    type CritiqueData,
+} from "../semantic-events.js"
+import { emit } from "../tui-protocol.js"
+
+export class CoordinationForwarder extends BaseObserver {
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (Coordination.is(event)) {
+            this.handleCoordination(event.data)
+            return
+        }
+        if (Critique.is(event)) {
+            this.handleCritique(event.data)
+            return
+        }
+    }
+
+    private handleCoordination(item: CoordinationData): void {
+        emit({
+            type: "story_log",
+            id: item.recipientId,
+            line: `[sentry/${item.kind}] ${item.reason}`,
+        })
+    }
+
+    private handleCritique(item: CritiqueData): void {
+        emit({
+            type: "story_log",
+            id: item.agentId,
+            line: `[critic/${item.verdict}] ${item.reasoning}`,
+        })
+    }
+}

--- a/packages/baro-orchestrator/src/forwarders/finalization-forwarder.ts
+++ b/packages/baro-orchestrator/src/forwarders/finalization-forwarder.ts
@@ -1,0 +1,24 @@
+import {
+    BaseObserver,
+    Participant,
+    SemanticEvent,
+} from "@mozaik-ai/core"
+
+import { FinalizeStarted, PrCreated } from "../semantic-events.js"
+import { emit } from "../tui-protocol.js"
+
+export class FinalizationForwarder extends BaseObserver {
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (FinalizeStarted.is(event)) {
+            emit({ type: "finalize_start" })
+            return
+        }
+        if (PrCreated.is(event)) {
+            emit({ type: "finalize_complete", pr_url: event.data.url })
+            return
+        }
+    }
+}

--- a/packages/baro-orchestrator/src/forwarders/progress-forwarder.ts
+++ b/packages/baro-orchestrator/src/forwarders/progress-forwarder.ts
@@ -1,0 +1,32 @@
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import { ConductorState, type ConductorStateData } from "../semantic-events.js"
+import { emit } from "../tui-protocol.js"
+
+export class ProgressForwarder extends BaseObserver {
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (ConductorState.is(event)) {
+            this.handleConductorState(event.data)
+        }
+    }
+
+    private handleConductorState(item: ConductorStateData): void {
+        if (
+            item.phase === "running_level" &&
+            item.currentLevel != null &&
+            item.totalLevels != null
+        ) {
+            emit({
+                type: "progress",
+                completed: item.currentLevel - 1,
+                total: item.totalLevels,
+                percentage: Math.round(
+                    ((item.currentLevel - 1) / Math.max(1, item.totalLevels)) * 100,
+                ),
+            })
+        }
+    }
+}

--- a/packages/baro-orchestrator/src/forwarders/story-lifecycle-forwarder.ts
+++ b/packages/baro-orchestrator/src/forwarders/story-lifecycle-forwarder.ts
@@ -1,0 +1,64 @@
+import {
+    BaseObserver,
+    Participant,
+    SemanticEvent,
+} from "@mozaik-ai/core"
+
+import {
+    AgentState,
+    StoryResult,
+    type AgentStateData,
+    type StoryResultData,
+} from "../semantic-events.js"
+import { emit } from "../tui-protocol.js"
+
+export class StoryLifecycleForwarder extends BaseObserver {
+    private startedStories = new Set<string>()
+    private retryCounts = new Map<string, number>()
+
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (AgentState.is(event)) {
+            this.handleAgentState(event.data)
+            return
+        }
+        if (StoryResult.is(event)) {
+            this.handleStoryResult(event.data)
+            return
+        }
+    }
+
+    private handleAgentState(item: AgentStateData): void {
+        if (item.phase === "running" && !this.startedStories.has(item.agentId)) {
+            this.startedStories.add(item.agentId)
+            emit({ type: "story_start", id: item.agentId, title: item.agentId })
+        }
+        if (item.phase === "waiting" && item.detail?.includes("retrying")) {
+            const count = (this.retryCounts.get(item.agentId) ?? 0) + 1
+            this.retryCounts.set(item.agentId, count)
+            emit({ type: "story_retry", id: item.agentId, attempt: count })
+        }
+    }
+
+    private handleStoryResult(item: StoryResultData): void {
+        if (item.success) {
+            emit({
+                type: "story_complete",
+                id: item.storyId,
+                duration_secs: item.durationSecs,
+                files_created: 0,
+                files_modified: 0,
+            })
+        } else {
+            emit({
+                type: "story_error",
+                id: item.storyId,
+                error: item.error ?? "unknown error",
+                attempt: item.attempts,
+                max_retries: item.attempts,
+            })
+        }
+    }
+}

--- a/packages/baro-orchestrator/src/forwarders/token-usage-forwarder.ts
+++ b/packages/baro-orchestrator/src/forwarders/token-usage-forwarder.ts
@@ -1,0 +1,66 @@
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import {
+    AgentResult,
+    CodexTurnEvent,
+    type AgentResultData,
+    type CodexTurnEventData,
+} from "../semantic-events.js"
+import { emit } from "../tui-protocol.js"
+
+export class TokenUsageForwarder extends BaseObserver {
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (AgentResult.is(event)) {
+            this.handleAgentResult(event.data)
+            return
+        }
+        if (CodexTurnEvent.is(event)) {
+            this.handleCodexTurnEvent(event.data)
+            return
+        }
+    }
+
+    private handleAgentResult(item: AgentResultData): void {
+        const usage = item.usage as
+            | { input_tokens?: unknown; output_tokens?: unknown }
+            | null
+        const inputTokens = this.numberOrZero(usage?.input_tokens)
+        const outputTokens = this.numberOrZero(usage?.output_tokens)
+
+        emit({
+            type: "token_usage",
+            id: item.agentId,
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+        })
+    }
+
+    private handleCodexTurnEvent(item: CodexTurnEventData): void {
+        if (item.phase !== "completed") return
+        if (item.raw.usage == null) return
+
+        const usage = item.raw.usage as {
+            input_tokens?: unknown
+            output_tokens?: unknown
+            reasoning_output_tokens?: unknown
+        }
+        const inputTokens = this.numberOrZero(usage.input_tokens)
+        const outputTokens =
+            this.numberOrZero(usage.output_tokens) +
+            this.numberOrZero(usage.reasoning_output_tokens)
+
+        emit({
+            type: "token_usage",
+            id: item.agentId,
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+        })
+    }
+
+    private numberOrZero(value: unknown): number {
+        return typeof value === "number" ? value : 0
+    }
+}


### PR DESCRIPTION
> Opened by [baro](https://baro.rs) — Mozaik-orchestrated parallel coding agents.

## Goal

Split the TUI BaroEvent forwarder god-class into focused BaseObserver forwarders without changing emitted BaroEvent JSON.

## Plan

```
Level 1 ─── S1, S2, S3, S4, S5, S6
Level 2 ─── S7
```

## Stories

| # | Story | Status | Duration | Commit |
|---|-------|--------|----------|--------|
| S1 | Extract story lifecycle forwarder | ✓ | 3:26 | `257a173` |
| S2 | Extract story log forwarder | ✓ | 3:22 | `257a173` |
| S3 | Extract token usage forwarder | ✓ | 4:09 | `b851829` |
| S4 | Extract progress forwarder | ✓ | 3:21 | `257a173` |
| S5 | Extract coordination forwarder | ✓ | 2:18 | `257a173` |
| S6 | Extract finalization forwarder | ✓ | 1:41 | `ec790f7` |
| S7 | Wire focused forwarders | ✓ | 3:07 | `f39bc47` |

## Diff stats

- **Files created**: 3
- **Files modified**: 1
- **Total commits**: 4

## Run summary

- **Wall time**: 7:43
- **Sequential time**: 21:24
- **Parallel speedup**: 2.77×
- **Stories passed**: 7/7
- **Stories failed**: 0
- **Total story attempts**: 7

---

🤖 Plan. Parallelize. Review. Ship. — opened by baro

Co-Authored-By: baro <285254893+baro-rs@users.noreply.github.com>