### PR TITLE
feat(0.44.0): per-phase --llm routing + --llm hybrid preset

### DIFF
--- a/crates/baro-tui/Cargo.toml
+++ b/crates/baro-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baro-tui"
-version = "0.43.3"
+version = "0.44.0"
 edition = "2021"
 
 [[bin]]

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -304,13 +304,20 @@ pub struct App {
     /// explicitly didn't sign up for). The fast path for "fix the typo" goals.
     pub quick: bool,
 
-    /// Which LLM provider runs the agents. Set via `--llm claude|openai`.
-    /// `claude` (the default) uses the Claude Code CLI as today. `openai`
-    /// is a placeholder until the Mozaik-native OpenAI participants are
-    /// feature-complete — currently it falls through to Claude behaviour
-    /// but is plumbed through to the orchestrator so each subsequent
-    /// phase can opt individual participants into the OpenAI path.
+    /// Which LLM provider runs the agents. Set via `--llm
+    /// claude|openai|codex|hybrid`. Read as **the default** every
+    /// phase uses unless an explicit per-phase override is set.
     pub llm: LlmProvider,
+    /// Per-phase overrides. Each defaults to `llm` when no override
+    /// is supplied on the command line. `--llm hybrid` is a preset
+    /// that flips these to a sensible split: Architect / Planner /
+    /// Surgeon stay on Claude (high-stakes, low-volume); Story and
+    /// Critic move to Codex (high-volume, cheap on subscription).
+    pub architect_llm: LlmProvider,
+    pub planner_llm: LlmProvider,
+    pub story_llm: LlmProvider,
+    pub critic_llm: LlmProvider,
+    pub surgeon_llm: LlmProvider,
 
     // Notification flag
     pub notification_ready: bool,
@@ -396,6 +403,11 @@ impl App {
             intra_level_delay_secs: None,
             quick: false,
             llm: LlmProvider::Claude,
+            architect_llm: LlmProvider::Claude,
+            planner_llm: LlmProvider::Claude,
+            story_llm: LlmProvider::Claude,
+            critic_llm: LlmProvider::Claude,
+            surgeon_llm: LlmProvider::Claude,
             token_usage: HashMap::new(),
             total_input_tokens: 0,
             total_output_tokens: 0,

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -82,6 +82,14 @@ pub struct ExecutorConfig {
     /// as `--llm`; subsequent phases will use this to pick the right
     /// participant sibling per LLM-using role.
     pub llm: crate::app::LlmProvider,
+    /// Per-phase overrides forwarded to orchestrate.ts as
+    /// `--story-llm` / `--critic-llm` / `--surgeon-llm`. When equal
+    /// to `llm`, the orchestrator treats them as "no override" and
+    /// the global default flows. Used by the `--llm hybrid` preset
+    /// to keep Story + Critic on a different backend than the rest.
+    pub story_llm: crate::app::LlmProvider,
+    pub critic_llm: crate::app::LlmProvider,
+    pub surgeon_llm: crate::app::LlmProvider,
     /// OpenAI API key captured by the TUI (either from `OPENAI_API_KEY`
     /// in the shell env or typed into the ApiKeyInput screen). Forwarded
     /// to the orchestrator subprocess as an env var when `llm = OpenAI`.

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -225,11 +225,32 @@ struct Cli {
     ///                      on the provider-picker screen when running
     ///                      interactively.
     ///   codex            — subscription-arbitrage path via OpenAI Codex
-    ///                      CLI (ChatGPT Plus/Pro billing). v1: Story
-    ///                      phase only; Architect / Planner / Critic /
-    ///                      Surgeon fall back to Claude.
-    #[arg(long, default_value = "claude", value_parser = ["claude", "openai", "codex"])]
+    ///                      CLI (ChatGPT Plus/Pro billing). All five
+    ///                      phases route through Codex.
+    ///   hybrid           — preset that mixes vendors per phase:
+    ///                      Architect / Planner / Surgeon stay on
+    ///                      Claude (high-stakes, low-volume), Story and
+    ///                      Critic move to Codex (high-volume, cheap
+    ///                      on ChatGPT subscription). Individual phase
+    ///                      overrides win when set.
+    #[arg(long, default_value = "claude", value_parser = ["claude", "openai", "codex", "hybrid"])]
     llm: String,
+
+    /// Per-phase overrides. Each accepts claude | openai | codex and
+    /// wins over `--llm` (including the `hybrid` preset) for that one
+    /// phase. Useful for surgical tuning: e.g. `--llm hybrid
+    /// --critic-llm claude` for a hybrid run that uses Claude for
+    /// Critic instead of Codex.
+    #[arg(long, value_parser = ["claude", "openai", "codex"])]
+    architect_llm: Option<String>,
+    #[arg(long, value_parser = ["claude", "openai", "codex"])]
+    planner_llm: Option<String>,
+    #[arg(long, value_parser = ["claude", "openai", "codex"])]
+    story_llm: Option<String>,
+    #[arg(long, value_parser = ["claude", "openai", "codex"])]
+    critic_llm: Option<String>,
+    #[arg(long, value_parser = ["claude", "openai", "codex"])]
+    surgeon_llm: Option<String>,
 }
 
 enum AppEvent {
@@ -450,13 +471,61 @@ async fn run_app(
         app.with_surgeon = false;
     }
 
-    // --llm picks the LLM provider. `claude` (default) → Claude Code
-    // CLI for every phase. `openai` → Mozaik native OpenAI runner end
-    // to end (Architect + Planner + Critic + Surgeon + StoryAgent),
-    // as of 0.33.
-    if let Some(provider) = app::LlmProvider::parse(&cli.llm) {
-        app.llm = provider;
+    // --llm picks the LLM provider. Three legacy values (claude /
+    // openai / codex) route every phase through one backend. The
+    // `hybrid` preset splits per-phase: Claude for Architect /
+    // Planner / Surgeon (high-stakes, low-volume calls), Codex for
+    // Story + Critic (high-volume, cheap on subscription).
+    match cli.llm.as_str() {
+        "hybrid" => {
+            // The preset only sets the defaults — explicit per-phase
+            // flags below win over these.
+            app.llm = app::LlmProvider::Claude; // bookkeeping default
+            app.architect_llm = app::LlmProvider::Claude;
+            app.planner_llm = app::LlmProvider::Claude;
+            app.story_llm = app::LlmProvider::Codex;
+            app.critic_llm = app::LlmProvider::Codex;
+            app.surgeon_llm = app::LlmProvider::Claude;
+        }
+        other => {
+            if let Some(provider) = app::LlmProvider::parse(other) {
+                app.llm = provider;
+                app.architect_llm = provider;
+                app.planner_llm = provider;
+                app.story_llm = provider;
+                app.critic_llm = provider;
+                app.surgeon_llm = provider;
+            }
+        }
     }
+
+    // Per-phase CLI overrides win over the preset / global default.
+    if let Some(ref v) = cli.architect_llm {
+        if let Some(p) = app::LlmProvider::parse(v) {
+            app.architect_llm = p;
+        }
+    }
+    if let Some(ref v) = cli.planner_llm {
+        if let Some(p) = app::LlmProvider::parse(v) {
+            app.planner_llm = p;
+        }
+    }
+    if let Some(ref v) = cli.story_llm {
+        if let Some(p) = app::LlmProvider::parse(v) {
+            app.story_llm = p;
+        }
+    }
+    if let Some(ref v) = cli.critic_llm {
+        if let Some(p) = app::LlmProvider::parse(v) {
+            app.critic_llm = p;
+        }
+    }
+    if let Some(ref v) = cli.surgeon_llm {
+        if let Some(p) = app::LlmProvider::parse(v) {
+            app.surgeon_llm = p;
+        }
+    }
+
     if app.llm == app::LlmProvider::OpenAI && std::env::var("OPENAI_API_KEY").is_err() {
         eprintln!(
             "[baro] WARNING: --llm openai requested but OPENAI_API_KEY is not set. \
@@ -879,6 +948,9 @@ async fn run_app(
                                         let sm = app.surgeon_model.clone();
                                         let ild = app.intra_level_delay_secs;
                                         let llm = app.llm;
+                                        let sllm = app.story_llm;
+                                        let cllm = app.critic_llm;
+                                        let surllm = app.surgeon_llm;
                                         let oak = app.openai_api_key.clone();
                                         let stm = app.story_model.clone();
                                         let err_tx = tx.clone();
@@ -909,7 +981,7 @@ async fn run_app(
                                                     return;
                                                 }
                                             }
-                                            spawn_executor(prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, openai_api_key: oak.clone(), story_model: stm.clone() });
+                                            spawn_executor(prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, story_llm: sllm, critic_llm: cllm, surgeon_llm: surllm, openai_api_key: oak.clone(), story_model: stm.clone() });
                                         });
                                     }
                                     Err(e) => {
@@ -950,6 +1022,9 @@ async fn run_app(
                                     let sm = app.surgeon_model.clone();
                                     let ild = app.intra_level_delay_secs;
                                     let llm = app.llm;
+                                    let sllm = app.story_llm;
+                                    let cllm = app.critic_llm;
+                                    let surllm = app.surgeon_llm;
                                     let oak = app.openai_api_key.clone();
                                     let stm = app.story_model.clone();
                                     let err_tx = tx.clone();
@@ -1000,7 +1075,7 @@ async fn run_app(
                                                 return;
                                             }
                                         }
-                                        spawn_executor(exec_prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, openai_api_key: oak.clone(), story_model: stm.clone() });
+                                        spawn_executor(exec_prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, story_llm: sllm, critic_llm: cllm, surgeon_llm: surllm, openai_api_key: oak.clone(), story_model: stm.clone() });
                                     });
                                 }
                             }
@@ -1093,7 +1168,13 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
     let architect_model = app.model_for_phase("architect");
     let context = app.claude_md_content.clone();
     let quick = app.quick;
-    let llm = app.llm;
+    // Per-phase routing: architect_llm and planner_llm let hybrid
+    // runs route Architect / Planner through Claude even when
+    // Story/Critic/Surgeon move to Codex (and vice versa). When the
+    // user didn't set per-phase overrides, both fall back to the
+    // global --llm value (set during CLI parsing).
+    let architect_llm = app.architect_llm;
+    let planner_llm = app.planner_llm;
     let openai_api_key = app.openai_api_key.clone();
 
     tokio::spawn(async move {
@@ -1114,7 +1195,7 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
             match architect_runner::run_architect(
                 &goal,
                 &cwd,
-                llm,
+                architect_llm,
                 architect_model.as_deref(),
                 context.as_deref(),
                 openai_api_key.as_deref(),
@@ -1148,7 +1229,7 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
         let result = planner_runner::run_planner(
             &goal,
             &cwd,
-            llm,
+            planner_llm,
             model.as_deref(),
             context.as_deref(),
             decision_doc.as_deref(),
@@ -1443,6 +1524,9 @@ fn spawn_executor(
         surgeon_model: config.surgeon_model,
         intra_level_delay_secs: config.intra_level_delay_secs,
         llm: config.llm.as_str().to_string(),
+        story_llm: config.story_llm.as_str().to_string(),
+        critic_llm: config.critic_llm.as_str().to_string(),
+        surgeon_llm: config.surgeon_llm.as_str().to_string(),
         openai_api_key: config.openai_api_key,
         story_model: config.story_model,
     };

--- a/crates/baro-tui/src/orchestrator_client.rs
+++ b/crates/baro-tui/src/orchestrator_client.rs
@@ -53,6 +53,14 @@ pub struct OrchestratorConfig {
     /// wired yet — a request for "openai" silently falls through to
     /// Claude behaviour until the per-phase siblings ship in 0.29+.
     pub llm: String,
+    /// Per-phase LLM overrides. Forwarded as `--story-llm` /
+    /// `--critic-llm` / `--surgeon-llm` only when they differ from
+    /// `llm` — that way pure-claude / pure-codex / pure-openai runs
+    /// have a clean command line and the orchestrator's startup
+    /// banner stays terse.
+    pub story_llm: String,
+    pub critic_llm: String,
+    pub surgeon_llm: String,
     /// OpenAI API key to inject as `OPENAI_API_KEY` into the
     /// orchestrator subprocess when `llm == "openai"`. The TUI gathers
     /// this from either the user's shell env or the ApiKeyInput
@@ -269,11 +277,29 @@ fn build_command(entry: &ScriptEntry, cfg: &OrchestratorConfig) -> Command {
         cmd.arg("--intra-level-delay").arg(d.to_string());
     }
     cmd.arg("--llm").arg(&cfg.llm);
+    // Per-phase overrides only sent when they DIFFER from the global
+    // `--llm`. Keeps the command line terse on pure-claude /
+    // pure-codex / pure-openai runs (no `--story-llm claude` noise
+    // when --llm claude already implies it).
+    if cfg.story_llm != cfg.llm {
+        cmd.arg("--story-llm").arg(&cfg.story_llm);
+    }
+    if cfg.critic_llm != cfg.llm {
+        cmd.arg("--critic-llm").arg(&cfg.critic_llm);
+    }
+    if cfg.surgeon_llm != cfg.llm {
+        cmd.arg("--surgeon-llm").arg(&cfg.surgeon_llm);
+    }
     // Only forward an explicitly-provided key. If openai_api_key is
     // None the user might still have the variable in their shell env;
     // tokio::Command inherits parent env by default, so it'll flow
     // through naturally without us touching it.
-    if cfg.llm == "openai" {
+    // If ANY phase uses openai, the API key needs to be available.
+    let uses_openai = cfg.llm == "openai"
+        || cfg.story_llm == "openai"
+        || cfg.critic_llm == "openai"
+        || cfg.surgeon_llm == "openai";
+    if uses_openai {
         if let Some(key) = &cfg.openai_api_key {
             cmd.env("OPENAI_API_KEY", key);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1660,7 +1660,7 @@
     },
     "packages/baro-app": {
       "name": "baro-ai",
-      "version": "0.43.3",
+      "version": "0.44.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/baro-app/package.json
+++ b/packages/baro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baro-ai",
-  "version": "0.43.3",
+  "version": "0.44.0",
   "description": "Autonomous parallel coding - plan and execute with AI",
   "type": "module",
   "bin": {

--- a/packages/baro-orchestrator/scripts/cli.ts
+++ b/packages/baro-orchestrator/scripts/cli.ts
@@ -43,6 +43,10 @@ interface CliArgs {
     storyModel?: string
     intraLevelDelaySecs?: number
     llm: "claude" | "openai" | "codex"
+    /** Optional per-phase overrides; each defaults to `llm`. */
+    storyLlm?: "claude" | "openai" | "codex"
+    criticLlm?: "claude" | "openai" | "codex"
+    surgeonLlm?: "claude" | "openai" | "codex"
     help: boolean
 }
 
@@ -134,6 +138,21 @@ function parseArgs(argv: string[]): CliArgs {
                 args.llm = v
                 break
             }
+            case "--story-llm":
+            case "--critic-llm":
+            case "--surgeon-llm": {
+                const v = required(argv, ++i, a)
+                if (v !== "claude" && v !== "openai" && v !== "codex") {
+                    process.stderr.write(
+                        `[cli] ${a} must be 'claude' | 'openai' | 'codex', got '${v}'\n`,
+                    )
+                    process.exit(2)
+                }
+                if (a === "--story-llm") args.storyLlm = v
+                else if (a === "--critic-llm") args.criticLlm = v
+                else args.surgeonLlm = v
+                break
+            }
             default:
                 process.stderr.write(`[cli] unknown flag: ${a}\n`)
                 process.exit(2)
@@ -215,6 +234,9 @@ async function main(): Promise<void> {
         surgeonModel: args.surgeonModel,
         intraLevelDelaySecs: args.intraLevelDelaySecs,
         llm: args.llm,
+        storyLlm: args.storyLlm,
+        criticLlm: args.criticLlm,
+        surgeonLlm: args.surgeonLlm,
         storyModel: args.storyModel,
     }
 

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -147,11 +147,24 @@ export interface OrchestrateConfig {
      * placeholder that runs the Claude flow.
      *
      * `"codex"` is the subscription-arbitrage path via OpenAI Codex CLI
-     * (ChatGPT Plus/Pro billing). v1: covers the Story phase; Architect
-     * + Planner + Critic + Surgeon fall back to Claude (codex-* siblings
-     * for those phases are a v2 follow-up).
+     * (ChatGPT Plus/Pro billing). All phases route through Codex.
+     *
+     * This `llm` field is the **default** every Story/Critic/Surgeon
+     * phase uses unless an explicit per-phase override
+     * (`storyLlm`/`criticLlm`/`surgeonLlm`) is set below. Architect +
+     * Planner phases are wired up in the Rust TUI layer, not here —
+     * orchestrate.ts doesn't see them.
      */
     llm?: "claude" | "openai" | "codex"
+    /**
+     * Optional per-phase overrides. When set, win over `llm`. Each can
+     * be any of the three providers, independent of the others. Used
+     * by the `--llm hybrid` preset (Story+Critic on Codex bulk-savings,
+     * Surgeon on Claude for rare-but-high-stakes failures).
+     */
+    storyLlm?: "claude" | "openai" | "codex"
+    criticLlm?: "claude" | "openai" | "codex"
+    surgeonLlm?: "claude" | "openai" | "codex"
     /**
      * Per-phase model override for StoryAgent. When set, wins over
      * each story's individual `model` field in the PRD as well as
@@ -189,25 +202,42 @@ export async function orchestrate(
     const env = new AgenticEnvironment()
     const emitTui = config.emitTuiEvents ?? true
     const llm: "claude" | "openai" | "codex" = config.llm ?? "claude"
+    // Per-phase resolution: each falls back to global `llm` when no
+    // explicit override is provided. This is the central place where
+    // hybrid configurations land — every downstream factory branches
+    // on storyLlm / criticLlm / surgeonLlm, not on the global `llm`.
+    const storyLlm = config.storyLlm ?? llm
+    const criticLlm = config.criticLlm ?? llm
+    const surgeonLlm = config.surgeonLlm ?? llm
 
     // Provider banner so the stderr / audit log makes the actual
     // routing obvious. As of 0.33 every LLM-using phase (Architect,
     // Planner, Critic, Surgeon, StoryAgent) routes end-to-end to the
     // selected provider — no mixed-mode anymore.
-    if (llm === "openai") {
+    // Per-phase banner so the audit log spells out exactly which
+    // backend each in-process phase uses. Architect + Planner are
+    // run by the Rust TUI as separate subprocesses — their llm
+    // routing is logged in their own banners.
+    const isHybrid =
+        new Set([storyLlm, criticLlm, surgeonLlm, llm]).size > 1
+    if (isHybrid) {
         process.stderr.write(
-            "[orchestrate] llm=openai: Architect, Planner, Critic, Surgeon, StoryAgent " +
-            "all running through Mozaik's native OpenAI runner (gpt-5.x).\n",
+            `[orchestrate] hybrid routing: story=${storyLlm} critic=${criticLlm} surgeon=${surgeonLlm} (default=${llm})\n`,
+        )
+    } else if (llm === "openai") {
+        process.stderr.write(
+            "[orchestrate] llm=openai: Story, Critic, Surgeon all running through " +
+                "Mozaik's native OpenAI runner (gpt-5.x).\n",
         )
     } else if (llm === "codex") {
         process.stderr.write(
-            "[orchestrate] llm=codex: every LLM phase shells out to `codex exec --json` " +
-            "(ChatGPT subscription path). Architect / Planner / Critic / Surgeon / StoryAgent " +
-            "all running through Codex.\n",
+            "[orchestrate] llm=codex: Story, Critic, Surgeon all shelling out to " +
+                "`codex exec --json` (ChatGPT subscription path).\n",
         )
     } else {
         process.stderr.write(
-            "[orchestrate] llm=claude: every LLM phase shells out to the Claude Code CLI.\n",
+            "[orchestrate] llm=claude: Story, Critic, Surgeon all shelling out to " +
+                "the Claude Code CLI.\n",
         )
     }
 
@@ -269,12 +299,12 @@ export async function orchestrate(
         // three — same ReplanItem shape — so downstream observers
         // (Conductor's replan-applier, Auditor, kaleidoskop) don't
         // notice the swap.
-        if (llm === "openai") {
+        if (surgeonLlm === "openai") {
             surgeon = new SurgeonOpenAI({
                 snapshot,
                 model: config.surgeonModel ?? "gpt-5.5",
             })
-        } else if (llm === "codex") {
+        } else if (surgeonLlm === "codex") {
             surgeon = new SurgeonCodex({
                 snapshot,
                 useLlm: config.surgeonUseLlm ?? true,
@@ -305,12 +335,12 @@ export async function orchestrate(
         // CritiqueItem shape, same AgentTargetedMessageItem corrective
         // emission — so downstream observers (Cartographer, Auditor,
         // kaleidoskop) don't notice the swap.
-        if (llm === "openai") {
+        if (criticLlm === "openai") {
             critic = new CriticOpenAI({
                 targets,
                 model: config.criticModel ?? "gpt-5.4-mini",
             })
-        } else if (llm === "codex") {
+        } else if (criticLlm === "codex") {
             critic = new CriticCodex({
                 targets,
                 model: config.criticModel,
@@ -423,7 +453,7 @@ export async function orchestrate(
     // per-spawn, so future per-story overrides could live there too.
     const storyFactory = new StoryFactory({
         cwd: config.cwd,
-        llm,
+        llm: storyLlm,
         openaiModel: config.storyModel ?? "gpt-5.5",
         storyModelOverride: config.storyModel,
     })


### PR DESCRIPTION
Adds five new optional CLI flags — --architect-llm, --planner-llm, --story-llm, --critic-llm, --surgeon-llm — each accepting claude/openai/codex. Each defaults to global --llm.

New `--llm hybrid` preset = Claude for Architect/Planner/Surgeon (high-stakes, low-volume), Codex for Story+Critic (high-volume, cheap on subscription). Per-phase overrides win over the preset.

Pure-mode runs (`--llm claude/openai/codex`) are behaviour-identical to 0.43.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)