### PR TITLE
feat: support OPENAI_BASE_URL for custom OpenAI-compatible endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ baro --architect-llm claude \
      "Your goal"
 ```
 
+### Custom OpenAI-compatible endpoints
+
+Any provider that exposes an OpenAI-compatible Chat Completions API works with `--llm openai`. Set `OPENAI_BASE_URL` to point at your endpoint and pass any model name via `--story-model` (or let it use the default):
+
+```bash
+# Xiaomi MiMo
+OPENAI_API_KEY=your-key OPENAI_BASE_URL=https://api.mimo.xiaomi.com/v1 \
+  baro --llm openai --story-model MiMo-7B-RL "Your goal"
+
+# OpenRouter (any model)
+OPENAI_API_KEY=your-key OPENAI_BASE_URL=https://openrouter.ai/api/v1 \
+  baro --llm openai --story-model anthropic/claude-3.5-sonnet "Your goal"
+
+# Local vLLM / Ollama
+OPENAI_API_KEY=not-needed OPENAI_BASE_URL=http://localhost:11434/v1 \
+  baro --llm openai --story-model llama3 "Your goal"
+```
+
+The `--openai-base-url` flag also works (wins over the env var when both are set).
+
 Full breakdown at [docs.baro.rs/llm-providers](https://docs.baro.rs/llm-providers) — provider economics, per-phase routing, the side-by-side benchmark across three real tasks: [**I tested Claude Code vs OpenAI Codex in my parallel agent setup. Then I built a hybrid.**](https://jigjoy.ai/blog/claude-code-vs-codex-baro)
 
 ## Recent real run
@@ -135,6 +155,12 @@ baro --llm hybrid "Add WebSocket support across api and frontend"
 # Route every phase through GPT-5.5 (Mozaik-native OpenAI API)
 OPENAI_API_KEY=sk-... baro --llm openai "Refactor the database layer"
 
+# Route through any OpenAI-compatible endpoint (Xiaomi MiMo, OpenRouter, vLLM, Ollama, etc.)
+OPENAI_API_KEY=your-key OPENAI_BASE_URL=https://api.mimo.xiaomi.com/v1 baro --llm openai "Refactor the database layer"
+
+# Or use the CLI flag (flag wins over env var)
+OPENAI_API_KEY=your-key baro --llm openai --openai-base-url https://api.mimo.xiaomi.com/v1 "Refactor the database layer"
+
 # Limit parallelism (plan-tier concurrency caps)
 baro --parallel 3 "Add unit tests for the auth module"
 
@@ -168,6 +194,7 @@ For a deeper side-by-side on a real refactor, see [baro vs Claude Code `/goal`](
   - [Claude CLI](https://docs.anthropic.com/en/docs/claude-cli) authenticated (for `--llm claude`, the default)
   - [OpenAI Codex CLI](https://github.com/openai/codex) authenticated (for `--llm codex`)
   - `OPENAI_API_KEY` set (for `--llm openai`)
+  - `OPENAI_BASE_URL` set to a custom endpoint (optional, for `--llm openai` — routes through Xiaomi MiMo, OpenRouter, vLLM, Ollama, or any OpenAI-compatible API)
   - Both Claude CLI **and** Codex CLI authenticated (for `--llm hybrid`)
 - Node.js 20+
 - macOS (arm64/x64), Linux (x64/arm64), Windows (x64)

--- a/crates/baro-tui/Cargo.toml
+++ b/crates/baro-tui/Cargo.toml
@@ -13,7 +13,7 @@ crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 chrono = "0.4"
 which = "6"
 tempfile = "3"

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -205,6 +205,10 @@ pub struct App {
     // written to disk.
     pub api_key_input: String,
     pub openai_api_key: Option<String>,
+    /// Optional custom base URL for OpenAI-compatible API endpoints
+    /// (e.g. Xiaomi MiMo, OpenRouter, local vLLM). Read from
+    /// `OPENAI_BASE_URL` env var or `--openai-base-url` CLI flag.
+    pub openai_base_url: Option<String>,
     /// Effort level passed to spawned `claude` processes via
     /// `--effort` (low|medium|high|xhigh|max). Default "high". Set via
     /// `baro --effort`.
@@ -350,6 +354,7 @@ impl App {
             provider_picker_index: 0,
             api_key_input: String::new(),
             openai_api_key: None,
+            openai_base_url: None,
             effort: "high".to_string(),
 
             goal_input: String::new(),

--- a/crates/baro-tui/src/architect_runner.rs
+++ b/crates/baro-tui/src/architect_runner.rs
@@ -39,6 +39,7 @@ pub async fn run_architect(
     model: Option<&str>,
     context: Option<&str>,
     openai_api_key: Option<&str>,
+    openai_base_url: Option<&str>,
     effort: &str,
 ) -> Result<String, ProcessRunError> {
     let entry = discovery::locate_script(cwd, SCRIPT_REL_PATH, BUNDLE_NAME).map_err(|e| {
@@ -91,6 +92,9 @@ pub async fn run_architect(
     if matches!(llm, LlmProvider::OpenAI) {
         if let Some(key) = openai_api_key {
             cmd.env("OPENAI_API_KEY", key);
+        }
+        if let Some(url) = openai_base_url {
+            cmd.env("OPENAI_BASE_URL", url);
         }
     }
 

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -94,6 +94,9 @@ pub struct ExecutorConfig {
     /// in the shell env or typed into the ApiKeyInput screen). Forwarded
     /// to the orchestrator subprocess as an env var when `llm = OpenAI`.
     pub openai_api_key: Option<String>,
+    /// Optional custom base URL for OpenAI-compatible API endpoints.
+    /// Forwarded to the orchestrator subprocess as `OPENAI_BASE_URL`.
+    pub openai_base_url: Option<String>,
     /// Effort level for spawned `claude` processes, forwarded as
     /// `--effort` to the orchestrator subprocess. Default "high".
     pub effort: String,

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -243,6 +243,15 @@ struct Cli {
     #[arg(long, default_value = "claude", value_parser = ["claude", "openai", "codex", "hybrid"])]
     llm: String,
 
+    /// Custom base URL for OpenAI-compatible API endpoints. When set,
+    /// all OpenAI-routed calls (Architect, Planner, Story, Critic,
+    /// Surgeon) are sent to this URL instead of api.openai.com.
+    /// Useful for providers that expose an OpenAI-compatible API:
+    /// Xiaomi MiMo, OpenRouter, vLLM, Ollama, etc. Can also be set
+    /// via the OPENAI_BASE_URL environment variable (flag wins).
+    #[arg(long, env = "OPENAI_BASE_URL")]
+    openai_base_url: Option<String>,
+
     /// Per-phase overrides. Each accepts claude | openai | codex and
     /// wins over `--llm` (including the `hybrid` preset) for that one
     /// phase. Useful for surgical tuning: e.g. `--llm hybrid
@@ -573,8 +582,8 @@ async fn run_app(
         }
     }
 
-    // Pre-fill OpenAI key from env BEFORE the goal branching below.
-    // Was previously inside the no-goal else-branch — that meant
+    // Pre-fill OpenAI key and base URL from env BEFORE the goal branching below.
+    // Was previously inside the no-goal else-branch -- that meant
     // `baro --llm openai "<goal>"` skipped both the env-read AND the
     // API-key entry screen, so if the user didn't have OPENAI_API_KEY
     // in their shell the planner subprocess started with no key and
@@ -582,6 +591,14 @@ async fn run_app(
     if let Ok(env_key) = std::env::var("OPENAI_API_KEY") {
         if !env_key.is_empty() {
             app.openai_api_key = Some(env_key);
+        }
+    }
+    // --openai-base-url flag wins over the env var when both are set.
+    if let Some(ref url) = cli.openai_base_url {
+        app.openai_base_url = Some(url.clone());
+    } else if let Ok(env_url) = std::env::var("OPENAI_BASE_URL") {
+        if !env_url.is_empty() {
+            app.openai_base_url = Some(env_url);
         }
     }
 
@@ -970,6 +987,7 @@ async fn run_app(
                                         let cllm = app.critic_llm;
                                         let surllm = app.surgeon_llm;
                                         let oak = app.openai_api_key.clone();
+                                        let obu = app.openai_base_url.clone();
                                         let eff = app.effort.clone();
                                         let stm = app.story_model.clone();
                                         let err_tx = tx.clone();
@@ -1000,7 +1018,7 @@ async fn run_app(
                                                     return;
                                                 }
                                             }
-                                            spawn_executor(prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, story_llm: sllm, critic_llm: cllm, surgeon_llm: surllm, openai_api_key: oak.clone(), effort: eff.clone(), story_model: stm.clone() });
+                                            spawn_executor(prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, story_llm: sllm, critic_llm: cllm, surgeon_llm: surllm, openai_api_key: oak.clone(), openai_base_url: obu.clone(), effort: eff.clone(), story_model: stm.clone() });
                                         });
                                     }
                                     Err(e) => {
@@ -1045,6 +1063,7 @@ async fn run_app(
                                     let cllm = app.critic_llm;
                                     let surllm = app.surgeon_llm;
                                     let oak = app.openai_api_key.clone();
+                                    let obu = app.openai_base_url.clone();
                                     let eff = app.effort.clone();
                                     let stm = app.story_model.clone();
                                     let err_tx = tx.clone();
@@ -1098,7 +1117,7 @@ async fn run_app(
                                                 return;
                                             }
                                         }
-                                        spawn_executor(exec_prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, story_llm: sllm, critic_llm: cllm, surgeon_llm: surllm, openai_api_key: oak.clone(), effort: eff.clone(), story_model: stm.clone() });
+                                        spawn_executor(exec_prd, exec_cwd, branch_tx, executor::ExecutorConfig { parallel: pl, timeout_secs: ts, model_routing: mr, override_model: om, with_critic: wc, critic_model: cm, with_librarian: wl, with_sentry: ws, with_surgeon: wsg, surgeon_use_llm: sul, surgeon_model: sm, intra_level_delay_secs: ild, llm, story_llm: sllm, critic_llm: cllm, surgeon_llm: surllm, openai_api_key: oak.clone(), openai_base_url: obu.clone(), effort: eff.clone(), story_model: stm.clone() });
                                     });
                                 }
                             }
@@ -1199,6 +1218,7 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
     let architect_llm = app.architect_llm;
     let planner_llm = app.planner_llm;
     let openai_api_key = app.openai_api_key.clone();
+    let openai_base_url = app.openai_base_url.clone();
     let effort = app.effort.clone();
 
     tokio::spawn(async move {
@@ -1223,6 +1243,7 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
                 architect_model.as_deref(),
                 context.as_deref(),
                 openai_api_key.as_deref(),
+                openai_base_url.as_deref(),
                 &effort,
             ).await {
                 Ok(doc) => {
@@ -1260,6 +1281,7 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
             decision_doc.as_deref(),
             quick,
             openai_api_key.as_deref(),
+            openai_base_url.as_deref(),
             &effort,
         ).await;
 
@@ -1556,6 +1578,7 @@ fn spawn_executor(
         critic_llm: config.critic_llm.as_str().to_string(),
         surgeon_llm: config.surgeon_llm.as_str().to_string(),
         openai_api_key: config.openai_api_key,
+        openai_base_url: config.openai_base_url,
         effort: config.effort,
         story_model: config.story_model,
     };

--- a/crates/baro-tui/src/orchestrator_client.rs
+++ b/crates/baro-tui/src/orchestrator_client.rs
@@ -67,6 +67,10 @@ pub struct OrchestratorConfig {
     /// screen; it isn't written to disk. `None` is a no-op (any value
     /// already in the parent env is inherited normally).
     pub openai_api_key: Option<String>,
+    /// Optional custom base URL for OpenAI-compatible API endpoints
+    /// (e.g. Xiaomi MiMo, OpenRouter, local vLLM). Forwarded as
+    /// `OPENAI_BASE_URL` env var when any phase uses OpenAI.
+    pub openai_base_url: Option<String>,
     /// Effort level forwarded as `--effort` to the orchestrator
     /// subprocess (applies to the Claude story path). Default "high".
     pub effort: String,
@@ -305,6 +309,9 @@ fn build_command(entry: &ScriptEntry, cfg: &OrchestratorConfig) -> Command {
     if uses_openai {
         if let Some(key) = &cfg.openai_api_key {
             cmd.env("OPENAI_API_KEY", key);
+        }
+        if let Some(url) = &cfg.openai_base_url {
+            cmd.env("OPENAI_BASE_URL", url);
         }
     }
     if let Some(m) = &cfg.story_model {

--- a/crates/baro-tui/src/planner_runner.rs
+++ b/crates/baro-tui/src/planner_runner.rs
@@ -33,6 +33,7 @@ pub async fn run_planner(
     decision_doc: Option<&str>,
     quick: bool,
     openai_api_key: Option<&str>,
+    openai_base_url: Option<&str>,
     effort: &str,
 ) -> Result<String, ProcessRunError> {
     let entry = discovery::locate_script(cwd, SCRIPT_REL_PATH, BUNDLE_NAME).map_err(|e| {
@@ -75,6 +76,9 @@ pub async fn run_planner(
     if matches!(llm, LlmProvider::OpenAI) {
         if let Some(key) = openai_api_key {
             cmd.env("OPENAI_API_KEY", key);
+        }
+        if let Some(url) = openai_base_url {
+            cmd.env("OPENAI_BASE_URL", url);
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,6 +484,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.7.0.tgz",
+      "integrity": "sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -524,12 +548,13 @@
       }
     },
     "node_modules/@mozaik-ai/core": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@mozaik-ai/core/-/core-3.10.2.tgz",
-      "integrity": "sha512-vhwI1/SVtuSkOe/PkrLMNZEo0Ek2Qk3kITFsO2IVSbBuoMH92O/erkdld+hALMXSwl9iaFbbvXa8P/EKzMyICA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@mozaik-ai/core/-/core-3.12.0.tgz",
+      "integrity": "sha512-s6f2A2S58FiG1EmPzPwzbVzx6GrOLBs8/RcmXC8XE4STnyH5/ZYyJdxvCOJCxyc6NuboF6eS7JismXDRvatTvQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
+        "@google/genai": "^2.6.0",
         "dotenv": "^17.4.1",
         "openai": "^6.38.0",
         "zod": "^4.3.6"
@@ -543,6 +568,69 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.0",
@@ -905,11 +993,16 @@
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -924,6 +1017,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -934,6 +1036,41 @@
     "node_modules/baro-ai": {
       "resolved": "packages/baro-app",
       "link": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -1004,11 +1141,19 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1032,6 +1177,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/esbuild": {
@@ -1077,6 +1231,12 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1095,6 +1255,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
@@ -1105,6 +1288,18 @@
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fsevents": {
@@ -1122,6 +1317,34 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -1135,6 +1358,45 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -1143,6 +1405,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-schema-to-ts": {
@@ -1156,6 +1427,27 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lilconfig": {
@@ -1188,6 +1480,12 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1215,7 +1513,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -1228,6 +1525,44 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-assign": {
@@ -1259,6 +1594,19 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -1354,6 +1702,30 @@
         }
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1386,6 +1758,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -1432,6 +1813,26 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.7.6",
@@ -1636,8 +2037,37 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",
@@ -1671,7 +2101,7 @@
         "baro": "bin/baro"
       },
       "devDependencies": {
-        "@mozaik-ai/core": "3.10.2",
+        "@mozaik-ai/core": "3.12.0",
         "@types/node": "^22.0.0",
         "tsup": "^8.0.2",
         "tsx": "^4.21.0",
@@ -1682,7 +2112,7 @@
       "name": "@baro/orchestrator",
       "version": "0.0.1",
       "dependencies": {
-        "@mozaik-ai/core": "3.10.2"
+        "@mozaik-ai/core": "3.12.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/baro-app/package.json
+++ b/packages/baro-app/package.json
@@ -23,7 +23,7 @@
     "zod-to-json-schema": "^3.25.1"
   },
   "devDependencies": {
-    "@mozaik-ai/core": "3.10.2",
+    "@mozaik-ai/core": "3.12.0",
     "@types/node": "^22.0.0",
     "tsup": "^8.0.2",
     "tsx": "^4.21.0",

--- a/packages/baro-orchestrator/package.json
+++ b/packages/baro-orchestrator/package.json
@@ -12,8 +12,7 @@
         "typecheck": "tsc -p tsconfig.json --noEmit"
     },
     "dependencies": {
-        "@mozaik-ai/core": "3.10.2",
-        "openai": "6.38.0"
+        "@mozaik-ai/core": "3.12.0"
     },
     "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/baro-orchestrator/package.json
+++ b/packages/baro-orchestrator/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@mozaik-ai/core": "3.10.2",
-        "openai": "^6.38.0"
+        "openai": "6.38.0"
     },
     "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/baro-orchestrator/package.json
+++ b/packages/baro-orchestrator/package.json
@@ -12,7 +12,8 @@
         "typecheck": "tsc -p tsconfig.json --noEmit"
     },
     "dependencies": {
-        "@mozaik-ai/core": "3.10.2"
+        "@mozaik-ai/core": "3.10.2",
+        "openai": "^6.38.0"
     },
     "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/baro-orchestrator/src/participants/critic-openai.ts
+++ b/packages/baro-orchestrator/src/participants/critic-openai.ts
@@ -33,6 +33,7 @@ import {
 } from "@mozaik-ai/core"
 
 import {
+    GenericOpenAIModel,
     UsageAccumulator,
     runInferenceRound,
 } from "../planning/openai-runtime.js"
@@ -73,10 +74,10 @@ function pickModel(name: string): GenerativeModel {
         case "gpt-5.4-nano":
             return new Gpt54Nano()
         default:
-            throw new Error(
-                `CriticOpenAI: unknown model "${name}" — Mozaik 3.9 ships ` +
-                `gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano`,
+            process.stderr.write(
+                `[pickModel] Using model "${name}" as-is with the OpenAI API.\n`,
             )
+            return new GenericOpenAIModel(name)
     }
 }
 

--- a/packages/baro-orchestrator/src/participants/openai-story-agent.ts
+++ b/packages/baro-orchestrator/src/participants/openai-story-agent.ts
@@ -63,6 +63,7 @@ import {
 
 import { AgenticEnvironment } from "@mozaik-ai/core"
 import {
+    GenericOpenAIModel,
     UsageAccumulator,
     runInferenceRound,
 } from "../planning/openai-runtime.js"
@@ -514,10 +515,10 @@ function pickModel(name: string): GenerativeModel {
         case "gpt-5.4-nano":
             return new Gpt54Nano()
         default:
-            throw new Error(
-                `OpenAIStoryAgent: unknown model "${name}" — Mozaik 3.9 ships ` +
-                `gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano`,
+            process.stderr.write(
+                `[pickModel] Using model "${name}" as-is with the OpenAI API.\n`,
             )
+            return new GenericOpenAIModel(name)
     }
 }
 

--- a/packages/baro-orchestrator/src/participants/surgeon-openai.ts
+++ b/packages/baro-orchestrator/src/participants/surgeon-openai.ts
@@ -32,6 +32,7 @@ import {
 } from "@mozaik-ai/core"
 
 import {
+    GenericOpenAIModel,
     UsageAccumulator,
     runInferenceRound,
 } from "../planning/openai-runtime.js"
@@ -74,10 +75,10 @@ function pickModel(name: string): GenerativeModel {
         case "gpt-5.4-nano":
             return new Gpt54Nano()
         default:
-            throw new Error(
-                `SurgeonOpenAI: unknown model "${name}" — Mozaik 3.9 ships ` +
-                `gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano`,
+            process.stderr.write(
+                `[pickModel] Using model "${name}" as-is with the OpenAI API.\n`,
             )
+            return new GenericOpenAIModel(name)
     }
 }
 

--- a/packages/baro-orchestrator/src/planning/architect-openai.ts
+++ b/packages/baro-orchestrator/src/planning/architect-openai.ts
@@ -31,6 +31,7 @@ import {
 } from "@mozaik-ai/core"
 
 import {
+    GenericOpenAIModel,
     UsageAccumulator,
     runInferenceRound,
 } from "./openai-runtime.js"
@@ -73,10 +74,10 @@ function pickModel(name: string): GenerativeModel {
         case "gpt-5.4-nano":
             return new Gpt54Nano()
         default:
-            throw new Error(
-                `ArchitectOpenAI: unknown model "${name}" — Mozaik 3.9 ships ` +
-                `gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano`,
+            process.stderr.write(
+                `[pickModel] Using model "${name}" as-is with the OpenAI API.\n`,
             )
+            return new GenericOpenAIModel(name)
     }
 }
 

--- a/packages/baro-orchestrator/src/planning/openai-runtime.ts
+++ b/packages/baro-orchestrator/src/planning/openai-runtime.ts
@@ -1,6 +1,9 @@
 /**
- * OpenAI inference runtime wrapper — temporarily stubbed during the
- * Mozaik 3.10 migration.
+ * OpenAI inference runtime — drives multi-round chat completions via
+ * the official OpenAI SDK. The SDK reads `OPENAI_API_KEY` and
+ * `OPENAI_BASE_URL` from the environment, so this automatically
+ * supports any OpenAI-compatible endpoint (Xiaomi MiMo, OpenRouter,
+ * vLLM, etc.).
  *
  * Background: in Mozaik 3.9.x this file wrapped `OpenAIResponses`
  * (the lower-level ModelRuntime) so baro could drive its own multi-
@@ -10,26 +13,24 @@
  *
  * Mozaik 3.10 consolidated the public OpenAI inference API: it
  * removed `OpenAIResponses`, `InferenceRequest`, `InferenceResponse`,
- * and `InputStream` from the public exports. The migration plan
- * (memory: mozaik-3-10-blocker.md, "Blocker 2") is to either:
- *   (a) ask Mozaik to re-expose those internals, or
- *   (b) rewrite this file against the new `OpenAIInferenceRunner`
- *       once Mozaik exposes a per-call `TokenUsage` channel for it.
- *
- * Until that decision is made, calling `runInferenceRound` throws.
- * This is an explicit gap, not a workaround — the `--llm claude`
- * path through `claude-cli-participant.ts` is unaffected.
+ * and `InputStream` from the public exports. Rather than waiting for
+ * Mozaik to re-expose those internals, this file now calls the
+ * OpenAI Chat Completions API directly via the `openai` SDK.
  *
  * `UsageAccumulator` is still useful (it just sums TokenUsage shapes,
  * doesn't depend on the removed classes) and stays exported so its
  * call sites don't break.
  */
 
+import OpenAI from "openai"
 import {
     ContextItem,
+    FunctionCallItem,
+    ModelMessageItem,
     TokenUsage,
     type GenerativeModel,
     type ModelContext,
+    type Tool,
 } from "@mozaik-ai/core"
 
 export interface InferenceRound {
@@ -38,19 +39,196 @@ export interface InferenceRound {
 }
 
 /**
- * One inference call against the OpenAI Responses API. Throws during
- * the Mozaik 3.10 migration — see file header.
+ * A minimal `GenerativeModel` implementation for arbitrary model
+ * names that aren't shipped by Mozaik. The model name is forwarded
+ * as-is to the OpenAI Chat Completions API, which makes this work
+ * with any OpenAI-compatible endpoint.
+ */
+export class GenericOpenAIModel {
+    specification: { name: string }
+    private _tools: Tool[] = []
+
+    constructor(name: string) {
+        this.specification = { name }
+    }
+
+    setTools(tools: Tool[]): void {
+        this._tools = tools
+    }
+
+    getTools(): Tool[] {
+        return this._tools
+    }
+}
+
+/**
+ * One inference round against the OpenAI Chat Completions API.
+ *
+ * Converts the Mozaik `ModelContext` items into OpenAI message
+ * format, calls `chat.completions.create`, and converts the
+ * response back into Mozaik `ContextItem`-s so the caller's
+ * multi-round loop keeps working unchanged.
  */
 export async function runInferenceRound(
-    _context: ModelContext,
-    _model: GenerativeModel,
+    context: ModelContext,
+    model: GenerativeModel,
 ): Promise<InferenceRound> {
-    throw new Error(
-        "OpenAI inference path is temporarily disabled during the " +
-            "Mozaik 3.10 migration (see Blocker 2). Use `--llm claude` " +
-            "until OpenAIResponses / InferenceRequest are restored to " +
-            "the @mozaik-ai/core public API.",
+    const client = new OpenAI()
+    const modelName = model.specification.name
+
+    // ── 1. Convert context items → OpenAI messages ───────────────
+    const messages: OpenAI.ChatCompletionMessageParam[] = []
+
+    for (const item of context.items) {
+        const json = (item as any).toJSON()
+
+        switch (item.type) {
+            case "system": {
+                const content = extractText(json)
+                messages.push({ role: "system", content })
+                break
+            }
+            case "user": {
+                const content = extractText(json)
+                messages.push({ role: "user", content })
+                break
+            }
+            case "message": {
+                // Assistant text message
+                const text = json?.content?.[0]?.text ?? ""
+                if (text) {
+                    messages.push({ role: "assistant", content: text })
+                }
+                break
+            }
+            case "function_call": {
+                // Previous assistant tool call
+                const fc = item as unknown as {
+                    callId: string
+                    name: string
+                    args: string
+                }
+                messages.push({
+                    role: "assistant",
+                    content: null,
+                    tool_calls: [
+                        {
+                            id: fc.callId,
+                            type: "function",
+                            function: {
+                                name: fc.name,
+                                arguments: fc.args,
+                            },
+                        },
+                    ],
+                })
+                break
+            }
+            case "function_call_output": {
+                // Tool result
+                const fco = item as unknown as {
+                    callId: string
+                    content: string
+                }
+                messages.push({
+                    role: "tool",
+                    tool_call_id: fco.callId,
+                    content: fco.content,
+                })
+                break
+            }
+            case "reasoning": {
+                // Reasoning items are not part of the chat message
+                // format — skip them silently.
+                break
+            }
+            // Unknown item types are silently skipped.
+        }
+    }
+
+    // ── 2. Convert Mozaik tools → OpenAI function tools ──────────
+    const mozaikTools: Tool[] =
+        (model as any).getTools?.() ?? []
+
+    const openaiTools: OpenAI.ChatCompletionTool[] = mozaikTools.map(
+        (t: any) => ({
+            type: "function" as const,
+            function: {
+                name: t.name,
+                description: t.description,
+                parameters: t.parameters,
+                ...(t.strict !== undefined ? { strict: t.strict } : {}),
+            },
+        }),
     )
+
+    // ── 3. Call the API ──────────────────────────────────────────
+    const response = await client.chat.completions.create({
+        model: modelName,
+        messages,
+        ...(openaiTools.length > 0 ? { tools: openaiTools } : {}),
+    })
+
+    const choice = response.choices[0]
+    if (!choice) {
+        throw new Error(
+            `OpenAI returned no choices for model "${modelName}"`,
+        )
+    }
+
+    const assistant = choice.message
+
+    // ── 4. Convert response → Mozaik ContextItems ────────────────
+    const items: ContextItem[] = []
+
+    if (assistant.content) {
+        items.push(
+            ModelMessageItem.rehydrate({ text: assistant.content }),
+        )
+    }
+
+    if (assistant.tool_calls) {
+        for (const tc of assistant.tool_calls) {
+            items.push(
+                FunctionCallItem.rehydrate({
+                    callId: tc.id,
+                    name: tc.function.name,
+                    args: tc.function.arguments,
+                }),
+            )
+        }
+    }
+
+    // ── 5. Extract token usage ───────────────────────────────────
+    const usage: TokenUsage | undefined = response.usage
+        ? {
+              inputTokens: response.usage.prompt_tokens,
+              outputTokens: response.usage.completion_tokens,
+              totalTokens: response.usage.total_tokens,
+              inputTokenDetails: {
+                  cached_tokens:
+                      (response.usage as any).prompt_tokens_details
+                          ?.cached_tokens ?? 0,
+              },
+              outputTokenDetails: {
+                  reasoning_tokens:
+                      (response.usage as any).completion_tokens_details
+                          ?.reasoning_tokens ?? 0,
+              },
+          }
+        : undefined
+
+    return { items, usage }
+}
+
+/** Extract plain text from a Mozaik item's toJSON() payload. */
+function extractText(json: any): string {
+    if (typeof json === "string") return json
+    if (typeof json?.content === "string") return json.content
+    if (Array.isArray(json?.content) && json.content[0]?.text)
+        return json.content[0].text
+    if (typeof json?.text === "string") return json.text
+    return ""
 }
 
 /**

--- a/packages/baro-orchestrator/src/planning/openai-runtime.ts
+++ b/packages/baro-orchestrator/src/planning/openai-runtime.ts
@@ -1,32 +1,31 @@
 /**
- * OpenAI inference runtime — drives multi-round chat completions via
- * the official OpenAI SDK. The SDK reads `OPENAI_API_KEY` and
- * `OPENAI_BASE_URL` from the environment, so this automatically
- * supports any OpenAI-compatible endpoint (Xiaomi MiMo, OpenRouter,
- * vLLM, etc.).
+ * Mozaik-native inference runtime for the OpenAI-compatible backend —
+ * the single chokepoint every non-CLI phase (Architect, Planner, Story,
+ * Critic, Surgeon) routes its per-round inference through.
  *
- * Background: in Mozaik 3.9.x this file wrapped `OpenAIResponses`
- * (the lower-level ModelRuntime) so baro could drive its own multi-
- * round inference loops while still receiving per-call `TokenUsage`
- * — usage data that `OpenAIInferenceRunner` (the convenience layer)
- * deliberately discards.
+ * Inference goes through Mozaik's `OpenAICompatibleChatCompletions`
+ * runtime, which speaks the OpenAI **Chat Completions** dialect against
+ * a configurable base URL. The OpenAI SDK inside Mozaik reads
+ * `OPENAI_API_KEY` and `OPENAI_BASE_URL` from the environment (baro's
+ * Rust layer forwards both), so the same code path serves real OpenAI
+ * and any OpenAI-compatible endpoint — DeepSeek, OpenRouter, vLLM,
+ * Ollama, Xiaomi MiMo, etc.
  *
- * Mozaik 3.10 consolidated the public OpenAI inference API: it
- * removed `OpenAIResponses`, `InferenceRequest`, `InferenceResponse`,
- * and `InputStream` from the public exports. Rather than waiting for
- * Mozaik to re-expose those internals, this file now calls the
- * OpenAI Chat Completions API directly via the `openai` SDK.
+ * Mozaik owns the `ModelContext` ⇄ chat-message conversion (including
+ * the tricky bits: merging consecutive/parallel tool calls into one
+ * assistant message, tool-result mapping, token-usage extraction), so
+ * baro no longer hand-rolls any of it. Provider-only request fields
+ * (e.g. DeepSeek's `thinking`) would be passed via the runtime's
+ * `extraBody` config if/when needed.
  *
- * `UsageAccumulator` is still useful (it just sums TokenUsage shapes,
- * doesn't depend on the removed classes) and stays exported so its
- * call sites don't break.
+ * `UsageAccumulator` sums per-round `TokenUsage`-s and is provider-
+ * agnostic.
  */
 
-import OpenAI from "openai"
 import {
     ContextItem,
-    FunctionCallItem,
-    ModelMessageItem,
+    InferenceRequest,
+    OpenAICompatibleChatCompletions,
     TokenUsage,
     type GenerativeModel,
     type ModelContext,
@@ -39,17 +38,28 @@ export interface InferenceRound {
 }
 
 /**
- * A minimal `GenerativeModel` implementation for arbitrary model
- * names that aren't shipped by Mozaik. The model name is forwarded
- * as-is to the OpenAI Chat Completions API, which makes this work
- * with any OpenAI-compatible endpoint.
+ * A minimal `GenerativeModel` for arbitrary model names that aren't
+ * shipped by Mozaik. The name is forwarded as-is to the Chat
+ * Completions API, which makes any OpenAI-compatible endpoint usable
+ * via `--story-model <name>` (e.g. `deepseek-chat`, `llama3`,
+ * `anthropic/claude-3.5-sonnet` on OpenRouter).
  */
-export class GenericOpenAIModel {
-    specification: { name: string }
+export class GenericOpenAIModel implements GenerativeModel {
+    readonly specification: GenerativeModel["specification"]
     private _tools: Tool[] = []
+    private _reasoningEffort = "medium"
+    private _streaming = false
 
     constructor(name: string) {
-        this.specification = { name }
+        this.specification = {
+            name,
+            supportReasoningEffort: false,
+            defaultReasoningEffort: undefined,
+            supportStreaming: false,
+            contextWindowSize: 128_000,
+            maxOutputTokens: 16_384,
+            supportFunctionCalling: true,
+        }
     }
 
     setTools(tools: Tool[]): void {
@@ -59,176 +69,47 @@ export class GenericOpenAIModel {
     getTools(): Tool[] {
         return this._tools
     }
+
+    // Capability methods are no-ops: a generic chat model carries no
+    // Mozaik-side reasoning-effort or streaming state. With
+    // `supportReasoningEffort: false`, the runtime sends no
+    // reasoning_effort field for it.
+    setReasoningEffort(effort: string): void {
+        this._reasoningEffort = effort
+    }
+
+    getReasoningEffort(): string {
+        return this._reasoningEffort
+    }
+
+    setStreaming(streaming: boolean): void {
+        this._streaming = streaming
+    }
+
+    getStreaming(): boolean {
+        return this._streaming
+    }
 }
 
+// Cached module-level: the runtime is stateless aside from its vendor
+// SDK client, which reads the API key + base URL from the env once at
+// construction. Re-instantiating per round would rebuild the client
+// (and re-read the env) on every call.
+let runtime: OpenAICompatibleChatCompletions | undefined
+
 /**
- * One inference round against the OpenAI Chat Completions API.
- *
- * Converts the Mozaik `ModelContext` items into OpenAI message
- * format, calls `chat.completions.create`, and converts the
- * response back into Mozaik `ContextItem`-s so the caller's
- * multi-round loop keeps working unchanged.
+ * One inference round against the configured OpenAI-compatible endpoint.
+ * Delegates the heavy lifting (message conversion, tool-call round-trip,
+ * usage extraction) to Mozaik's runtime and returns the new context
+ * items plus this round's `TokenUsage`.
  */
 export async function runInferenceRound(
     context: ModelContext,
     model: GenerativeModel,
 ): Promise<InferenceRound> {
-    const client = new OpenAI()
-    const modelName = model.specification.name
-
-    // ── 1. Convert context items → OpenAI messages ───────────────
-    const messages: OpenAI.ChatCompletionMessageParam[] = []
-
-    for (const item of context.items) {
-        const json = (item as any).toJSON()
-
-        switch (item.type) {
-            case "system": {
-                const content = extractText(json)
-                messages.push({ role: "system", content })
-                break
-            }
-            case "user": {
-                const content = extractText(json)
-                messages.push({ role: "user", content })
-                break
-            }
-            case "message": {
-                // Assistant text message
-                const text = json?.content?.[0]?.text ?? ""
-                if (text) {
-                    messages.push({ role: "assistant", content: text })
-                }
-                break
-            }
-            case "function_call": {
-                // Previous assistant tool call
-                const fc = item as unknown as {
-                    callId: string
-                    name: string
-                    args: string
-                }
-                messages.push({
-                    role: "assistant",
-                    content: null,
-                    tool_calls: [
-                        {
-                            id: fc.callId,
-                            type: "function",
-                            function: {
-                                name: fc.name,
-                                arguments: fc.args,
-                            },
-                        },
-                    ],
-                })
-                break
-            }
-            case "function_call_output": {
-                // Tool result
-                const fco = item as unknown as {
-                    callId: string
-                    content: string
-                }
-                messages.push({
-                    role: "tool",
-                    tool_call_id: fco.callId,
-                    content: fco.content,
-                })
-                break
-            }
-            case "reasoning": {
-                // Reasoning items are not part of the chat message
-                // format — skip them silently.
-                break
-            }
-            // Unknown item types are silently skipped.
-        }
-    }
-
-    // ── 2. Convert Mozaik tools → OpenAI function tools ──────────
-    const mozaikTools: Tool[] =
-        (model as any).getTools?.() ?? []
-
-    const openaiTools: OpenAI.ChatCompletionTool[] = mozaikTools.map(
-        (t: any) => ({
-            type: "function" as const,
-            function: {
-                name: t.name,
-                description: t.description,
-                parameters: t.parameters,
-                ...(t.strict !== undefined ? { strict: t.strict } : {}),
-            },
-        }),
-    )
-
-    // ── 3. Call the API ──────────────────────────────────────────
-    const response = await client.chat.completions.create({
-        model: modelName,
-        messages,
-        ...(openaiTools.length > 0 ? { tools: openaiTools } : {}),
-    })
-
-    const choice = response.choices[0]
-    if (!choice) {
-        throw new Error(
-            `OpenAI returned no choices for model "${modelName}"`,
-        )
-    }
-
-    const assistant = choice.message
-
-    // ── 4. Convert response → Mozaik ContextItems ────────────────
-    const items: ContextItem[] = []
-
-    if (assistant.content) {
-        items.push(
-            ModelMessageItem.rehydrate({ text: assistant.content }),
-        )
-    }
-
-    if (assistant.tool_calls) {
-        for (const tc of assistant.tool_calls) {
-            items.push(
-                FunctionCallItem.rehydrate({
-                    callId: tc.id,
-                    name: tc.function.name,
-                    args: tc.function.arguments,
-                }),
-            )
-        }
-    }
-
-    // ── 5. Extract token usage ───────────────────────────────────
-    const usage: TokenUsage | undefined = response.usage
-        ? {
-              inputTokens: response.usage.prompt_tokens,
-              outputTokens: response.usage.completion_tokens,
-              totalTokens: response.usage.total_tokens,
-              inputTokenDetails: {
-                  cached_tokens:
-                      (response.usage as any).prompt_tokens_details
-                          ?.cached_tokens ?? 0,
-              },
-              outputTokenDetails: {
-                  reasoning_tokens:
-                      (response.usage as any).completion_tokens_details
-                          ?.reasoning_tokens ?? 0,
-              },
-          }
-        : undefined
-
-    return { items, usage }
-}
-
-/** Extract plain text from a Mozaik item's toJSON() payload. */
-function extractText(json: any): string {
-    if (typeof json === "string") return json
-    if (typeof json?.content === "string") return json.content
-    if (Array.isArray(json?.content) && json.content[0]?.text)
-        return json.content[0].text
-    if (typeof json?.text === "string") return json.text
-    return ""
+    runtime ??= new OpenAICompatibleChatCompletions()
+    const response = await runtime.infer(new InferenceRequest(model, context))
+    return { items: response.contextItems, usage: response.tokenUsage }
 }
 
 /**

--- a/packages/baro-orchestrator/src/planning/planner-openai.ts
+++ b/packages/baro-orchestrator/src/planning/planner-openai.ts
@@ -28,6 +28,7 @@ import {
 } from "@mozaik-ai/core"
 
 import {
+    GenericOpenAIModel,
     UsageAccumulator,
     runInferenceRound,
 } from "./openai-runtime.js"
@@ -73,10 +74,10 @@ function pickModel(name: string): GenerativeModel {
         case "gpt-5.4-nano":
             return new Gpt54Nano()
         default:
-            throw new Error(
-                `PlannerOpenAI: unknown model "${name}" — Mozaik 3.9 ships ` +
-                `gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano`,
+            process.stderr.write(
+                `[pickModel] Using model "${name}" as-is with the OpenAI API.\n`,
             )
+            return new GenericOpenAIModel(name)
     }
 }
 


### PR DESCRIPTION
## Summary

Add `OPENAI_BASE_URL` env var and `--openai-base-url` CLI flag so baro can route through any OpenAI-compatible endpoint (Xiaomi MiMo, OpenRouter, vLLM, Ollama, etc.) instead of only `api.openai.com`.

### Rust side
- Add `--openai-base-url` CLI flag (`env: OPENAI_BASE_URL`, flag wins over env)
- Read `OPENAI_BASE_URL` from env on startup
- Forward `OPENAI_BASE_URL` to architect, planner, and orchestrator subprocesses via env injection (same pattern as `OPENAI_API_KEY`)

### TypeScript side
- Rewrite `openai-runtime.ts` to use the OpenAI SDK directly (replaces the disabled Mozaik 3.10 migration stub that threw on every call)
- Add `GenericOpenAIModel` class for arbitrary model names (not just `gpt-5.x`)
- Update `pickModel` in all 5 OpenAI participants to accept any model name — known `gpt-5.x` models use Mozaik wrappers, unknown names fall through to `GenericOpenAIModel`

### Docs
- Add "Custom OpenAI-compatible endpoints" section with Xiaomi MiMo, OpenRouter, and vLLM examples
- Update "Try it" section with `OPENAI_BASE_URL` usage
- Update Requirements section to mention `OPENAI_BASE_URL`

## Usage

```bash
# Xiaomi MiMo
OPENAI_API_KEY=*** OPENAI_BASE_URL=https://api.mimo.xiaomi.com/v1 \
  baro --llm openai --story-model MiMo-7B-RL "Your goal"

# OpenRouter
OPENAI_API_KEY=*** OPENAI_BASE_URL=https://openrouter.ai/api/v1 \
  baro --llm openai "Your goal"

# Or use the CLI flag
OPENAI_API_KEY=*** baro --llm openai --openai-base-url https://api.mimo.xiaomi.com/v1 "Your goal"
```

## Notes
- The `--openai-base-url` flag wins over the `OPENAI_BASE_URL` env var when both are set
- The OpenAI SDK natively reads `OPENAI_BASE_URL` from the environment, so the TypeScript side requires no special handling
- Known models (`gpt-5.5`, `gpt-5.4`, etc.) continue using Mozaik wrappers; any other model name uses the new `GenericOpenAIModel` which passes the name as-is to the OpenAI API