### PR TITLE
chore(ci): bump release workflow actions to Node 24 versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -57,7 +57,7 @@ jobs:
         run: cp target/${{ matrix.target }}/release/baro.exe ${{ matrix.artifact }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
@@ -66,20 +66,20 @@ jobs:
     needs: build-binary
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: binaries/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: binaries/**/*
           generate_release_notes: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
GitHub deprecated Node 20 on Actions runners — Node 24 becomes the default on 2026-06-02. Bumping each pinned major to whatever release moved to Node 24.

| Action | Was | Now |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/setup-node | v4 | v6 |
| softprops/action-gh-release | v2 | v3 |

Each bump targets the latest stable major. softprops v3.0.0 was the explicit Node 20 → Node 24 migration; the others are routine major bumps that happened to ship Node 24 along the way. Behavior contract is unchanged for our usage (single matrix upload per platform, single download in publish job, plain release creation with auto-generated notes).

Will only exercise on the next \`v*\` tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)