### PR TITLE
feat: add OpenCode as a new agentic backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,16 @@ baro --llm opencode -m openai/gpt-4o "Your goal"
 # OpenCode with a local model (LM Studio, Ollama, etc.)
 baro --llm opencode -m lmstudio/qwen3-coder "Your goal"
 
-# Mix: Claude plans, OpenCode executes stories
+# Mix: Claude plans, OpenCode executes stories.
+# Note: `-m` is a GLOBAL override applied to every phase, so it can't be
+# combined with a Claude/OpenCode split (a provider/model string would be
+# handed to the Claude phases too, which only accept opus/sonnet/haiku).
+# Let OpenCode pick its configured default for the story phase instead.
 baro --architect-llm claude --planner-llm claude \
-     --story-llm opencode -m anthropic/claude-sonnet-4 "Your goal"
+     --story-llm opencode "Your goal"
 ```
 
-OpenCode manages its own API keys via `opencode providers` — no additional env vars needed for baro. Runs with `--dangerously-skip-permissions` for unattended execution in baro's per-story worktrees.
+OpenCode manages its own API keys and per-provider model defaults via `opencode providers` — no additional env vars needed for baro, and no `-m` required when you're happy with the OpenCode default. `-m provider/model` sets the model for **all** phases at once, so use it only when every phase runs on a non-Claude backend (e.g. `--llm opencode`). Runs with `--dangerously-skip-permissions` for unattended execution in baro's per-story worktrees.
 
 Full breakdown at [docs.baro.rs/llm-providers](https://docs.baro.rs/llm-providers) — provider economics, per-phase routing, the side-by-side benchmark across three real tasks: [**I tested Claude Code vs OpenAI Codex in my parallel agent setup. Then I built a hybrid.**](https://jigjoy.ai/blog/claude-code-vs-codex-baro)
 

--- a/README.md
+++ b/README.md
@@ -69,15 +69,16 @@ flowchart LR
     F --> PR([Pull Request])
 ```
 
-Every story is one CLI subprocess — Claude Code, OpenAI Codex CLI, or a Mozaik-native OpenAI Responses session, depending on `--llm`. Auth inherits from whichever CLI you already have signed in, no API key plumbing.
+Every story is one CLI subprocess — Claude Code, OpenAI Codex CLI, OpenCode, or a Mozaik-native OpenAI Responses session, depending on `--llm`. Auth inherits from whichever CLI you already have signed in, no API key plumbing.
 
-## Three LLM backends, one DAG
+## Four LLM backends, one DAG
 
 ```bash
-baro --llm claude  "Your goal"   # default — Claude Code on Anthropic Max subscription
-baro --llm codex   "Your goal"   # OpenAI Codex CLI on ChatGPT Pro/Plus subscription
-baro --llm openai  "Your goal"   # Mozaik-native OpenAI Responses (per-call API billing)
-baro --llm hybrid  "Your goal"   # Claude on Architect/Planner/Surgeon, Codex on Story/Critic
+baro --llm claude    "Your goal"   # default — Claude Code on Anthropic Max subscription
+baro --llm codex     "Your goal"   # OpenAI Codex CLI on ChatGPT Pro/Plus subscription
+baro --llm openai    "Your goal"   # Mozaik-native OpenAI Responses (per-call API billing)
+baro --llm opencode  "Your goal"   # OpenCode CLI — multi-provider agent shell (any model)
+baro --llm hybrid    "Your goal"   # Claude on Architect/Planner/Surgeon, Codex on Story/Critic
 ```
 
 Same orchestration. Same DAG. Same prompts. The only thing that moves is which provider every agent talks to. `--llm hybrid` is the new default-recommendation for serious runs — Claude where the upstream plan matters, Codex for the parallel story+critic work that dominates the budget.
@@ -85,11 +86,11 @@ Same orchestration. Same DAG. Same prompts. The only thing that moves is which p
 Each phase has its own override flag if you want to mix it yourself:
 
 ```bash
-baro --architect-llm claude \
-     --planner-llm  claude \
-     --story-llm    codex  \
-     --critic-llm   codex  \
-     --surgeon-llm  claude \
+baro --architect-llm claude   \
+     --planner-llm  claude   \
+     --story-llm    opencode \
+     --critic-llm   codex    \
+     --surgeon-llm  claude   \
      "Your goal"
 ```
 
@@ -112,6 +113,27 @@ OPENAI_API_KEY=not-needed OPENAI_BASE_URL=http://localhost:11434/v1 \
 ```
 
 The `--openai-base-url` flag also works (wins over the env var when both are set).
+
+### OpenCode (multi-provider agent shell)
+
+[OpenCode](https://opencode.ai) is an open-source coding agent that supports any LLM provider. With `--llm opencode`, baro delegates story execution to the `opencode` CLI. Model selection uses the `-m provider/model` format:
+
+```bash
+# OpenCode with Anthropic Claude
+baro --llm opencode -m anthropic/claude-sonnet-4 "Your goal"
+
+# OpenCode with OpenAI
+baro --llm opencode -m openai/gpt-4o "Your goal"
+
+# OpenCode with a local model (LM Studio, Ollama, etc.)
+baro --llm opencode -m lmstudio/qwen3-coder "Your goal"
+
+# Mix: Claude plans, OpenCode executes stories
+baro --architect-llm claude --planner-llm claude \
+     --story-llm opencode -m anthropic/claude-sonnet-4 "Your goal"
+```
+
+OpenCode manages its own API keys via `opencode providers` — no additional env vars needed for baro. Runs with `--dangerously-skip-permissions` for unattended execution in baro's per-story worktrees.
 
 Full breakdown at [docs.baro.rs/llm-providers](https://docs.baro.rs/llm-providers) — provider economics, per-phase routing, the side-by-side benchmark across three real tasks: [**I tested Claude Code vs OpenAI Codex in my parallel agent setup. Then I built a hybrid.**](https://jigjoy.ai/blog/claude-code-vs-codex-baro)
 
@@ -139,7 +161,7 @@ A story's route can name **any** backend (`claude:opus`, `openai:MiniMax-M3`, `c
 | **Architect** | One Opus call before planning — emits a `DecisionDocument` that pins every cross-cutting design decision (file paths, schemas, API shapes, library choices) so 30 parallel agents don't each invent their own |
 | **Planner** | Decomposes the goal into a story DAG, with the DecisionDocument already pinned |
 | **Conductor** | State machine that drives the run by reacting to bus events |
-| **StoryAgent** | One CLI subprocess per story (Claude Code / Codex / OpenAI Responses, picked by `--llm` or `--story-llm`); multi-turn loop until story completes |
+| **StoryAgent** | One CLI subprocess per story (Claude Code / Codex / OpenCode / OpenAI Responses, picked by `--llm` or `--story-llm`); multi-turn loop until story completes |
 | **Critic** | Per-turn evaluator (Haiku). On fail verdict, injects corrective feedback as the agent's next turn |
 | **Sentry** | Flags overlapping Edit/Write tool calls across concurrent stories |
 | **Librarian** | Indexes one agent's Read/Grep findings so siblings don't redo the exploration |
@@ -255,6 +277,7 @@ The memory system adds ~1s startup overhead (ONNX model load) and negligible per
 - At least one of:
   - [Claude CLI](https://docs.anthropic.com/en/docs/claude-cli) authenticated (for `--llm claude`, the default)
   - [OpenAI Codex CLI](https://github.com/openai/codex) authenticated (for `--llm codex`)
+  - [OpenCode CLI](https://opencode.ai) with a provider configured (for `--llm opencode`)
   - `OPENAI_API_KEY` set (for `--llm openai`)
   - `OPENAI_BASE_URL` set to a custom endpoint (optional, for `--llm openai` — routes through Xiaomi MiMo, OpenRouter, vLLM, Ollama, or any OpenAI-compatible API)
   - Both Claude CLI **and** Codex CLI authenticated (for `--llm hybrid`)

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -346,6 +346,13 @@ pub struct App {
     pub story_llm: LlmProvider,
     pub critic_llm: LlmProvider,
     pub surgeon_llm: LlmProvider,
+    /// True when the user passed `--llm` explicitly (any value, including
+    /// `claude` and `hybrid`). The provider picker is shown only when no
+    /// `--llm` was given — keying on `llm != Claude` was wrong because
+    /// the `hybrid` preset and an explicit `--llm claude` both resolve
+    /// `llm` to Claude, which wrongly re-prompted (and, for hybrid, the
+    /// picker then collapsed the per-phase split).
+    pub llm_explicitly_set: bool,
 
     // Notification flag
     pub notification_ready: bool,
@@ -451,6 +458,7 @@ impl App {
             story_llm: LlmProvider::Claude,
             critic_llm: LlmProvider::Claude,
             surgeon_llm: LlmProvider::Claude,
+            llm_explicitly_set: false,
             token_usage: HashMap::new(),
             total_input_tokens: 0,
             total_output_tokens: 0,
@@ -508,7 +516,15 @@ impl App {
             .unwrap_or(0)
     }
 
-    // Planner toggle
+    // Planner toggle (Welcome screen radio). Cycles the backend AND
+    // reconciles it into the routing fields. Execution routes off
+    // `llm` / `*_llm` / `model_for_phase` — NOT the legacy `planner`
+    // enum — so mutating `planner` alone (the old behaviour) left the
+    // radio cosmetic: picking opencode/codex/openai on the Welcome
+    // screen still ran every phase on Claude. We now propagate the
+    // selection to all routing fields so the chosen backend actually
+    // drives the run, matching what the ProviderPicker Enter handler
+    // does.
     pub fn toggle_planner(&mut self) {
         self.planner = match self.planner {
             Planner::Claude => Planner::OpenAI,
@@ -516,6 +532,18 @@ impl App {
             Planner::Codex => Planner::OpenCode,
             Planner::OpenCode => Planner::Claude,
         };
+        let provider = match self.planner {
+            Planner::Claude => LlmProvider::Claude,
+            Planner::OpenAI => LlmProvider::OpenAI,
+            Planner::Codex => LlmProvider::Codex,
+            Planner::OpenCode => LlmProvider::OpenCode,
+        };
+        self.llm = provider;
+        self.architect_llm = provider;
+        self.planner_llm = provider;
+        self.story_llm = provider;
+        self.critic_llm = provider;
+        self.surgeon_llm = provider;
     }
 
     // Execute screen tab navigation

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -28,6 +28,8 @@ pub enum Screen {
 pub enum Planner {
     Claude,
     OpenAI,
+    Codex,
+    OpenCode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -202,10 +204,13 @@ pub struct App {
     pub planner: Planner,
 
     // Provider-picker screen (first step when invoked without a goal).
-    // 0 = Claude Code, 1 = Mozaik native (OpenAI). Stored as an index
-    // for trivial up/down handling; the chosen LlmProvider lands in
-    // `self.llm` on confirm.
+    // Index into `provider_picker_options`; the chosen LlmProvider
+    // lands in `self.llm` on confirm.
     pub provider_picker_index: usize,
+    /// Available backends for the picker, populated at startup. Claude
+    /// and OpenAI are always present; Codex and OpenCode are added when
+    /// their CLI is detected on PATH.
+    pub provider_picker_options: Vec<LlmProvider>,
 
     // API-key input screen — buffer for the in-progress text. The
     // confirmed key (whether from this input or the environment) is
@@ -367,6 +372,16 @@ impl App {
             planner: Planner::Claude,
 
             provider_picker_index: 0,
+            provider_picker_options: {
+                let mut opts = vec![LlmProvider::Claude, LlmProvider::OpenAI];
+                if which::which("codex").is_ok() {
+                    opts.push(LlmProvider::Codex);
+                }
+                if which::which("opencode").is_ok() {
+                    opts.push(LlmProvider::OpenCode);
+                }
+                opts
+            },
             api_key_input: String::new(),
             openai_api_key: None,
             openai_base_url: None,
@@ -497,7 +512,9 @@ impl App {
     pub fn toggle_planner(&mut self) {
         self.planner = match self.planner {
             Planner::Claude => Planner::OpenAI,
-            Planner::OpenAI => Planner::Claude,
+            Planner::OpenAI => Planner::Codex,
+            Planner::Codex => Planner::OpenCode,
+            Planner::OpenCode => Planner::Claude,
         };
     }
 

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -121,6 +121,12 @@ pub enum LlmProvider {
     /// Implementation: `packages/baro-orchestrator/src/participants/
     /// codex-cli-participant.ts`.
     Codex,
+    /// OpenCode CLI subprocess. Multi-provider agent shell that outputs
+    /// JSONL via `opencode run --format json`. Supports any model via
+    /// `-m provider/model` flag. One-shot non-interactive invocation.
+    /// Implementation: `packages/baro-orchestrator/src/participants/
+    /// opencode-cli-participant.ts`.
+    OpenCode,
 }
 
 impl LlmProvider {
@@ -129,6 +135,7 @@ impl LlmProvider {
             Self::Claude => "claude",
             Self::OpenAI => "openai",
             Self::Codex => "codex",
+            Self::OpenCode => "opencode",
         }
     }
 
@@ -137,6 +144,7 @@ impl LlmProvider {
             "claude" => Some(Self::Claude),
             "openai" => Some(Self::OpenAI),
             "codex" => Some(Self::Codex),
+            "opencode" => Some(Self::OpenCode),
             _ => None,
         }
     }
@@ -1002,6 +1010,12 @@ impl App {
                     Some("gpt-5.5".to_string())
                 }
                 (LlmProvider::OpenAI, "review") => Some("gpt-5.4-mini".to_string()),
+                // OpenCode supports any provider/model — use anthropic/claude-sonnet-4
+                // for heavy phases and a smaller model for review/critic.
+                (LlmProvider::OpenCode, "architect" | "planning" | "execution" | "story") => {
+                    Some("anthropic/claude-sonnet-4".to_string())
+                }
+                (LlmProvider::OpenCode, "review") => Some("anthropic/claude-haiku-3".to_string()),
                 _ => None,
             };
         }

--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -1010,12 +1010,11 @@ impl App {
                     Some("gpt-5.5".to_string())
                 }
                 (LlmProvider::OpenAI, "review") => Some("gpt-5.4-mini".to_string()),
-                // OpenCode supports any provider/model — use anthropic/claude-sonnet-4
-                // for heavy phases and a smaller model for review/critic.
-                (LlmProvider::OpenCode, "architect" | "planning" | "execution" | "story") => {
-                    Some("anthropic/claude-sonnet-4".to_string())
-                }
-                (LlmProvider::OpenCode, "review") => Some("anthropic/claude-haiku-3".to_string()),
+                // OpenCode: no hardcoded model — let it use whatever the
+                // user configured in their opencode setup. Returning None
+                // means the TS side passes no --model flag and opencode
+                // picks its own default provider + model.
+                (LlmProvider::OpenCode, _) => None,
                 _ => None,
             };
         }

--- a/crates/baro-tui/src/doctor.rs
+++ b/crates/baro-tui/src/doctor.rs
@@ -46,6 +46,7 @@ pub async fn run() -> i32 {
     results.push(check_claude_version().await);
     results.push(check_claude_print_call().await);
     results.push(check_codex_on_path().await);
+    results.push(check_opencode_on_path().await);
     results.push(check_gh_on_path().await);
     results.push(check_audit_dir_writable().await);
 
@@ -198,6 +199,24 @@ async fn check_codex_on_path() -> CheckResult {
             "codex on PATH (optional, used for --llm codex)",
             "binary not found",
             "Install OpenAI Codex CLI from https://developers.openai.com/codex/cli if you want the `--llm codex` subscription path; otherwise this check is informational and Claude / OpenAI routes still work.",
+        ),
+    }
+}
+
+/// Verify `opencode` binary is reachable (optional — only needed for
+/// `baro --llm opencode`). Soft failure: opencode is optional
+/// infrastructure for the OpenCode backend; not having it doesn't
+/// block Claude, OpenAI, or Codex workflows.
+async fn check_opencode_on_path() -> CheckResult {
+    match which::which("opencode") {
+        Ok(path) => CheckResult::pass(
+            "opencode on PATH (optional, used for --llm opencode)",
+            format!("{}", path.display()),
+        ),
+        Err(_) => CheckResult::fail(
+            "opencode on PATH (optional, used for --llm opencode)",
+            "binary not found",
+            "Install opencode from https://opencode.ai if you want the `--llm opencode` multi-provider path; otherwise this check is informational and other routes still work.",
         ),
     }
 }

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -165,8 +165,14 @@ struct Cli {
     #[arg(long)]
     timeout: Option<u64>,
 
-    /// Override model for all phases (valid: opus, sonnet, haiku)
-    #[arg(long = "model", value_parser = ["opus", "sonnet", "haiku"])]
+    /// Override model for all phases. For `--llm claude` the valid
+    /// values are opus / sonnet / haiku; for openai / codex / opencode
+    /// the value is passed through verbatim (e.g.
+    /// `anthropic/claude-sonnet-4`, `openai/gpt-4o`,
+    /// `lmstudio/qwen3-coder`). Validation is per-backend at runtime
+    /// rather than a fixed clap allow-list, so non-Claude backends can
+    /// name any provider/model their CLI understands.
+    #[arg(long = "model", short = 'm')]
     model: Option<String>,
 
     /// Effort level for spawned `claude` processes (the Architect,
@@ -509,6 +515,14 @@ async fn run_app(
     }
 
     if let Some(ref model) = cli.model {
+        // `--model` is a GLOBAL override applied to every phase. We
+        // accept it verbatim here (no clap value_parser) so non-Claude
+        // backends can name any provider/model string — e.g.
+        // `--llm opencode -m anthropic/claude-sonnet-4`. The Claude-only
+        // opus/sonnet/haiku vocabulary is validated AFTER per-phase
+        // backends are resolved (see the model-vs-backend check below),
+        // because that's the point where we know which phases actually
+        // run on Claude and would choke on a provider/model string.
         app.override_model = Some(model.clone());
         app.model_routing = false;
     } else if cli.no_model_routing {
@@ -587,6 +601,13 @@ async fn run_app(
     // `hybrid` preset splits per-phase: Claude for Architect /
     // Planner / Surgeon (high-stakes, low-volume calls), Codex for
     // Story + Critic (high-volume, cheap on subscription).
+    // Did the user actually type `--llm`? `cli.llm` has a default of
+    // "claude", so its value alone can't distinguish an explicit
+    // `--llm claude` (or `--llm hybrid`, which also resolves llm to
+    // Claude) from the no-flag default. We need that distinction to
+    // decide whether to show the provider picker, so scan the raw argv.
+    app.llm_explicitly_set = std::env::args().any(|a| a == "--llm" || a.starts_with("--llm="));
+
     match cli.llm.as_str() {
         "hybrid" => {
             // The preset only sets the defaults — explicit per-phase
@@ -634,6 +655,39 @@ async fn run_app(
     if let Some(ref v) = cli.surgeon_llm {
         if let Some(p) = app::LlmProvider::parse(v) {
             app.surgeon_llm = p;
+        }
+    }
+
+    // Validate a global `--model` against the resolved per-phase
+    // backends. `--model` is applied verbatim to EVERY phase, but the
+    // Claude CLI only understands opus/sonnet/haiku — a provider/model
+    // string like `anthropic/claude-sonnet-4` would make any Claude
+    // phase fail. So if `--model` isn't a Claude model name AND at
+    // least one phase still routes through Claude, reject early with a
+    // clear message instead of letting the Claude subprocess choke.
+    // (This is why the check lives here, after per-phase resolution,
+    // rather than at parse time.)
+    if let Some(ref model) = cli.model {
+        let is_claude_model = matches!(model.as_str(), "opus" | "sonnet" | "haiku");
+        let any_claude_phase = [
+            app.architect_llm,
+            app.planner_llm,
+            app.story_llm,
+            app.critic_llm,
+            app.surgeon_llm,
+        ]
+        .iter()
+        .any(|p| *p == app::LlmProvider::Claude);
+        if !is_claude_model && any_claude_phase {
+            eprintln!(
+                "[baro] error: --model '{}' is not a Claude model (opus/sonnet/haiku) \
+                 but at least one phase still runs on Claude. `--model` applies to \
+                 every phase, so it must be Claude-compatible unless all phases use a \
+                 non-Claude backend. Route the Claude phases elsewhere (e.g. \
+                 `--llm opencode`) or use a per-phase model flag.",
+                model
+            );
+            std::process::exit(2);
         }
     }
 
@@ -719,10 +773,15 @@ async fn run_app(
             }
         } else {
             // No goal: show ProviderPicker first — UNLESS the user
-            // explicitly chose a non-default backend via --llm (the
-            // picker only offers Claude/OpenAI; codex/opencode/hybrid
-            // users already made their choice on the command line).
-            if app.llm != app::LlmProvider::Claude {
+            // explicitly chose a backend via --llm. Gate on whether
+            // --llm was actually passed, NOT on `llm != Claude`: the
+            // `hybrid` preset and an explicit `--llm claude` both
+            // resolve `llm` to Claude, and the old guard wrongly
+            // re-prompted them. Worse, for hybrid the picker's Enter
+            // handler then overwrote every per-phase backend with one
+            // provider, silently destroying the hybrid split the user
+            // asked for.
+            if app.llm_explicitly_set {
                 app.screen = app::Screen::Welcome;
             } else {
                 app.screen = app::Screen::ProviderPicker;
@@ -1401,7 +1460,17 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
                 ))
                 .await;
             None
-        } else if matches!(planner, Planner::Claude | Planner::Codex | Planner::OpenCode) {
+        } else {
+            // Run the Architect for every backend. The TS architect
+            // (run-architect.ts) has a path for all four providers
+            // (claude / openai / codex / opencode), so gating on the
+            // backend was both unnecessary and incoherent: upstream ran
+            // it for Claude only, this branch had widened it to
+            // Claude|Codex|OpenCode (silently changing Codex behaviour
+            // and still excluding OpenAI for no reason). Gate purely on
+            // `!quick` — quick mode is the only case that legitimately
+            // skips the design document. Routing keys off `architect_llm`
+            // (the real per-phase field), not the legacy `planner` enum.
             let _ = tx.send(AppEvent::ArchitectStarted).await;
             match architect_runner::run_architect(
                 &goal,
@@ -1430,8 +1499,6 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
                     None
                 }
             }
-        } else {
-            None
         };
 
         // Phase 2 — Planner. TS subprocess decides Claude vs OpenAI

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -473,6 +473,8 @@ async fn run_app(
 
     app.planner = match rc.planner.as_deref() {
         Some("openai") => Planner::OpenAI,
+        Some("codex") => Planner::Codex,
+        Some("opencode") => Planner::OpenCode,
         _ => Planner::Claude,
     };
 
@@ -491,8 +493,19 @@ async fn run_app(
     if cli.planner != "claude" {
         app.planner = match cli.planner.as_str() {
             "openai" => Planner::OpenAI,
+            "codex" => Planner::Codex,
+            "opencode" => Planner::OpenCode,
             _ => Planner::Claude,
         };
+    }
+
+    // When --llm is set, auto-select the matching planner so the user
+    // doesn't need to pass both --llm and --planner.
+    match cli.llm.as_str() {
+        "openai" => app.planner = Planner::OpenAI,
+        "codex" => app.planner = Planner::Codex,
+        "opencode" => app.planner = Planner::OpenCode,
+        _ => {} // claude/hybrid keep the default or explicit --planner
     }
 
     if let Some(ref model) = cli.model {
@@ -836,25 +849,40 @@ async fn run_app(
                     Screen::ProviderPicker => match key.code {
                         KeyCode::Esc | KeyCode::Char('q') => return Ok(()),
                         KeyCode::Up | KeyCode::Char('k') => {
-                            app.provider_picker_index = 0;
+                            if app.provider_picker_index > 0 {
+                                app.provider_picker_index -= 1;
+                            } else {
+                                app.provider_picker_index = app.provider_picker_options.len().saturating_sub(1);
+                            }
                         }
                         KeyCode::Down | KeyCode::Char('j') => {
-                            app.provider_picker_index = 1;
+                            if app.provider_picker_index < app.provider_picker_options.len().saturating_sub(1) {
+                                app.provider_picker_index += 1;
+                            } else {
+                                app.provider_picker_index = 0;
+                            }
                         }
                         KeyCode::Enter | KeyCode::Char('\r') | KeyCode::Char('\n') => {
-                            if app.provider_picker_index == 0 {
-                                app.llm = app::LlmProvider::Claude;
-                                app.screen = Screen::Welcome;
+                            let chosen = app.provider_picker_options[app.provider_picker_index];
+                            app.llm = chosen;
+                            app.architect_llm = chosen;
+                            app.planner_llm = chosen;
+                            app.story_llm = chosen;
+                            app.critic_llm = chosen;
+                            app.surgeon_llm = chosen;
+                            // Set the legacy planner enum to match
+                            app.planner = match chosen {
+                                app::LlmProvider::Claude => app::Planner::Claude,
+                                app::LlmProvider::OpenAI => app::Planner::OpenAI,
+                                app::LlmProvider::Codex => app::Planner::Codex,
+                                app::LlmProvider::OpenCode => app::Planner::OpenCode,
+                            };
+                            // OpenAI needs an API key — detour if missing
+                            if chosen == app::LlmProvider::OpenAI && app.openai_api_key.is_none() {
+                                app.api_key_input.clear();
+                                app.screen = Screen::ApiKeyInput;
                             } else {
-                                app.llm = app::LlmProvider::OpenAI;
-                                // Skip the API-key screen if the user
-                                // already has the secret in their env.
-                                if app.openai_api_key.is_some() {
-                                    app.screen = Screen::Welcome;
-                                } else {
-                                    app.api_key_input.clear();
-                                    app.screen = Screen::ApiKeyInput;
-                                }
+                                app.screen = Screen::Welcome;
                             }
                         }
                         _ => {}
@@ -1373,7 +1401,7 @@ fn spawn_planner(app: &App, cwd: &Path, tx: mpsc::Sender<AppEvent>) {
                 ))
                 .await;
             None
-        } else if matches!(planner, Planner::Claude) {
+        } else if matches!(planner, Planner::Claude | Planner::Codex | Planner::OpenCode) {
             let _ = tx.send(AppEvent::ArchitectStarted).await;
             match architect_runner::run_architect(
                 &goal,

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -303,7 +303,7 @@ struct Cli {
     ///                      Critic move to Codex (high-volume, cheap
     ///                      on ChatGPT subscription). Individual phase
     ///                      overrides win when set.
-    #[arg(long, default_value = "claude", value_parser = ["claude", "openai", "codex", "hybrid"])]
+    #[arg(long, default_value = "claude", value_parser = ["claude", "openai", "codex", "opencode", "hybrid"])]
     llm: String,
 
     /// Custom base URL for OpenAI-compatible API endpoints. When set,
@@ -315,20 +315,20 @@ struct Cli {
     #[arg(long, env = "OPENAI_BASE_URL")]
     openai_base_url: Option<String>,
 
-    /// Per-phase overrides. Each accepts claude | openai | codex and
+    /// Per-phase overrides. Each accepts claude | openai | codex | opencode and
     /// wins over `--llm` (including the `hybrid` preset) for that one
     /// phase. Useful for surgical tuning: e.g. `--llm hybrid
     /// --critic-llm claude` for a hybrid run that uses Claude for
     /// Critic instead of Codex.
-    #[arg(long, value_parser = ["claude", "openai", "codex"])]
+    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode"])]
     architect_llm: Option<String>,
-    #[arg(long, value_parser = ["claude", "openai", "codex"])]
+    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode"])]
     planner_llm: Option<String>,
-    #[arg(long, value_parser = ["claude", "openai", "codex"])]
+    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode"])]
     story_llm: Option<String>,
-    #[arg(long, value_parser = ["claude", "openai", "codex"])]
+    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode"])]
     critic_llm: Option<String>,
-    #[arg(long, value_parser = ["claude", "openai", "codex"])]
+    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode"])]
     surgeon_llm: Option<String>,
 
     /// Disable semantic memory (MemoryLibrarian). Uses tag-based

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -705,8 +705,15 @@ async fn run_app(
                 }
             }
         } else {
-            // No goal: show ProviderPicker first.
-            app.screen = app::Screen::ProviderPicker;
+            // No goal: show ProviderPicker first — UNLESS the user
+            // explicitly chose a non-default backend via --llm (the
+            // picker only offers Claude/OpenAI; codex/opencode/hybrid
+            // users already made their choice on the command line).
+            if app.llm != app::LlmProvider::Claude {
+                app.screen = app::Screen::Welcome;
+            } else {
+                app.screen = app::Screen::ProviderPicker;
+            }
         }
     }
 

--- a/crates/baro-tui/src/screens/planning.rs
+++ b/crates/baro-tui/src/screens/planning.rs
@@ -77,6 +77,7 @@ pub fn render(f: &mut Frame, app: &App) {
         crate::app::LlmProvider::Claude => "Claude",
         crate::app::LlmProvider::OpenAI => "OpenAI",
         crate::app::LlmProvider::Codex => "Codex",
+        crate::app::LlmProvider::OpenCode => "OpenCode",
     };
 
     if let Some(ref err) = app.planning_error {

--- a/crates/baro-tui/src/screens/provider_picker.rs
+++ b/crates/baro-tui/src/screens/provider_picker.rs
@@ -1,12 +1,11 @@
 //! Provider picker — the first screen `baro` shows when invoked with
-//! no goal. Two options:
+//! no goal and no explicit `--llm`. Dynamically shows backends detected
+//! at startup:
 //!
-//!   0. Claude Code      — uses the existing `claude` CLI session.
-//!                         No API key needed.
-//!   1. Mozaik native    — every phase routes through Mozaik's
-//!      (OpenAI)          native OpenAI runner. Needs an
-//!                         `OPENAI_API_KEY` (read from env, or
-//!                         entered on the next screen).
+//!   - Claude Code      — always available
+//!   - Mozaik native    — always available (needs OPENAI_API_KEY)
+//!   - Codex            — shown when `codex` is on PATH
+//!   - OpenCode         — shown when `opencode` is on PATH
 //!
 //! Up/Down to highlight, Enter to confirm. The picked
 //! `LlmProvider` lands in `app.llm`; the next screen is decided in
@@ -20,24 +19,67 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::App;
+use crate::app::{App, LlmProvider};
 use crate::theme;
 
+/// Description text for each provider option.
+fn provider_description(provider: LlmProvider) -> &'static [&'static str] {
+    match provider {
+        LlmProvider::Claude => &[
+            "The default. Drives every phase through your existing",
+            "`claude` CLI session — no API key, your subscription does",
+            "the work. Best when you're already paying for Claude Pro/Max.",
+        ],
+        LlmProvider::OpenAI => &[
+            "Runs every phase through gpt-5.x via Mozaik's native",
+            "OpenAI inference runner. Requires OPENAI_API_KEY (either",
+            "in your shell already, or entered on the next screen).",
+        ],
+        LlmProvider::Codex => &[
+            "OpenAI Codex CLI. Drives every phase through your",
+            "`codex` CLI session — ChatGPT Pro/Plus subscription",
+            "billing. One-shot non-interactive per story.",
+        ],
+        LlmProvider::OpenCode => &[
+            "OpenCode CLI — multi-provider agent shell. Uses whatever",
+            "model you configured in opencode (any provider). No extra",
+            "API keys needed, opencode manages its own credentials.",
+        ],
+    }
+}
+
+fn provider_title(provider: LlmProvider) -> &'static str {
+    match provider {
+        LlmProvider::Claude => "Claude Code",
+        LlmProvider::OpenAI => "Mozaik native — OpenAI",
+        LlmProvider::Codex => "Codex CLI",
+        LlmProvider::OpenCode => "OpenCode",
+    }
+}
+
 pub fn draw(f: &mut Frame, app: &App, area: Rect) {
+    let num_options = app.provider_picker_options.len();
+
+    // Dynamic layout: title area + one 7-row box per option + gaps + hint
+    let mut constraints: Vec<Constraint> = vec![
+        Constraint::Length(2), // top padding
+        Constraint::Length(2), // title
+        Constraint::Length(2), // subtitle
+        Constraint::Length(1), // gap
+    ];
+    for i in 0..num_options {
+        constraints.push(Constraint::Length(7)); // option box
+        if i < num_options - 1 {
+            constraints.push(Constraint::Length(1)); // gap between options
+        }
+    }
+    constraints.push(Constraint::Length(2)); // gap before hint
+    constraints.push(Constraint::Length(2)); // hint
+    constraints.push(Constraint::Min(0)); // remaining
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(2), // top padding
-            Constraint::Length(2), // title
-            Constraint::Length(2), // subtitle
-            Constraint::Length(2), // gap
-            Constraint::Length(7), // option 1
-            Constraint::Length(1), // gap
-            Constraint::Length(7), // option 2
-            Constraint::Length(2), // gap
-            Constraint::Length(2), // hint
-            Constraint::Min(0),
-        ])
+        .constraints(constraints)
         .split(centred(area, 78));
 
     let title = Paragraph::new(Line::from(vec![Span::styled(
@@ -56,47 +98,58 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     .alignment(Alignment::Center);
     f.render_widget(subtitle, chunks[2]);
 
-    let claude_selected = app.provider_picker_index == 0;
-    let openai_selected = app.provider_picker_index == 1;
+    // Render each option box
+    let options_start = 4; // chunk index where option boxes begin
+    for (i, &provider) in app.provider_picker_options.iter().enumerate() {
+        let selected = app.provider_picker_index == i;
+        // Options alternate with gap chunks: option at +0, gap at +1
+        let chunk_idx = options_start + i * 2;
+        if chunk_idx < chunks.len() {
+            f.render_widget(
+                option_widget(
+                    selected,
+                    provider_title(provider),
+                    provider_description(provider),
+                ),
+                chunks[chunk_idx],
+            );
+        }
+    }
 
-    f.render_widget(
-        option_widget(
-            claude_selected,
-            "Claude Code",
-            &[
-                "The default. Drives every phase through your existing",
-                "`claude` CLI session — no API key, your subscription does",
-                "the work. Best when you're already paying for Claude Pro/Max.",
-            ],
-        ),
-        chunks[4],
-    );
-
-    f.render_widget(
-        option_widget(
-            openai_selected,
-            "Mozaik native — OpenAI",
-            &[
-                "Runs every phase through gpt-5.x via Mozaik's native",
-                "OpenAI inference runner. Requires OPENAI_API_KEY (either",
-                "in your shell already, or entered on the next screen).",
-            ],
-        ),
-        chunks[6],
-    );
-
+    // Hint line is at chunks.len() - 2 (before the Min(0) filler)
+    let hint_idx = chunks.len() - 2;
     let hint = Paragraph::new(Line::from(vec![
-        Span::styled("↑", Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "↑",
+            Style::default()
+                .fg(theme::ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled("/", Style::default().fg(theme::MUTED)),
-        Span::styled("↓", Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "↓",
+            Style::default()
+                .fg(theme::ACCENT)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled("  choose    ", Style::default().fg(theme::MUTED)),
-        Span::styled("Enter", Style::default().fg(theme::SUCCESS).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "Enter",
+            Style::default()
+                .fg(theme::SUCCESS)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled("  confirm    ", Style::default().fg(theme::MUTED)),
-        Span::styled("q", Style::default().fg(theme::ERROR).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "q",
+            Style::default()
+                .fg(theme::ERROR)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled("  quit", Style::default().fg(theme::MUTED)),
     ]))
     .alignment(Alignment::Center);
-    f.render_widget(hint, chunks[8]);
+    f.render_widget(hint, chunks[hint_idx]);
 }
 
 fn option_widget(selected: bool, title: &str, body: &[&str]) -> Paragraph<'static> {

--- a/crates/baro-tui/src/screens/welcome.rs
+++ b/crates/baro-tui/src/screens/welcome.rs
@@ -227,14 +227,17 @@ pub fn render(f: &mut Frame, app: &App) {
     };
 
     let planner_focused = focused == WelcomeField::Planner;
-    let is_claude = app.planner == Planner::Claude;
 
     let mut planner_spans = vec![
         Span::styled("  Planner:  ", Style::default().fg(theme::MUTED)),
     ];
-    planner_spans.extend(radio(is_claude, "claude", planner_focused));
+    planner_spans.extend(radio(app.planner == Planner::Claude, "claude", planner_focused));
     planner_spans.push(Span::raw("  "));
-    planner_spans.extend(radio(!is_claude, "openai", planner_focused));
+    planner_spans.extend(radio(app.planner == Planner::OpenAI, "openai", planner_focused));
+    planner_spans.push(Span::raw("  "));
+    planner_spans.extend(radio(app.planner == Planner::Codex, "codex", planner_focused));
+    planner_spans.push(Span::raw("  "));
+    planner_spans.extend(radio(app.planner == Planner::OpenCode, "opencode", planner_focused));
 
     let settings_lines = vec![
         Line::from(model_spans),

--- a/packages/baro-orchestrator/scripts/cli.ts
+++ b/packages/baro-orchestrator/scripts/cli.ts
@@ -54,11 +54,11 @@ interface CliArgs {
     tierMap?: TierMap
     /** Raw `--openai-endpoint name=url` specs, resolved to a map later. */
     endpointSpecs: string[]
-    llm: "claude" | "openai" | "codex"
+    llm: "claude" | "openai" | "codex" | "opencode"
     /** Optional per-phase overrides; each defaults to `llm`. */
-    storyLlm?: "claude" | "openai" | "codex"
-    criticLlm?: "claude" | "openai" | "codex"
-    surgeonLlm?: "claude" | "openai" | "codex"
+    storyLlm?: "claude" | "openai" | "codex" | "opencode"
+    criticLlm?: "claude" | "openai" | "codex" | "opencode"
+    surgeonLlm?: "claude" | "openai" | "codex" | "opencode"
     help: boolean
 }
 
@@ -160,9 +160,9 @@ function parseArgs(argv: string[]): CliArgs {
                 break
             case "--llm": {
                 const v = required(argv, ++i, "--llm")
-                if (v !== "claude" && v !== "openai" && v !== "codex") {
+                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode") {
                     process.stderr.write(
-                        `[cli] --llm must be 'claude' | 'openai' | 'codex', got '${v}'\n`,
+                        `[cli] --llm must be 'claude' | 'openai' | 'codex' | 'opencode', got '${v}'\n`,
                     )
                     process.exit(2)
                 }
@@ -173,9 +173,9 @@ function parseArgs(argv: string[]): CliArgs {
             case "--critic-llm":
             case "--surgeon-llm": {
                 const v = required(argv, ++i, a)
-                if (v !== "claude" && v !== "openai" && v !== "codex") {
+                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode") {
                     process.stderr.write(
-                        `[cli] ${a} must be 'claude' | 'openai' | 'codex', got '${v}'\n`,
+                        `[cli] ${a} must be 'claude' | 'openai' | 'codex' | 'opencode', got '${v}'\n`,
                     )
                     process.exit(2)
                 }

--- a/packages/baro-orchestrator/scripts/run-architect.ts
+++ b/packages/baro-orchestrator/scripts/run-architect.ts
@@ -59,10 +59,10 @@ function parseArgs(argv: string[]): Args {
                 break
             case "--llm": {
                 const v = required(argv, ++i, "--llm")
-                if (v !== "claude" && v !== "openai" && v !== "codex") {
-                    fatal(`--llm must be 'claude' | 'openai' | 'codex', got '${v}'`)
+                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode") {
+                    fatal(`--llm must be 'claude' | 'openai' | 'codex' | 'opencode', got '${v}'`)
                 }
-                llm = v as "claude" | "openai" | "codex"
+                llm = v as "claude" | "openai" | "codex" | "opencode"
                 break
             }
             case "--model":

--- a/packages/baro-orchestrator/scripts/run-architect.ts
+++ b/packages/baro-orchestrator/scripts/run-architect.ts
@@ -22,6 +22,7 @@ import { readFileSync } from "fs"
 import { runArchitectClaude } from "../src/planning/architect-claude.js"
 import { runArchitectCodex } from "../src/planning/architect-codex.js"
 import { runArchitectOpenAI } from "../src/planning/architect-openai.js"
+import { runArchitectOpenCode } from "../src/planning/architect-opencode.js"
 
 interface Args {
     goal: string
@@ -33,7 +34,7 @@ interface Args {
      * Codex covers the Story phase (which dominates token spend);
      * Architect and Planner stay on Claude.
      */
-    llm: "claude" | "openai" | "codex"
+    llm: "claude" | "openai" | "codex" | "opencode"
     model?: string
     effort?: string
     contextFile?: string
@@ -42,7 +43,7 @@ interface Args {
 function parseArgs(argv: string[]): Args {
     let goal: string | undefined
     let cwd: string | undefined
-    let llm: "claude" | "openai" | "codex" | undefined
+    let llm: "claude" | "openai" | "codex" | "opencode" | undefined
     let model: string | undefined
     let effort: string | undefined
     let contextFile: string | undefined
@@ -127,6 +128,13 @@ async function main(): Promise<void> {
             })
         } else if (args.llm === "codex") {
             doc = await runArchitectCodex({
+                goal: args.goal,
+                cwd: args.cwd,
+                model: args.model,
+                projectContext,
+            })
+        } else if (args.llm === "opencode") {
+            doc = await runArchitectOpenCode({
                 goal: args.goal,
                 cwd: args.cwd,
                 model: args.model,

--- a/packages/baro-orchestrator/scripts/run-planner.ts
+++ b/packages/baro-orchestrator/scripts/run-planner.ts
@@ -23,6 +23,7 @@ import { readFileSync } from "fs"
 import { runPlannerClaude } from "../src/planning/planner-claude.js"
 import { runPlannerCodex } from "../src/planning/planner-codex.js"
 import { runPlannerOpenAI } from "../src/planning/planner-openai.js"
+import { runPlannerOpenCode } from "../src/planning/planner-opencode.js"
 
 interface Args {
     goal: string
@@ -33,7 +34,7 @@ interface Args {
      * v1 positioning: Codex covers the Story phase; Architect and
      * Planner stay on Claude.
      */
-    llm: "claude" | "openai" | "codex"
+    llm: "claude" | "openai" | "codex" | "opencode"
     model?: string
     effort?: string
     contextFile?: string
@@ -44,7 +45,7 @@ interface Args {
 function parseArgs(argv: string[]): Args {
     let goal: string | undefined
     let cwd: string | undefined
-    let llm: "claude" | "openai" | "codex" | undefined
+    let llm: "claude" | "openai" | "codex" | "opencode" | undefined
     let model: string | undefined
     let effort: string | undefined
     let contextFile: string | undefined
@@ -151,6 +152,15 @@ async function main(): Promise<void> {
             })
         } else if (args.llm === "codex") {
             prdJson = await runPlannerCodex({
+                goal: args.goal,
+                cwd: args.cwd,
+                model: args.model,
+                projectContext,
+                decisionDocument,
+                quick: args.quick,
+            })
+        } else if (args.llm === "opencode") {
+            prdJson = await runPlannerOpenCode({
                 goal: args.goal,
                 cwd: args.cwd,
                 model: args.model,

--- a/packages/baro-orchestrator/scripts/run-planner.ts
+++ b/packages/baro-orchestrator/scripts/run-planner.ts
@@ -63,10 +63,10 @@ function parseArgs(argv: string[]): Args {
                 break
             case "--llm": {
                 const v = required(argv, ++i, "--llm")
-                if (v !== "claude" && v !== "openai" && v !== "codex") {
-                    fatal(`--llm must be 'claude' | 'openai' | 'codex', got '${v}'`)
+                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode") {
+                    fatal(`--llm must be 'claude' | 'openai' | 'codex' | 'opencode', got '${v}'`)
                 }
-                llm = v as "claude" | "openai" | "codex"
+                llm = v as "claude" | "openai" | "codex" | "opencode"
                 break
             }
             case "--model":

--- a/packages/baro-orchestrator/scripts/test-opencode-integration.ts
+++ b/packages/baro-orchestrator/scripts/test-opencode-integration.ts
@@ -20,12 +20,17 @@
  * Exit code 0 = all tests passed, non-zero = failure.
  */
 
-import { mkdtempSync, writeFileSync, rmSync } from "fs"
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "fs"
 import { execSync } from "child_process"
 import { join } from "path"
 import { tmpdir } from "os"
 
-import { AgenticEnvironment } from "@mozaik-ai/core"
+import {
+    AgenticEnvironment,
+    FunctionCallItem,
+    FunctionCallOutputItem,
+    ModelMessageItem,
+} from "@mozaik-ai/core"
 
 import { mapOpenCodeEvent } from "../src/opencode-stream-mapper.js"
 import { OpenCodeCliParticipant } from "../src/participants/opencode-cli-participant.js"
@@ -37,6 +42,17 @@ import { runOpenCodeOneShot } from "../src/opencode-one-shot.js"
 let testDir: string
 let passed = 0
 let failed = 0
+let skipped = 0
+
+/** True when the `opencode` binary is resolvable on PATH. */
+function opencodeAvailable(): boolean {
+    try {
+        execSync("command -v opencode", { stdio: "ignore" })
+        return true
+    } catch {
+        return false
+    }
+}
 
 function setup(): void {
     testDir = mkdtempSync(join(tmpdir(), "baro-opencode-test-"))
@@ -92,32 +108,64 @@ function testStreamMapper(): void {
     }
     const textResult = mapOpenCodeEvent("agent-1", textEvent)
     assert(textResult.items.length >= 1, "text event produces items")
-    // Check that a ModelMessageItem was produced
-    const hasModelMsg = textResult.items.some((item) => {
-        const data = JSON.stringify(item)
-        return data.includes("Hello world")
-    })
-    assert(hasModelMsg, "text event produces ModelMessageItem with correct text")
+    // Assert an actual ModelMessageItem carrying the text — not a
+    // stringified substring match, which would also pass if "Hello world"
+    // landed in some other item's raw passthrough. ModelMessageItem keeps
+    // its text in content parts (content[].text), not a top-level field.
+    const modelMsg = textResult.items.find(
+        (item): item is ModelMessageItem => item instanceof ModelMessageItem,
+    )
+    const modelMsgText = modelMsg
+        ? (JSON.parse(JSON.stringify(modelMsg)).content ?? [])
+              .map((p: { text?: string }) => p.text ?? "")
+              .join("")
+        : undefined
+    assert(
+        modelMsgText === "Hello world",
+        "text event produces a ModelMessageItem with the correct text",
+    )
 
-    // tool_call
+    // tool_use — the REAL opencode shape: one event carrying both the
+    // call (state.input) and result (state.output). Must yield a
+    // FunctionCallItem AND a FunctionCallOutputItem.
+    const toolUseEvent = {
+        type: "tool_use",
+        timestamp: 1236,
+        sessionID: "ses_test123",
+        part: {
+            type: "tool",
+            tool: "write",
+            callID: "tooluse_abc",
+            state: {
+                status: "completed",
+                input: { filePath: "/tmp/test.txt", content: "hi" },
+                output: "(no output)",
+            },
+        },
+    }
+    const toolUseResult = mapOpenCodeEvent("agent-1", toolUseEvent)
+    assert(toolUseResult.items.length >= 1, "tool_use event produces items")
+    assert(
+        toolUseResult.items.some((i) => i instanceof FunctionCallItem),
+        "tool_use produces a FunctionCallItem (real opencode shape)",
+    )
+    assert(
+        toolUseResult.items.some((i) => i instanceof FunctionCallOutputItem),
+        "completed tool_use produces a FunctionCallOutputItem",
+    )
+
+    // tool_call / tool_result — legacy fallback shape still maps.
     const toolCallEvent = {
         type: "tool_call",
-        timestamp: 1236,
+        timestamp: 1237,
         sessionID: "ses_test123",
         part: { id: "call_1", type: "tool-call", tool: "Read", args: { path: "/tmp/test.txt" } },
     }
     const toolResult = mapOpenCodeEvent("agent-1", toolCallEvent)
-    assert(toolResult.items.length >= 1, "tool_call event produces items")
-
-    // tool_result
-    const toolResultEvent = {
-        type: "tool_result",
-        timestamp: 1237,
-        sessionID: "ses_test123",
-        part: { id: "call_1", type: "tool-result", tool: "Read", result: "file contents" },
-    }
-    const toolResResult = mapOpenCodeEvent("agent-1", toolResultEvent)
-    assert(toolResResult.items.length >= 1, "tool_result event produces items")
+    assert(
+        toolResult.items.some((i) => i instanceof FunctionCallItem),
+        "legacy tool_call event still maps to a FunctionCallItem",
+    )
 
     // step_finish
     const finishEvent = {
@@ -193,10 +241,51 @@ async function testCliParticipant(): Promise<void> {
 async function testStoryAgent(): Promise<void> {
     process.stderr.write("\n[test] 4. Story agent (live opencode invocation)\n")
 
+    // A story is real work: edit the worktree. Use a file-mutation
+    // prompt (not a prose echo) so success means the agent actually did
+    // something — and so the strengthened success predicate (which
+    // requires >=1 tool call) is exercised on a genuine task.
+    const targetFile = "STORY_AGENT_OK.txt"
     const env = new AgenticEnvironment()
     const agent = new OpenCodeStoryAgent({
         id: "test-story-1",
-        prompt: 'Say exactly: STORY_AGENT_OK',
+        prompt: `Create a file named ${targetFile} in the current directory containing exactly the text DONE. Use your file-writing tools.`,
+        cwd: testDir,
+        retries: 0,
+        timeoutSecs: 120,
+    })
+
+    agent.join(env)
+    const outcome = await agent.run(env)
+
+    assert(outcome.success === true, `story succeeded (got: ${outcome.success}, error: ${outcome.error})`)
+    assert(outcome.attempts === 1, `completed in 1 attempt (got: ${outcome.attempts})`)
+    assert(outcome.error === null, "no error in outcome")
+    assert(outcome.durationSecs >= 0, "duration is non-negative")
+    // The whole point of a story: the worktree changed.
+    assert(
+        existsSync(join(testDir, targetFile)),
+        `story agent actually created ${targetFile} in the worktree`,
+    )
+
+    agent.leave(env)
+}
+
+// ─── Test 5: Success predicate rejects no-op (regression guard) ───────
+//
+// `opencode run` exits 0 even when the model just talks and does no
+// work. A prose-only prompt invokes no tools, so the success predicate
+// MUST reject it — otherwise a refused/no-op story would be reported as
+// a false PASS to the Conductor (the exact gap this backend's review
+// surfaced). This guards that predicate against regressing back to
+// exit-code-only.
+async function testNoOpRejected(): Promise<void> {
+    process.stderr.write("\n[test] 5. No-op story is rejected (regression guard)\n")
+
+    const env = new AgenticEnvironment()
+    const agent = new OpenCodeStoryAgent({
+        id: "test-story-noop",
+        prompt: "Reply with the single word ACKNOWLEDGED and do nothing else. Do not use any tools.",
         cwd: testDir,
         retries: 0,
         timeoutSecs: 60,
@@ -205,10 +294,14 @@ async function testStoryAgent(): Promise<void> {
     agent.join(env)
     const outcome = await agent.run(env)
 
-    assert(outcome.success === true, `story succeeded (got: ${outcome.success})`)
-    assert(outcome.attempts === 1, `completed in 1 attempt (got: ${outcome.attempts})`)
-    assert(outcome.error === null, "no error in outcome")
-    assert(outcome.durationSecs >= 0, "duration is non-negative")
+    assert(
+        outcome.success === false,
+        `no-op (zero-tool) story is NOT marked passed (got success=${outcome.success})`,
+    )
+    assert(
+        outcome.error != null,
+        "no-op story carries a reason for the non-pass",
+    )
 
     agent.leave(env)
 }
@@ -224,22 +317,40 @@ async function main(): Promise<void> {
         // Unit-level test (no live process needed)
         testStreamMapper()
 
-        // Live integration tests (need opencode on PATH + configured provider)
-        await testOneShot()
-        await testCliParticipant()
-        await testStoryAgent()
+        // Live integration tests need `opencode` on PATH + a configured
+        // provider. Probe up front and SKIP (not fail) when it's absent,
+        // so CI / machines without opencode don't conflate "environment
+        // not provisioned" with "code regression". A genuine failure
+        // still exits non-zero; a missing binary exits 0 after the unit
+        // test.
+        if (opencodeAvailable()) {
+            await testOneShot()
+            await testCliParticipant()
+            await testStoryAgent()
+            await testNoOpRejected()
+        } else {
+            skipped += 4
+            process.stderr.write(
+                "\n[test] opencode not found on PATH — SKIPPING live tests 2-4 " +
+                    "(install opencode and configure a provider to run them).\n",
+            )
+        }
     } finally {
         teardown()
     }
 
     process.stderr.write(
-        `\n═══ Results: ${passed} passed, ${failed} failed ═══\n`,
+        `\n═══ Results: ${passed} passed, ${failed} failed, ${skipped} skipped ═══\n`,
     )
 
     if (failed > 0) {
         process.exit(1)
     }
-    process.stderr.write("All tests passed.\n")
+    process.stderr.write(
+        skipped > 0
+            ? "Unit tests passed (live tests skipped).\n"
+            : "All tests passed.\n",
+    )
 }
 
 main().catch((e) => {

--- a/packages/baro-orchestrator/scripts/test-opencode-integration.ts
+++ b/packages/baro-orchestrator/scripts/test-opencode-integration.ts
@@ -1,0 +1,248 @@
+/**
+ * Integration test: OpenCode backend.
+ *
+ * Exercises the full stack — stream mapper, CLI participant, story agent,
+ * and one-shot runner — against a real `opencode` process in a temporary
+ * git repository. Validates that:
+ *
+ *   1. The stream mapper correctly parses OpenCode's JSONL output
+ *   2. The CLI participant transitions through expected phases
+ *   3. The one-shot runner returns assistant text
+ *   4. The story agent completes a simple task end-to-end
+ *
+ * Usage:
+ *   npx tsx packages/baro-orchestrator/scripts/test-opencode-integration.ts
+ *
+ * Prerequisites:
+ *   - `opencode` binary on PATH
+ *   - A configured LLM provider in opencode (any will do)
+ *
+ * Exit code 0 = all tests passed, non-zero = failure.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync } from "fs"
+import { execSync } from "child_process"
+import { join } from "path"
+import { tmpdir } from "os"
+
+import { AgenticEnvironment } from "@mozaik-ai/core"
+
+import { mapOpenCodeEvent } from "../src/opencode-stream-mapper.js"
+import { OpenCodeCliParticipant } from "../src/participants/opencode-cli-participant.js"
+import { OpenCodeStoryAgent } from "../src/participants/opencode-story-agent.js"
+import { runOpenCodeOneShot } from "../src/opencode-one-shot.js"
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+let testDir: string
+let passed = 0
+let failed = 0
+
+function setup(): void {
+    testDir = mkdtempSync(join(tmpdir(), "baro-opencode-test-"))
+    execSync("git init", { cwd: testDir, stdio: "ignore" })
+    writeFileSync(join(testDir, "README.md"), "# Integration test project\n")
+    execSync("git add . && git commit -m 'init'", {
+        cwd: testDir,
+        stdio: "ignore",
+    })
+    process.stderr.write(`[test] temp dir: ${testDir}\n`)
+}
+
+function teardown(): void {
+    try {
+        rmSync(testDir, { recursive: true, force: true })
+    } catch {
+        // best-effort
+    }
+}
+
+function assert(condition: boolean, msg: string): void {
+    if (condition) {
+        passed++
+        process.stderr.write(`  ✓ ${msg}\n`)
+    } else {
+        failed++
+        process.stderr.write(`  ✗ FAIL: ${msg}\n`)
+    }
+}
+
+// ─── Test 1: Stream Mapper ────────────────────────────────────────────
+
+function testStreamMapper(): void {
+    process.stderr.write("\n[test] 1. Stream mapper\n")
+
+    // step_start
+    const startEvent = {
+        type: "step_start",
+        timestamp: 1234,
+        sessionID: "ses_test123",
+        part: { id: "prt_1", messageID: "msg_1", sessionID: "ses_test123", type: "step-start" },
+    }
+    const startResult = mapOpenCodeEvent("agent-1", startEvent)
+    assert(startResult.sessionId === "ses_test123", "extracts sessionId")
+    assert(startResult.items.length >= 1, "step_start produces items")
+
+    // text
+    const textEvent = {
+        type: "text",
+        timestamp: 1235,
+        sessionID: "ses_test123",
+        part: { id: "prt_2", messageID: "msg_1", sessionID: "ses_test123", type: "text", text: "Hello world" },
+    }
+    const textResult = mapOpenCodeEvent("agent-1", textEvent)
+    assert(textResult.items.length >= 1, "text event produces items")
+    // Check that a ModelMessageItem was produced
+    const hasModelMsg = textResult.items.some((item) => {
+        const data = JSON.stringify(item)
+        return data.includes("Hello world")
+    })
+    assert(hasModelMsg, "text event produces ModelMessageItem with correct text")
+
+    // tool_call
+    const toolCallEvent = {
+        type: "tool_call",
+        timestamp: 1236,
+        sessionID: "ses_test123",
+        part: { id: "call_1", type: "tool-call", tool: "Read", args: { path: "/tmp/test.txt" } },
+    }
+    const toolResult = mapOpenCodeEvent("agent-1", toolCallEvent)
+    assert(toolResult.items.length >= 1, "tool_call event produces items")
+
+    // tool_result
+    const toolResultEvent = {
+        type: "tool_result",
+        timestamp: 1237,
+        sessionID: "ses_test123",
+        part: { id: "call_1", type: "tool-result", tool: "Read", result: "file contents" },
+    }
+    const toolResResult = mapOpenCodeEvent("agent-1", toolResultEvent)
+    assert(toolResResult.items.length >= 1, "tool_result event produces items")
+
+    // step_finish
+    const finishEvent = {
+        type: "step_finish",
+        timestamp: 1238,
+        sessionID: "ses_test123",
+        part: {
+            id: "prt_3", type: "step-finish", reason: "stop",
+            tokens: { total: 100, input: 90, output: 10, reasoning: 0 },
+            cost: 0.001,
+        },
+    }
+    const finishResult = mapOpenCodeEvent("agent-1", finishEvent)
+    assert(finishResult.items.length >= 1, "step_finish produces items")
+
+    // unknown
+    const unknownEvent = { type: "foobar", timestamp: 1239, sessionID: "ses_test123" }
+    const unknownResult = mapOpenCodeEvent("agent-1", unknownEvent)
+    assert(unknownResult.items.length >= 1, "unknown event produces items (not dropped)")
+}
+
+// ─── Test 2: One-Shot Runner (live) ───────────────────────────────────
+
+async function testOneShot(): Promise<void> {
+    process.stderr.write("\n[test] 2. One-shot runner (live opencode invocation)\n")
+
+    try {
+        const result = await runOpenCodeOneShot({
+            prompt: 'Say exactly this text and nothing else: BARO_INTEGRATION_TEST_PASS',
+            cwd: testDir,
+            timeoutMs: 60_000,
+            label: "test-oneshot",
+        })
+        assert(result.includes("BARO_INTEGRATION_TEST_PASS"), "one-shot returns expected text")
+        assert(result.length > 0, "one-shot returns non-empty text")
+    } catch (e) {
+        assert(false, `one-shot threw: ${(e as Error).message}`)
+    }
+}
+
+// ─── Test 3: CLI Participant (live) ───────────────────────────────────
+
+async function testCliParticipant(): Promise<void> {
+    process.stderr.write("\n[test] 3. CLI participant (live opencode invocation)\n")
+
+    const env = new AgenticEnvironment()
+    const participant = new OpenCodeCliParticipant("test-agent", {
+        cwd: testDir,
+        prompt: 'Say exactly: CLI_PARTICIPANT_OK',
+    })
+
+    participant.join(env)
+    participant.start(env)
+
+    try {
+        await participant.ready
+        assert(true, "participant becomes ready")
+        assert(participant.getPhase() === "running", `phase is running (got: ${participant.getPhase()})`)
+    } catch (e) {
+        assert(false, `participant.ready rejected: ${(e as Error).message}`)
+    }
+
+    const summary = await participant.done
+    assert(summary.exitCode === 0, `exit code is 0 (got: ${summary.exitCode})`)
+    assert(summary.error === null, "no error on summary")
+    assert(participant.getPhase() === "done", `final phase is done (got: ${participant.getPhase()})`)
+
+    participant.leave(env)
+}
+
+// ─── Test 4: Story Agent (live) ───────────────────────────────────────
+
+async function testStoryAgent(): Promise<void> {
+    process.stderr.write("\n[test] 4. Story agent (live opencode invocation)\n")
+
+    const env = new AgenticEnvironment()
+    const agent = new OpenCodeStoryAgent({
+        id: "test-story-1",
+        prompt: 'Say exactly: STORY_AGENT_OK',
+        cwd: testDir,
+        retries: 0,
+        timeoutSecs: 60,
+    })
+
+    agent.join(env)
+    const outcome = await agent.run(env)
+
+    assert(outcome.success === true, `story succeeded (got: ${outcome.success})`)
+    assert(outcome.attempts === 1, `completed in 1 attempt (got: ${outcome.attempts})`)
+    assert(outcome.error === null, "no error in outcome")
+    assert(outcome.durationSecs >= 0, "duration is non-negative")
+
+    agent.leave(env)
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+    process.stderr.write("═══ OpenCode Backend Integration Test ═══\n")
+
+    setup()
+
+    try {
+        // Unit-level test (no live process needed)
+        testStreamMapper()
+
+        // Live integration tests (need opencode on PATH + configured provider)
+        await testOneShot()
+        await testCliParticipant()
+        await testStoryAgent()
+    } finally {
+        teardown()
+    }
+
+    process.stderr.write(
+        `\n═══ Results: ${passed} passed, ${failed} failed ═══\n`,
+    )
+
+    if (failed > 0) {
+        process.exit(1)
+    }
+    process.stderr.write("All tests passed.\n")
+}
+
+main().catch((e) => {
+    process.stderr.write(`FATAL: ${(e as Error).message}\n`)
+    process.exit(2)
+})

--- a/packages/baro-orchestrator/src/main.ts
+++ b/packages/baro-orchestrator/src/main.ts
@@ -45,6 +45,26 @@ export {
     type CodexStoryOutcome,
 } from "./participants/codex-story-agent.js"
 
+export {
+    OpenCodeCliParticipant,
+    type OpenCodeCliParticipantOptions,
+    type OpenCodeRunSummary,
+} from "./participants/opencode-cli-participant.js"
+
+export {
+    OpenCodeStoryAgent,
+    type OpenCodeStorySpec,
+    type OpenCodeStoryOutcome,
+} from "./participants/opencode-story-agent.js"
+
+export {
+    mapOpenCodeEvent,
+    type OpenCodeMapResult,
+    type MappedOpenCodeItem,
+} from "./opencode-stream-mapper.js"
+
+export { runOpenCodeOneShot, type RunOpenCodeOneShotOptions } from "./opencode-one-shot.js"
+
 export { Auditor, type AuditorOptions } from "./participants/auditor.js"
 
 export {

--- a/packages/baro-orchestrator/src/opencode-one-shot.ts
+++ b/packages/baro-orchestrator/src/opencode-one-shot.ts
@@ -122,7 +122,9 @@ export async function runOpenCodeOneShot(
                     }
                     continue
                 }
-                if (type === "tool_call") {
+                // Real opencode emits `tool_use`; `tool_call` is the
+                // legacy paired-shape fallback. Log either.
+                if (type === "tool_use" || type === "tool_call") {
                     const part = event.part as Record<string, unknown> | undefined
                     const tool =
                         typeof part?.tool === "string"
@@ -151,11 +153,6 @@ export async function runOpenCodeOneShot(
             clearTimeout(timer)
             const elapsedMs = Date.now() - startedAt
 
-            if (assistantText.trim()) {
-                resolve(assistantText)
-                return
-            }
-
             const ctx = [
                 `elapsed=${elapsedMs}ms`,
                 `exit=${code}`,
@@ -168,6 +165,28 @@ export async function runOpenCodeOneShot(
             ]
                 .filter((x): x is string => x !== null)
                 .join(" ")
+
+            // Abnormal termination must fail even if SOME text accumulated.
+            // The architect/planner callers feed the returned string into a
+            // markdown doc / JSON extractor that happily accepts a truncated
+            // but syntactically-closed fragment — so resolving partial text
+            // on a timeout (SIGTERM) or crash silently produces an
+            // incomplete design doc or PRD with no error surfaced. Treat
+            // timeout, a terminating signal, or a non-zero exit as failure.
+            if (timedOut || signal != null || (code != null && code !== 0)) {
+                reject(
+                    new Error(
+                        `runOpenCodeOneShot: opencode terminated abnormally before completing (${ctx})`,
+                    ),
+                )
+                return
+            }
+
+            if (assistantText.trim()) {
+                resolve(assistantText)
+                return
+            }
+
             reject(
                 new Error(
                     `runOpenCodeOneShot: opencode produced no text output (${ctx})`,

--- a/packages/baro-orchestrator/src/opencode-one-shot.ts
+++ b/packages/baro-orchestrator/src/opencode-one-shot.ts
@@ -1,0 +1,178 @@
+/**
+ * Shared helper: run a one-shot `opencode run --format json` invocation
+ * against a single combined prompt, collect the JSONL stream, and return
+ * the concatenated assistant `text` output. Used by
+ * `architect-opencode.ts`, `planner-opencode.ts`, and similar planning
+ * phases so the spawn + parse logic lives in one place.
+ *
+ * Implementation note: uses `spawn()` + streaming rather than
+ * `execFile()` + buffer because execFile discards stdout on timeout.
+ * Streaming lets us:
+ *   - forward OpenCode's structured events to stderr live so the audit
+ *     log captures them even on timeout
+ *   - track which event subtypes were observed for the error message
+ *   - kill OpenCode with SIGTERM on timeout instead of execFile's
+ *     harsher escalation
+ */
+
+import { ChildProcess, spawn } from "child_process"
+
+/** Options for `runOpenCodeOneShot`. */
+export interface RunOpenCodeOneShotOptions {
+    /** Combined system+user prompt. Passed as the final positional argv. */
+    prompt: string
+    /** Working directory for the OpenCode process. */
+    cwd: string
+    /**
+     * Model identifier in `provider/model` format. Omit to use
+     * OpenCode's configured default.
+     */
+    model?: string
+    /** Path to the `opencode` binary. Default: "opencode". */
+    opencodeBin?: string
+    /** Per-call timeout in milliseconds. Default: 600_000 (10 minutes). */
+    timeoutMs?: number
+    /**
+     * Per-phase label written into the live stderr stream so users can
+     * tell architect/planner/critic traffic apart in one log tail.
+     * Defaults to "opencode".
+     */
+    label?: string
+}
+
+/**
+ * Spawn `opencode run --format json --dangerously-skip-permissions`,
+ * collect all `text` events, and return the concatenated assistant text.
+ *
+ * @throws Error if the process exits without producing any text output.
+ */
+export async function runOpenCodeOneShot(
+    opts: RunOpenCodeOneShotOptions,
+): Promise<string> {
+    const label = opts.label ?? "opencode"
+    const args = ["run", "--format", "json", "--dangerously-skip-permissions"]
+    if (opts.model) args.push("-m", opts.model)
+    if (opts.cwd) args.push("--dir", opts.cwd)
+    args.push(opts.prompt)
+
+    const timeoutMs = opts.timeoutMs ?? 600_000
+
+    return await new Promise<string>((resolve, reject) => {
+        let proc: ChildProcess
+        try {
+            proc = spawn(opts.opencodeBin ?? "opencode", args, {
+                cwd: opts.cwd,
+                stdio: ["ignore", "pipe", "pipe"],
+            })
+        } catch (e) {
+            reject(e instanceof Error ? e : new Error(String(e)))
+            return
+        }
+
+        let assistantText = ""
+        let stdoutBuffer = ""
+        const eventTypesSeen: string[] = []
+        let timedOut = false
+
+        const startedAt = Date.now()
+        const timer = setTimeout(() => {
+            timedOut = true
+            try {
+                proc.kill("SIGTERM")
+            } catch {
+                /* noop */
+            }
+        }, timeoutMs)
+
+        proc.stdout!.setEncoding("utf8")
+        proc.stdout!.on("data", (chunk: string) => {
+            stdoutBuffer += chunk
+            let nl: number
+            while ((nl = stdoutBuffer.indexOf("\n")) >= 0) {
+                const line = stdoutBuffer.slice(0, nl).trim()
+                stdoutBuffer = stdoutBuffer.slice(nl + 1)
+                if (!line) continue
+                let event: Record<string, unknown>
+                try {
+                    event = JSON.parse(line) as Record<string, unknown>
+                } catch {
+                    continue
+                }
+                const type = typeof event.type === "string" ? event.type : ""
+                if (type) eventTypesSeen.push(type)
+
+                if (type === "step_finish") {
+                    const part = event.part as Record<string, unknown> | undefined
+                    const tokens = part?.tokens as
+                        | { input?: number; output?: number }
+                        | undefined
+                    if (tokens) {
+                        process.stderr.write(
+                            `[${label}] usage: in=${tokens.input ?? 0} out=${tokens.output ?? 0}\n`,
+                        )
+                    }
+                    continue
+                }
+                if (type === "text") {
+                    const part = event.part as Record<string, unknown> | undefined
+                    if (part && typeof part.text === "string") {
+                        assistantText = assistantText
+                            ? `${assistantText}\n${part.text}`
+                            : part.text
+                    }
+                    continue
+                }
+                if (type === "tool_call") {
+                    const part = event.part as Record<string, unknown> | undefined
+                    const tool =
+                        typeof part?.tool === "string"
+                            ? part.tool.slice(0, 120)
+                            : "?"
+                    process.stderr.write(`[${label}] tool: ${tool}\n`)
+                    continue
+                }
+            }
+        })
+
+        proc.stderr!.setEncoding("utf8")
+        proc.stderr!.on("data", (chunk: string) => {
+            const trimmed = chunk.trimEnd()
+            if (trimmed) {
+                process.stderr.write(`[${label}/stderr] ${trimmed}\n`)
+            }
+        })
+
+        proc.on("error", (err) => {
+            clearTimeout(timer)
+            reject(err)
+        })
+
+        proc.on("exit", (code, signal) => {
+            clearTimeout(timer)
+            const elapsedMs = Date.now() - startedAt
+
+            if (assistantText.trim()) {
+                resolve(assistantText)
+                return
+            }
+
+            const ctx = [
+                `elapsed=${elapsedMs}ms`,
+                `exit=${code}`,
+                signal ? `signal=${signal}` : null,
+                timedOut ? `timedOut=true (cap=${timeoutMs}ms)` : null,
+                `events=${eventTypesSeen.length}`,
+                eventTypesSeen.length > 0
+                    ? `event_types=[${[...new Set(eventTypesSeen)].join(",")}]`
+                    : null,
+            ]
+                .filter((x): x is string => x !== null)
+                .join(" ")
+            reject(
+                new Error(
+                    `runOpenCodeOneShot: opencode produced no text output (${ctx})`,
+                ),
+            )
+        })
+    })
+}

--- a/packages/baro-orchestrator/src/opencode-stream-mapper.ts
+++ b/packages/baro-orchestrator/src/opencode-stream-mapper.ts
@@ -1,0 +1,162 @@
+/**
+ * Map OpenCode CLI `opencode run --format json` stream events to typed
+ * items for bus delivery. Sibling of `codex-stream-mapper.ts` (the Codex
+ * mapper) and `stream-json-mapper.ts` (the Claude mapper).
+ *
+ * OpenCode stream shape — observed against real `opencode run --format json`
+ * output. Each stdout line is a JSONL envelope:
+ *
+ *   {"type":"step_start","timestamp":N,"sessionID":"…","part":{…}}
+ *   {"type":"text","timestamp":N,"sessionID":"…","part":{"type":"text","text":"…",…}}
+ *   {"type":"tool_call","timestamp":N,"sessionID":"…","part":{"type":"tool-call","id":"…","tool":"…","args":{…}}}
+ *   {"type":"tool_result","timestamp":N,"sessionID":"…","part":{"type":"tool-result","id":"…","tool":"…","result":"…"}}
+ *   {"type":"step_finish","timestamp":N,"sessionID":"…","part":{"type":"step-finish","tokens":{…},"cost":N,…}}
+ *
+ * Mapping strategy:
+ *
+ *   - `step_start` → OpenCodeSystem semantic event (subtype "step_start").
+ *   - `text` → ModelMessageItem (assistant text) + OpenCodeStepEvent.
+ *   - `tool_call` → FunctionCallItem + OpenCodeStepEvent.
+ *   - `tool_result` → FunctionCallOutputItem + OpenCodeStepEvent.
+ *   - `step_finish` → OpenCodeSystem semantic event (subtype "step_finish",
+ *     carries token/cost metadata in `raw`).
+ *   - Unknown → OpenCodeUnknownEvent so nothing is silently dropped.
+ *
+ * Every input event maps to a non-empty array — we never silently drop
+ * data. Downstream observers (audit log, kaleidoskop replay, debug
+ * consoles) see every envelope OpenCode produces.
+ */
+
+import {
+    FunctionCallItem,
+    FunctionCallOutputItem,
+    ModelMessageItem,
+    SemanticEvent,
+} from "@mozaik-ai/core"
+
+import {
+    OpenCodeStepEvent,
+    OpenCodeSystem,
+    OpenCodeUnknownEvent,
+} from "./semantic-events.js"
+
+/** Union of all item types the OpenCode mapper can produce. */
+export type MappedOpenCodeItem =
+    | ModelMessageItem
+    | FunctionCallItem
+    | FunctionCallOutputItem
+    | SemanticEvent<unknown>
+
+/** Result of mapping a single OpenCode JSONL event. */
+export interface OpenCodeMapResult {
+    /** Mapped items to deliver on the bus. Always non-empty. */
+    items: MappedOpenCodeItem[]
+    /** OpenCode `sessionID` observed on this event, if any. */
+    sessionId: string | null
+}
+
+/**
+ * Map a single parsed OpenCode JSONL event to typed Mozaik items.
+ *
+ * @param agentId - The baro agent ID (story ID) that owns this stream.
+ * @param event - A parsed JSON object from OpenCode's stdout.
+ * @returns Mapped items and optional session ID.
+ */
+export function mapOpenCodeEvent(
+    agentId: string,
+    event: Record<string, any>,
+): OpenCodeMapResult {
+    const sessionId =
+        typeof event.sessionID === "string" ? event.sessionID : null
+    const items: MappedOpenCodeItem[] = []
+    const type = typeof event.type === "string" ? event.type : ""
+
+    // ─── step_start ────────────────────────────────────────────────
+    if (type === "step_start") {
+        items.push(
+            OpenCodeSystem.create({
+                agentId,
+                subtype: "step_start",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── text (assistant message) ──────────────────────────────────
+    if (type === "text") {
+        const part = event.part as Record<string, any> | undefined
+        const text = typeof part?.text === "string" ? part.text : ""
+        if (text) {
+            items.push(ModelMessageItem.rehydrate({ text }))
+        }
+        items.push(
+            OpenCodeStepEvent.create({
+                agentId,
+                stepType: "text",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── tool_call ─────────────────────────────────────────────────
+    if (type === "tool_call") {
+        const part = event.part as Record<string, any> | undefined
+        const callId = typeof part?.id === "string" ? part.id : `opencode:${Date.now()}`
+        const name = typeof part?.tool === "string" ? part.tool : "unknown"
+        const args =
+            part?.args !== undefined
+                ? typeof part.args === "string"
+                    ? part.args
+                    : JSON.stringify(part.args)
+                : "{}"
+        items.push(FunctionCallItem.rehydrate({ callId, name, args }))
+        items.push(
+            OpenCodeStepEvent.create({
+                agentId,
+                stepType: "tool_call",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── tool_result ───────────────────────────────────────────────
+    if (type === "tool_result") {
+        const part = event.part as Record<string, any> | undefined
+        const callId = typeof part?.id === "string" ? part.id : `opencode:${Date.now()}`
+        const result = typeof part?.result === "string" ? part.result : ""
+        items.push(FunctionCallOutputItem.create(callId, result))
+        items.push(
+            OpenCodeStepEvent.create({
+                agentId,
+                stepType: "tool_result",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── step_finish ───────────────────────────────────────────────
+    if (type === "step_finish") {
+        items.push(
+            OpenCodeSystem.create({
+                agentId,
+                subtype: "step_finish",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── unknown / future event type ───────────────────────────────
+    items.push(
+        OpenCodeUnknownEvent.create({
+            agentId,
+            openCodeType: type || "unspecified",
+            raw: event,
+        }),
+    )
+    return { items, sessionId }
+}

--- a/packages/baro-orchestrator/src/opencode-stream-mapper.ts
+++ b/packages/baro-orchestrator/src/opencode-stream-mapper.ts
@@ -8,16 +8,22 @@
  *
  *   {"type":"step_start","timestamp":N,"sessionID":"…","part":{…}}
  *   {"type":"text","timestamp":N,"sessionID":"…","part":{"type":"text","text":"…",…}}
- *   {"type":"tool_call","timestamp":N,"sessionID":"…","part":{"type":"tool-call","id":"…","tool":"…","args":{…}}}
- *   {"type":"tool_result","timestamp":N,"sessionID":"…","part":{"type":"tool-result","id":"…","tool":"…","result":"…"}}
+ *   {"type":"tool_use","timestamp":N,"sessionID":"…","part":{"type":"tool","tool":"write","callID":"…","state":{"status":"completed","input":{…},"output":"…"}}}
  *   {"type":"step_finish","timestamp":N,"sessionID":"…","part":{"type":"step-finish","tokens":{…},"cost":N,…}}
+ *
+ * NOTE: a tool invocation arrives as ONE `tool_use` event carrying both
+ * the call (`part.state.input`) and its result (`part.state.output`),
+ * NOT as a `tool_call`/`tool_result` pair. The pair shape is kept as a
+ * fallback for forward/backward compatibility but is not what the
+ * current binary emits.
  *
  * Mapping strategy:
  *
  *   - `step_start` → OpenCodeSystem semantic event (subtype "step_start").
  *   - `text` → ModelMessageItem (assistant text) + OpenCodeStepEvent.
- *   - `tool_call` → FunctionCallItem + OpenCodeStepEvent.
- *   - `tool_result` → FunctionCallOutputItem + OpenCodeStepEvent.
+ *   - `tool_use` → FunctionCallItem (+ FunctionCallOutputItem once the
+ *     tool completed) + OpenCodeStepEvent(s).
+ *   - `tool_call` / `tool_result` → fallback for the legacy paired shape.
  *   - `step_finish` → OpenCodeSystem semantic event (subtype "step_finish",
  *     carries token/cost metadata in `raw`).
  *   - Unknown → OpenCodeUnknownEvent so nothing is silently dropped.
@@ -62,9 +68,16 @@ export interface OpenCodeMapResult {
  * @param event - A parsed JSON object from OpenCode's stdout.
  * @returns Mapped items and optional session ID.
  */
+/** Best-effort stable id suffix from an event's own timestamp. */
+function eventTimestamp(event: Record<string, unknown>): string {
+    return typeof event.timestamp === "number"
+        ? String(event.timestamp)
+        : "0"
+}
+
 export function mapOpenCodeEvent(
     agentId: string,
-    event: Record<string, any>,
+    event: Record<string, unknown>,
 ): OpenCodeMapResult {
     const sessionId =
         typeof event.sessionID === "string" ? event.sessionID : null
@@ -85,7 +98,7 @@ export function mapOpenCodeEvent(
 
     // ─── text (assistant message) ──────────────────────────────────
     if (type === "text") {
-        const part = event.part as Record<string, any> | undefined
+        const part = event.part as Record<string, unknown> | undefined
         const text = typeof part?.text === "string" ? part.text : ""
         if (text) {
             items.push(ModelMessageItem.rehydrate({ text }))
@@ -100,10 +113,67 @@ export function mapOpenCodeEvent(
         return { items, sessionId }
     }
 
-    // ─── tool_call ─────────────────────────────────────────────────
+    // ─── tool_use ──────────────────────────────────────────────────
+    // The real `opencode run --format json` stream emits a SINGLE
+    // `tool_use` event per tool invocation (verified against the live
+    // binary), carrying both the call and its result in `part.state`:
+    //   part.tool             — tool name (e.g. "write", "bash", "read")
+    //   part.callID           — invocation id
+    //   part.state.input      — the arguments object
+    //   part.state.output     — the textual result (present once completed)
+    //   part.state.status     — "completed" | …
+    // The earlier `tool_call` / `tool_result` two-event shape (kept as a
+    // fallback below) was an assumption that never matched real output,
+    // so tool activity silently fell through to OpenCodeUnknownEvent —
+    // breaking function-call delivery and any tool-based success check.
+    if (type === "tool_use") {
+        const part = event.part as Record<string, unknown> | undefined
+        const state =
+            (part?.state as Record<string, unknown> | undefined) ?? undefined
+        const callId =
+            typeof part?.callID === "string"
+                ? part.callID
+                : typeof part?.id === "string"
+                  ? part.id
+                  : `opencode:${eventTimestamp(event)}`
+        const name = typeof part?.tool === "string" ? part.tool : "unknown"
+        const args =
+            state?.input !== undefined
+                ? typeof state.input === "string"
+                    ? state.input
+                    : JSON.stringify(state.input)
+                : "{}"
+        items.push(FunctionCallItem.rehydrate({ callId, name, args }))
+        items.push(
+            OpenCodeStepEvent.create({
+                agentId,
+                stepType: "tool_call",
+                raw: event,
+            }),
+        )
+        // Emit the result too when the tool has finished, so observers see
+        // a matched call/output pair from the single event.
+        if (state?.output !== undefined) {
+            const result =
+                typeof state.output === "string"
+                    ? state.output
+                    : JSON.stringify(state.output)
+            items.push(FunctionCallOutputItem.create(callId, result))
+            items.push(
+                OpenCodeStepEvent.create({
+                    agentId,
+                    stepType: "tool_result",
+                    raw: event,
+                }),
+            )
+        }
+        return { items, sessionId }
+    }
+
+    // ─── tool_call (legacy/fallback shape) ─────────────────────────
     if (type === "tool_call") {
-        const part = event.part as Record<string, any> | undefined
-        const callId = typeof part?.id === "string" ? part.id : `opencode:${Date.now()}`
+        const part = event.part as Record<string, unknown> | undefined
+        const callId = typeof part?.id === "string" ? part.id : `opencode:${eventTimestamp(event)}`
         const name = typeof part?.tool === "string" ? part.tool : "unknown"
         const args =
             part?.args !== undefined
@@ -122,10 +192,10 @@ export function mapOpenCodeEvent(
         return { items, sessionId }
     }
 
-    // ─── tool_result ───────────────────────────────────────────────
+    // ─── tool_result (legacy/fallback shape) ───────────────────────
     if (type === "tool_result") {
-        const part = event.part as Record<string, any> | undefined
-        const callId = typeof part?.id === "string" ? part.id : `opencode:${Date.now()}`
+        const part = event.part as Record<string, unknown> | undefined
+        const callId = typeof part?.id === "string" ? part.id : `opencode:${eventTimestamp(event)}`
         const result = typeof part?.result === "string" ? part.result : ""
         items.push(FunctionCallOutputItem.create(callId, result))
         items.push(

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -140,16 +140,16 @@ export interface OrchestrateConfig {
      * Planner phases are wired up in the Rust TUI layer, not here —
      * orchestrate.ts doesn't see them.
      */
-    llm?: "claude" | "openai" | "codex"
+    llm?: "claude" | "openai" | "codex" | "opencode"
     /**
      * Optional per-phase overrides. When set, win over `llm`. Each can
      * be any of the three providers, independent of the others. Used
      * by the `--llm hybrid` preset (Story+Critic on Codex bulk-savings,
      * Surgeon on Claude for rare-but-high-stakes failures).
      */
-    storyLlm?: "claude" | "openai" | "codex"
-    criticLlm?: "claude" | "openai" | "codex"
-    surgeonLlm?: "claude" | "openai" | "codex"
+    storyLlm?: "claude" | "openai" | "codex" | "opencode"
+    criticLlm?: "claude" | "openai" | "codex" | "opencode"
+    surgeonLlm?: "claude" | "openai" | "codex" | "opencode"
     /**
      * Per-phase model override for StoryAgent. When set, wins over
      * each story's individual `model` field in the PRD as well as
@@ -240,7 +240,7 @@ export async function orchestrate(
 ): Promise<OrchestrateResult> {
     const env = new AgenticEnvironment()
     const emitTui = config.emitTuiEvents ?? true
-    const llm: "claude" | "openai" | "codex" = config.llm ?? "claude"
+    const llm: "claude" | "openai" | "codex" | "opencode" = config.llm ?? "claude"
     // Per-phase resolution: each falls back to global `llm` when no
     // explicit override is provided. This is the central place where
     // hybrid configurations land — every downstream factory branches

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -30,6 +30,7 @@ import {
 import { Critic } from "./participants/critic.js"
 import { CriticCodex } from "./participants/critic-codex.js"
 import { CriticOpenAI } from "./participants/critic-openai.js"
+import { CriticOpenCode } from "./participants/critic-opencode.js"
 import { Finalizer } from "./participants/finalizer.js"
 import { joinBaroEventForwarders } from "./participants/forwarders/index.js"
 import { Librarian } from "./participants/librarian.js"
@@ -41,6 +42,7 @@ import { type StoryAgent } from "./participants/story-agent.js"
 import { Surgeon, type PrdSnapshot } from "./participants/surgeon.js"
 import { SurgeonCodex } from "./participants/surgeon-codex.js"
 import { SurgeonOpenAI } from "./participants/surgeon-openai.js"
+import { SurgeonOpenCode } from "./participants/surgeon-opencode.js"
 import { PrdFile, loadPrd } from "./prd.js"
 import { RunStartRequest } from "./semantic-events.js"
 import { emit } from "./tui-protocol.js"
@@ -287,6 +289,11 @@ export async function orchestrate(
             "[orchestrate] llm=codex: Story, Critic, Surgeon all shelling out to " +
                 "`codex exec --json` (ChatGPT subscription path).\n",
         )
+    } else if (llm === "opencode") {
+        process.stderr.write(
+            "[orchestrate] llm=opencode: Story, Critic, Surgeon all shelling out to " +
+                "`opencode run --format json` (OpenCode CLI path).\n",
+        )
     } else {
         process.stderr.write(
             "[orchestrate] llm=claude: Story, Critic, Surgeon all shelling out to " +
@@ -359,7 +366,7 @@ export async function orchestrate(
     // Phase-4 observer — Surgeon (adaptive DAG mutation). Opt-in.
     // Joins early so it sees StoryResultItem-s from the moment the
     // Conductor starts running.
-    let surgeon: Surgeon | SurgeonOpenAI | SurgeonCodex | null = null
+    let surgeon: Surgeon | SurgeonOpenAI | SurgeonCodex | SurgeonOpenCode | null = null
     if (config.withSurgeon) {
         const snapshot = (): PrdSnapshot => {
             const current = loadPrd(config.prdPath)
@@ -391,6 +398,12 @@ export async function orchestrate(
                 useLlm: config.surgeonUseLlm ?? true,
                 model: config.surgeonModel,
             })
+        } else if (surgeonLlm === "opencode") {
+            surgeon = new SurgeonOpenCode({
+                snapshot,
+                useLlm: config.surgeonUseLlm ?? true,
+                model: config.surgeonModel,
+            })
         } else {
             surgeon = new Surgeon({
                 snapshot,
@@ -404,7 +417,7 @@ export async function orchestrate(
     // Phase-3 observer — Critic (live acceptance-criteria evaluator).
     // Opt-in (default OFF). Spawns `claude --model haiku` subprocesses
     // for each evaluation, inheriting Claude CLI auth.
-    let critic: Critic | CriticOpenAI | CriticCodex | null = null
+    let critic: Critic | CriticOpenAI | CriticCodex | CriticOpenCode | null = null
     if (config.withCritic) {
         const prd = loadPrd(config.prdPath)
         const targets = new Map<string, readonly string[]>(
@@ -423,6 +436,11 @@ export async function orchestrate(
             })
         } else if (criticLlm === "codex") {
             critic = new CriticCodex({
+                targets,
+                model: config.criticModel,
+            })
+        } else if (criticLlm === "opencode") {
+            critic = new CriticOpenCode({
                 targets,
                 model: config.criticModel,
             })

--- a/packages/baro-orchestrator/src/participants/critic-opencode.ts
+++ b/packages/baro-orchestrator/src/participants/critic-opencode.ts
@@ -1,0 +1,180 @@
+/**
+ * CriticOpenCode — live acceptance-criteria evaluator via
+ * `opencode run --format json`. Sibling of `critic.ts` (Claude),
+ * `critic-openai.ts`, and `critic-codex.ts`.
+ *
+ * Same bus contract as the other variants: observes AgentResultItem
+ * events, evaluates the agent's output against acceptance criteria,
+ * publishes a CritiqueItem (audit trail), and emits an
+ * AgentTargetedMessageItem corrective when the verdict is "fail" (up
+ * to maxEmissionsPerAgent). The only difference is which subprocess
+ * the verdict call shells to.
+ *
+ * Library-grade: no imports from prd.ts, story-agent.ts, or
+ * conductor.ts.
+ */
+
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import { runOpenCodeOneShot } from "../opencode-one-shot.js"
+import {
+    AgentResult,
+    AgentTargetedMessage,
+    Critique,
+} from "../semantic-events.js"
+import {
+    VERDICT_SYSTEM_PROMPT,
+    buildEvalPrompt,
+    buildCorrectiveMessage,
+    extractVerdictJson,
+} from "./critic.js"
+
+export interface CriticOpenCodeOptions {
+    /** Map from agentId to its acceptance-criteria strings. */
+    targets: ReadonlyMap<string, readonly string[]>
+    /** Max corrective AgentTargetedMessageItem-s per agent. Default: 2. */
+    maxEmissionsPerAgent?: number
+    /**
+     * Model identifier in `provider/model` format
+     * (e.g. "anthropic/claude-sonnet-4"). Omit to use OpenCode's
+     * configured default.
+     */
+    model?: string
+    /** Path to the `opencode` binary. Default: "opencode". */
+    opencodeBin?: string
+    /** Per-evaluation timeout in milliseconds. Default: 180_000 (3 min). */
+    timeoutMs?: number
+}
+
+export class CriticOpenCode extends BaseObserver {
+    private readonly opts: Required<
+        Omit<CriticOpenCodeOptions, "targets" | "model" | "opencodeBin">
+    > & {
+        targets: ReadonlyMap<string, readonly string[]>
+        model: string | undefined
+        opencodeBin: string
+    }
+    private readonly emissions = new Map<string, number>()
+    private readonly turnCount = new Map<string, number>()
+    private readonly pending = new Set<Promise<void>>()
+
+    constructor(opts: CriticOpenCodeOptions) {
+        super()
+        this.opts = {
+            maxEmissionsPerAgent: opts.maxEmissionsPerAgent ?? 2,
+            model: opts.model,
+            opencodeBin: opts.opencodeBin ?? "opencode",
+            timeoutMs: opts.timeoutMs ?? 180_000,
+            targets: opts.targets,
+        }
+    }
+
+    /** Resolves once every in-flight evaluation has emitted its CritiqueItem. */
+    async idle(): Promise<void> {
+        await Promise.allSettled([...this.pending])
+    }
+
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (!AgentResult.is(event)) return
+        const { agentId, isError, resultText } = event.data
+        if (isError || !resultText) return
+
+        const criteria = this.opts.targets.get(agentId)
+        if (!criteria || criteria.length === 0) return
+
+        const turn = (this.turnCount.get(agentId) ?? 0) + 1
+        this.turnCount.set(agentId, turn)
+
+        const work = (async () => {
+            const { verdict, reasoning, violatedCriteria } = await this.evaluate(
+                resultText,
+                criteria,
+            )
+
+            const critiqueEvent = Critique.create({
+                agentId,
+                verdict,
+                reasoning,
+                violatedCriteria,
+                turn,
+                modelUsed: this.opts.model ?? "opencode-default",
+            })
+            for (const env of this.getEnvironments()) {
+                env.deliverSemanticEvent(this, critiqueEvent)
+            }
+
+            if (verdict === "fail") {
+                const emitted = this.emissions.get(agentId) ?? 0
+                if (emitted < this.opts.maxEmissionsPerAgent) {
+                    this.emissions.set(agentId, emitted + 1)
+                    const text = buildCorrectiveMessage(reasoning, violatedCriteria)
+                    const msg = AgentTargetedMessage.create({
+                        recipientId: agentId,
+                        text,
+                        metadata: {
+                            criticTurn: turn,
+                            emissionIndex: emitted + 1,
+                        },
+                    })
+                    for (const env of this.getEnvironments()) {
+                        env.deliverSemanticEvent(this, msg)
+                    }
+                }
+            }
+        })()
+
+        this.pending.add(work)
+        work.finally(() => {
+            this.pending.delete(work)
+        })
+
+        await work
+    }
+
+    private async evaluate(
+        resultText: string,
+        criteria: readonly string[],
+    ): Promise<{
+        verdict: "pass" | "fail"
+        reasoning: string
+        violatedCriteria: string[]
+    }> {
+        const userPrompt = buildEvalPrompt(criteria, resultText)
+        const prompt = `${VERDICT_SYSTEM_PROMPT}\n\n${userPrompt}`
+
+        try {
+            const text = await runOpenCodeOneShot({
+                prompt,
+                cwd: process.cwd(),
+                model: this.opts.model,
+                opencodeBin: this.opts.opencodeBin,
+                timeoutMs: this.opts.timeoutMs,
+                label: "opencode-critic",
+            })
+
+            const verdictJson = extractVerdictJson(text.trim())
+            const parsed = JSON.parse(verdictJson) as {
+                verdict: "pass" | "fail"
+                reasoning: string
+                violated_criteria: string[]
+            }
+
+            return {
+                verdict: parsed.verdict === "pass" ? "pass" : "fail",
+                reasoning: parsed.reasoning ?? "",
+                violatedCriteria: Array.isArray(parsed.violated_criteria)
+                    ? parsed.violated_criteria
+                    : [],
+            }
+        } catch (err) {
+            return {
+                verdict: "fail",
+                reasoning: `CriticOpenCode LLM call failed: ${String((err as Error)?.message ?? err)}`,
+                violatedCriteria: ["[critic error — could not evaluate]"],
+            }
+        }
+    }
+}

--- a/packages/baro-orchestrator/src/participants/opencode-cli-participant.ts
+++ b/packages/baro-orchestrator/src/participants/opencode-cli-participant.ts
@@ -62,6 +62,21 @@ export interface OpenCodeRunSummary {
     sessionId: string | null
     exitCode: number | null
     error: Error | null
+    /**
+     * True once at least one `step_finish` event was observed — i.e. the
+     * agent loop actually completed a step rather than the process simply
+     * exiting. `opencode run` exits 0 even when the model refuses or
+     * produces no work, so exit code alone is NOT proof of task success
+     * (verified empirically). Callers should require this before treating
+     * exitCode 0 as a real completion.
+     */
+    sawStepFinish: boolean
+    /**
+     * Number of `tool_call` events observed. A code-writing story that
+     * claims success having invoked zero tools is suspect — the agent
+     * likely answered in prose instead of editing the worktree.
+     */
+    toolCallCount: number
 }
 
 /**
@@ -99,6 +114,9 @@ export class OpenCodeCliParticipant extends BaseObserver {
     private sessionId: string | null = null
     private exitCode: number | null = null
     private spawnError: Error | null = null
+    private sawStepFinish = false
+    private toolCallCount = 0
+    private doneSettled = false
     private resolveDone!: (summary: OpenCodeRunSummary) => void
     private resolveReady!: () => void
     private rejectReady!: (e: Error) => void
@@ -125,6 +143,21 @@ export class OpenCodeCliParticipant extends BaseObserver {
         this.done = new Promise<OpenCodeRunSummary>((res) => {
             this.resolveDone = res
         })
+    }
+
+    /**
+     * Settle the `done` promise exactly once. Both the `exit` and
+     * `error` process listeners can fire (in either order, or one
+     * without the other), so every resolution path goes through here to
+     * avoid a double-resolve and, more importantly, to guarantee `done`
+     * always settles — the previous `error` handler rejected `ready` but
+     * never resolved `done`, so an async spawn error with no following
+     * `exit` left `done` pending forever and any awaiter hung.
+     */
+    private settleDone(summary: OpenCodeRunSummary): void {
+        if (this.doneSettled) return
+        this.doneSettled = true
+        this.resolveDone(summary)
     }
 
     getSessionId(): string | null {
@@ -154,10 +187,12 @@ export class OpenCodeCliParticipant extends BaseObserver {
             this.spawnError = e instanceof Error ? e : new Error(String(e))
             this.transition("failed", this.spawnError.message)
             this.rejectReady(this.spawnError)
-            this.resolveDone({
+            this.settleDone({
                 sessionId: null,
                 exitCode: null,
                 error: this.spawnError,
+                sawStepFinish: this.sawStepFinish,
+                toolCallCount: this.toolCallCount,
             })
             return
         }
@@ -171,8 +206,22 @@ export class OpenCodeCliParticipant extends BaseObserver {
         proc.stdout!.on("data", (chunk: string) => this.handleStdout(chunk))
         proc.stderr!.on("data", (chunk: string) => this.handleStderr(chunk))
         proc.on("error", (err) => {
+            // Async process error (e.g. EACCES/EPIPE surfaced after a
+            // successful spawn). An 'exit' event may NOT follow, so settle
+            // `done` here too — otherwise the story agent's `await
+            // opencode.done` recovery path (and the one-shot caller) hang
+            // until their outer timeout, or forever where there is none.
+            OpenCodeCliParticipant.active.delete(this)
             this.spawnError = err
+            this.transition("failed", err.message)
             this.rejectReady(err)
+            this.settleDone({
+                sessionId: this.sessionId,
+                exitCode: this.exitCode,
+                error: err,
+                sawStepFinish: this.sawStepFinish,
+                toolCallCount: this.toolCallCount,
+            })
         })
         proc.on("exit", (code) => {
             OpenCodeCliParticipant.active.delete(this)
@@ -185,10 +234,12 @@ export class OpenCodeCliParticipant extends BaseObserver {
                 finalPhase,
                 code != null ? `exit code ${code}` : "no exit code",
             )
-            this.resolveDone({
+            this.settleDone({
                 sessionId: this.sessionId,
                 exitCode: code,
                 error: this.spawnError,
+                sawStepFinish: this.sawStepFinish,
+                toolCallCount: this.toolCallCount,
             })
         })
     }
@@ -261,6 +312,17 @@ export class OpenCodeCliParticipant extends BaseObserver {
         const { items, sessionId } = mapOpenCodeEvent(this.agentId, parsed)
         if (sessionId && !this.sessionId) {
             this.sessionId = sessionId
+        }
+        // Track completion evidence for the success predicate. exitCode 0
+        // is necessary but not sufficient — `opencode run` exits 0 on a
+        // refused/no-op turn — so the story agent additionally requires a
+        // step_finish (the agent loop actually completed) and at least one
+        // tool_call (it did work rather than answering in prose).
+        if (parsed.type === "step_finish") this.sawStepFinish = true
+        // Real opencode emits `tool_use`; `tool_call` is the legacy
+        // fallback shape. Count either as evidence the agent did work.
+        if (parsed.type === "tool_use" || parsed.type === "tool_call") {
+            this.toolCallCount += 1
         }
 
         for (const item of items) {

--- a/packages/baro-orchestrator/src/participants/opencode-cli-participant.ts
+++ b/packages/baro-orchestrator/src/participants/opencode-cli-participant.ts
@@ -140,6 +140,12 @@ export class OpenCodeCliParticipant extends BaseObserver {
             this.resolveReady = res
             this.rejectReady = rej
         })
+        // Suppress UnhandledPromiseRejection when callers only await
+        // `done` and never attach a rejection handler to `ready`. The
+        // rejection is still observable by callers who do await `ready`;
+        // the no-op catch here only prevents the Node.js warning when no
+        // one is listening.
+        this.ready.catch(() => { /* suppressed — callers use `done` */ })
         this.done = new Promise<OpenCodeRunSummary>((res) => {
             this.resolveDone = res
         })

--- a/packages/baro-orchestrator/src/participants/opencode-cli-participant.ts
+++ b/packages/baro-orchestrator/src/participants/opencode-cli-participant.ts
@@ -1,0 +1,324 @@
+/**
+ * OpenCodeCliParticipant — wraps an OpenCode CLI process as a
+ * first-class Mozaik Participant. Sibling of `CodexCliParticipant`
+ * and `ClaudeCliParticipant`.
+ *
+ * Spawned with `opencode run --format json --dangerously-skip-permissions "PROMPT"`.
+ * OpenCode `run` is one-shot non-interactive: takes a single prompt as
+ * argv, streams JSONL events to stdout, exits when the agent finishes.
+ * There is no stdin event loop (unlike Claude Code's stream-json input).
+ * That makes this participant simpler than ClaudeCliParticipant in one
+ * respect — `onExternalEvent` doesn't forward AgentTargetedMessage to a
+ * running process; new prompts mean a new OpenCode invocation.
+ *
+ * Library-grade: knows nothing about baro, PRD, or stories. Only knows
+ * about agent IDs, working directories, and OpenCode.
+ */
+
+import { ChildProcess, spawn } from "child_process"
+
+import {
+    BaseObserver,
+    FunctionCallItem,
+    FunctionCallOutputItem,
+    ModelMessageItem,
+    Participant,
+    SemanticEvent,
+} from "@mozaik-ai/core"
+
+import { AgenticEnvironment } from "@mozaik-ai/core"
+import {
+    AgentState,
+    AgentTargetedMessage,
+    OpenCodeSystem,
+    type AgentPhase,
+} from "../semantic-events.js"
+import { mapOpenCodeEvent } from "../opencode-stream-mapper.js"
+
+/** Options for constructing an OpenCodeCliParticipant. */
+export interface OpenCodeCliParticipantOptions {
+    /** Working directory for the OpenCode process. Required. */
+    cwd: string
+    /** Initial prompt — passed as the final argv to `opencode run`. */
+    prompt: string
+    /**
+     * Model identifier in `provider/model` format (e.g.
+     * "anthropic/claude-sonnet-4-20250514", "openai/gpt-4o").
+     * Passed via `-m`. Omit to let OpenCode use its configured default.
+     */
+    model?: string
+    /** Path to the `opencode` binary. Default: "opencode" (resolved via PATH). */
+    opencodeBin?: string
+    /**
+     * Whether to pass `--dangerously-skip-permissions`. Required for
+     * autonomous baro runs because OpenCode's default mode prompts for
+     * tool approvals. Default: true.
+     */
+    skipPermissions?: boolean
+}
+
+/** Summary emitted when the OpenCode process exits. */
+export interface OpenCodeRunSummary {
+    sessionId: string | null
+    exitCode: number | null
+    error: Error | null
+}
+
+/**
+ * Mozaik participant that wraps a single `opencode run` CLI subprocess.
+ * Streams JSONL events to the bus and manages lifecycle transitions.
+ */
+export class OpenCodeCliParticipant extends BaseObserver {
+    /**
+     * Process-wide registry of every OpenCode child currently running.
+     * Used by the orchestrator's SIGINT/SIGTERM handlers to nuke orphans
+     * so a killed baro doesn't leave background agents burning quota.
+     */
+    private static readonly active = new Set<OpenCodeCliParticipant>()
+
+    /** Send a signal to every active OpenCode child. Idempotent. */
+    static killAll(signal: NodeJS.Signals = "SIGTERM"): void {
+        for (const p of OpenCodeCliParticipant.active) {
+            try {
+                p.proc?.kill(signal)
+            } catch {
+                // best-effort
+            }
+        }
+    }
+
+    private readonly options: Required<
+        Pick<OpenCodeCliParticipantOptions, "opencodeBin" | "skipPermissions">
+    > &
+        OpenCodeCliParticipantOptions
+
+    private proc: ChildProcess | null = null
+    private buffer = ""
+    private envRef: AgenticEnvironment | null = null
+    private currentPhase: AgentPhase = "idle"
+    private sessionId: string | null = null
+    private exitCode: number | null = null
+    private spawnError: Error | null = null
+    private resolveDone!: (summary: OpenCodeRunSummary) => void
+    private resolveReady!: () => void
+    private rejectReady!: (e: Error) => void
+
+    /** Resolves once OpenCode emits its first `step_start` event. */
+    public readonly ready: Promise<void>
+    /** Resolves once the OpenCode process exits (regardless of success). */
+    public readonly done: Promise<OpenCodeRunSummary>
+
+    constructor(
+        public readonly agentId: string,
+        opts: OpenCodeCliParticipantOptions,
+    ) {
+        super()
+        this.options = {
+            opencodeBin: "opencode",
+            skipPermissions: true,
+            ...opts,
+        }
+        this.ready = new Promise<void>((res, rej) => {
+            this.resolveReady = res
+            this.rejectReady = rej
+        })
+        this.done = new Promise<OpenCodeRunSummary>((res) => {
+            this.resolveDone = res
+        })
+    }
+
+    getSessionId(): string | null {
+        return this.sessionId
+    }
+
+    getPhase(): AgentPhase {
+        return this.currentPhase
+    }
+
+    /**
+     * Spawn the OpenCode process and start streaming its events into the
+     * environment. Idempotent: subsequent calls are a no-op.
+     */
+    start(environment: AgenticEnvironment): void {
+        if (this.proc) return
+        this.envRef = environment
+
+        const args = this.buildArgs()
+        let proc: ChildProcess
+        try {
+            proc = spawn(this.options.opencodeBin, args, {
+                cwd: this.options.cwd,
+                stdio: ["ignore", "pipe", "pipe"],
+            })
+        } catch (e) {
+            this.spawnError = e instanceof Error ? e : new Error(String(e))
+            this.transition("failed", this.spawnError.message)
+            this.rejectReady(this.spawnError)
+            this.resolveDone({
+                sessionId: null,
+                exitCode: null,
+                error: this.spawnError,
+            })
+            return
+        }
+
+        this.proc = proc
+        OpenCodeCliParticipant.active.add(this)
+        this.transition("starting")
+
+        proc.stdout!.setEncoding("utf8")
+        proc.stderr!.setEncoding("utf8")
+        proc.stdout!.on("data", (chunk: string) => this.handleStdout(chunk))
+        proc.stderr!.on("data", (chunk: string) => this.handleStderr(chunk))
+        proc.on("error", (err) => {
+            this.spawnError = err
+            this.rejectReady(err)
+        })
+        proc.on("exit", (code) => {
+            OpenCodeCliParticipant.active.delete(this)
+            this.exitCode = code
+            const finalPhase: AgentPhase =
+                this.spawnError != null || (code != null && code !== 0)
+                    ? "failed"
+                    : "done"
+            this.transition(
+                finalPhase,
+                code != null ? `exit code ${code}` : "no exit code",
+            )
+            this.resolveDone({
+                sessionId: this.sessionId,
+                exitCode: code,
+                error: this.spawnError,
+            })
+        })
+    }
+
+    /** Kill the OpenCode process. Resolves once exit fires. */
+    abort(signal: NodeJS.Signals = "SIGTERM"): void {
+        this.transition("aborted")
+        this.proc?.kill(signal)
+    }
+
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        // No-op for now. OpenCode run is one-shot: it doesn't have a
+        // stdin user-message channel like Claude Code. AgentTargetedMessage
+        // delivery to a running OpenCode would require a new invocation.
+        if (
+            AgentTargetedMessage.is(event) &&
+            event.data.recipientId === this.agentId
+        ) {
+            process.stderr.write(
+                `[opencode:${this.agentId}] received AgentTargetedMessage but OpenCode run is one-shot — dropped\n`,
+            )
+        }
+    }
+
+    private buildArgs(): string[] {
+        // `opencode run --format json --dangerously-skip-permissions`
+        const args = ["run", "--format", "json"]
+        if (this.options.skipPermissions) {
+            args.push("--dangerously-skip-permissions")
+        }
+        if (this.options.model) args.push("-m", this.options.model)
+        if (this.options.cwd) args.push("--dir", this.options.cwd)
+        // Prompt is the final positional. spawn() passes argv directly
+        // so no quoting needed.
+        args.push(this.options.prompt)
+        return args
+    }
+
+    private handleStdout(chunk: string): void {
+        this.buffer += chunk
+        let nl: number
+        while ((nl = this.buffer.indexOf("\n")) >= 0) {
+            const line = this.buffer.slice(0, nl).trim()
+            this.buffer = this.buffer.slice(nl + 1)
+            if (!line) continue
+            this.processLine(line)
+        }
+    }
+
+    private handleStderr(chunk: string): void {
+        const trimmed = chunk.trimEnd()
+        if (!trimmed) return
+        process.stderr.write(`[opencode:${this.agentId}/stderr] ${trimmed}\n`)
+    }
+
+    private processLine(line: string): void {
+        let parsed: Record<string, any>
+        try {
+            parsed = JSON.parse(line)
+        } catch {
+            process.stderr.write(
+                `[opencode:${this.agentId}] non-JSON stdout: ${line.slice(0, 200)}\n`,
+            )
+            return
+        }
+
+        const { items, sessionId } = mapOpenCodeEvent(this.agentId, parsed)
+        if (sessionId && !this.sessionId) {
+            this.sessionId = sessionId
+        }
+
+        for (const item of items) {
+            if (item instanceof SemanticEvent) {
+                // Lifecycle signals: step_start → ready + running.
+                if (
+                    OpenCodeSystem.is(item) &&
+                    item.data.subtype === "step_start"
+                ) {
+                    this.transition("running", "opencode step started")
+                    this.resolveReady()
+                }
+                // Don't transition to "done" on step_finish — the
+                // process-exit listener owns that, so we observe the real
+                // exit code before locking in the AgentPhase.
+            }
+            this.dispatch(item)
+        }
+    }
+
+    /**
+     * Route a mapped event to the right Mozaik delivery channel.
+     * Assistant-side LLM items use Mozaik's typed channels; everything
+     * else goes through deliverSemanticEvent.
+     */
+    private dispatch(
+        item:
+            | ModelMessageItem
+            | FunctionCallItem
+            | FunctionCallOutputItem
+            | SemanticEvent<unknown>,
+    ): void {
+        if (!this.envRef) return
+        if (item instanceof ModelMessageItem) {
+            this.envRef.deliverModelMessage(this, item)
+            return
+        }
+        if (item instanceof FunctionCallItem) {
+            this.envRef.deliverFunctionCall(this, item)
+            return
+        }
+        if (item instanceof FunctionCallOutputItem) {
+            this.envRef.deliverFunctionCallOutput(this, item)
+            return
+        }
+        this.envRef.deliverSemanticEvent(this, item)
+    }
+
+    private transition(next: AgentPhase, detail?: string): void {
+        if (next === this.currentPhase) return
+        this.currentPhase = next
+        this.envRef?.deliverSemanticEvent(
+            this,
+            AgentState.create({
+                agentId: this.agentId,
+                phase: next,
+                detail,
+            }),
+        )
+    }
+}

--- a/packages/baro-orchestrator/src/participants/opencode-story-agent.ts
+++ b/packages/baro-orchestrator/src/participants/opencode-story-agent.ts
@@ -283,14 +283,36 @@ export class OpenCodeStoryAgent extends BaseObserver {
         opencode.leave(this.envRef)
         this.currentOpenCode = null
 
-        const success =
-            summary.exitCode === 0 && summary.error == null
-
-        if (!success) {
+        // Success requires POSITIVE evidence of completed work, not
+        // merely the absence of a crash. `opencode run` exits 0 even when
+        // the model refuses the task or produces no edits (verified
+        // empirically: a refusal turn returns exitCode 0), so a clean exit
+        // alone would mark a no-op story as passed. We therefore also
+        // require the agent loop to have actually finished (`sawStepFinish`)
+        // and to have invoked at least one tool — a code-writing story that
+        // claims success having touched no tools almost certainly answered
+        // in prose instead of editing the worktree. This brings the
+        // OpenCode predicate up to (and slightly past) the Claude path,
+        // which gates on a non-error result payload.
+        if (summary.exitCode !== 0 || summary.error != null) {
             const reason = summary.error
                 ? summary.error.message
                 : `non-zero exit ${summary.exitCode}`
             return { success: false, summary, error: reason }
+        }
+        if (!summary.sawStepFinish) {
+            return {
+                success: false,
+                summary,
+                error: "opencode exited 0 but emitted no step_finish — the agent loop did not complete (likely a refusal or early abort)",
+            }
+        }
+        if (summary.toolCallCount === 0) {
+            return {
+                success: false,
+                summary,
+                error: "opencode exited 0 but invoked no tools — the agent answered in prose without editing the worktree, so the story is not verifiably done",
+            }
         }
 
         return { success: true, summary, error: null }

--- a/packages/baro-orchestrator/src/participants/opencode-story-agent.ts
+++ b/packages/baro-orchestrator/src/participants/opencode-story-agent.ts
@@ -1,0 +1,347 @@
+/**
+ * OpenCodeStoryAgent — story-level wrapper that drives an
+ * OpenCodeCliParticipant through a single piece of work, with retries
+ * and per-attempt timeout. Sibling of `codex-story-agent.ts` (Codex)
+ * and `story-agent.ts` (Claude).
+ *
+ * Lifecycle is simpler than the Claude variant because OpenCode `run` is
+ * one-shot: each attempt spawns a fresh `opencode run --format json`
+ * process, which streams events and exits when the agent finishes. There
+ * is no multi-turn quiet-timer / stdin-injection dance.
+ *
+ *   idle ─► starting ─► running ─► done | failed
+ *                              ╰► retrying ─► running ─► …
+ *
+ * Outer retry budget and hard timeout match StoryAgent's defaults so
+ * the orchestrator-level semantics are uniform across backends.
+ */
+
+import { setTimeout as setTimeoutPromise } from "timers/promises"
+
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import { AgenticEnvironment } from "@mozaik-ai/core"
+import {
+    AgentState,
+    StoryResult,
+    type AgentPhase,
+} from "../semantic-events.js"
+import {
+    OpenCodeCliParticipant,
+    type OpenCodeRunSummary,
+} from "./opencode-cli-participant.js"
+
+/** Specification for an OpenCode-backed story execution. */
+export interface OpenCodeStorySpec {
+    /** Story ID, used as agentId for observer attribution. */
+    id: string
+    /** The prompt sent to OpenCode as the initial user message. */
+    prompt: string
+    /** Working directory for OpenCode. */
+    cwd: string
+    /** Optional model override (e.g. "anthropic/claude-sonnet-4-20250514"). */
+    model?: string
+    /** Retry budget (number of *additional* attempts after the first). */
+    retries?: number
+    /** Per-attempt timeout in seconds. Default: 600. */
+    timeoutSecs?: number
+    /** Delay between retries in milliseconds. Default: 1500. */
+    retryDelayMs?: number
+    /**
+     * Hard cap in seconds for the entire story across all attempts. The
+     * OpenCode process is aborted unconditionally when this fires. <= 0
+     * disables the absolute kill timer. Default: 0 (matches StoryAgent).
+     */
+    hardTimeoutSecs?: number
+    /**
+     * Whether to pass `--dangerously-skip-permissions`. Required for
+     * autonomous baro runs because OpenCode's default mode prompts for
+     * tool approvals. Default: true.
+     */
+    skipPermissions?: boolean
+}
+
+/** Outcome of a completed (passed or exhausted) story execution. */
+export interface OpenCodeStoryOutcome {
+    storyId: string
+    success: boolean
+    attempts: number
+    durationSecs: number
+    finalSummary: OpenCodeRunSummary | null
+    error: string | null
+}
+
+/**
+ * Mozaik observer that runs a story on the OpenCode backend with retry
+ * logic and timeout management.
+ */
+export class OpenCodeStoryAgent extends BaseObserver {
+    private readonly spec: Required<
+        Pick<
+            OpenCodeStorySpec,
+            | "retries"
+            | "timeoutSecs"
+            | "retryDelayMs"
+            | "hardTimeoutSecs"
+            | "skipPermissions"
+        >
+    > &
+        OpenCodeStorySpec
+
+    private envRef: AgenticEnvironment | null = null
+    private currentOpenCode: OpenCodeCliParticipant | null = null
+    private currentPhase: AgentPhase = "idle"
+    private startedAt: number | null = null
+    private resolveDone!: (outcome: OpenCodeStoryOutcome) => void
+    public readonly done: Promise<OpenCodeStoryOutcome>
+
+    constructor(spec: OpenCodeStorySpec) {
+        super()
+        this.spec = {
+            retries: 2,
+            timeoutSecs: 600,
+            retryDelayMs: 1500,
+            hardTimeoutSecs: 0,
+            skipPermissions: true,
+            ...spec,
+        }
+        this.done = new Promise<OpenCodeStoryOutcome>((res) => {
+            this.resolveDone = res
+        })
+    }
+
+    get id(): string {
+        return this.spec.id
+    }
+
+    get agentId(): string {
+        return this.spec.id
+    }
+
+    getPhase(): AgentPhase {
+        return this.currentPhase
+    }
+
+    getCurrentOpenCode(): OpenCodeCliParticipant | null {
+        return this.currentOpenCode
+    }
+
+    /**
+     * Begin executing the story. Idempotent. Returns the `done` promise
+     * for the caller's convenience.
+     */
+    run(environment: AgenticEnvironment): Promise<OpenCodeStoryOutcome> {
+        if (this.startedAt != null) {
+            return this.done
+        }
+        this.envRef = environment
+        this.startedAt = Date.now()
+        this.transition("starting", "story queued")
+        void this.executeAllAttempts()
+        return this.done
+    }
+
+    /**
+     * No-op: OpenCode run is one-shot, there's no stdin channel to forward
+     * mid-flight messages to.
+     */
+    override async onExternalEvent(
+        _source: Participant,
+        _event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        // Intentionally empty — OpenCode run doesn't have the multi-turn
+        // stdin lifecycle that StoryAgent uses for Claude.
+    }
+
+    /** Abort the story, killing the running OpenCode (if any). */
+    abort(): void {
+        this.currentOpenCode?.abort()
+        this.transition("aborted", "external abort")
+    }
+
+    private async executeAllAttempts(): Promise<void> {
+        const maxAttempts = this.spec.retries + 1
+        let lastSummary: OpenCodeRunSummary | null = null
+        let lastError: string | null = null
+        let hardTimedOut = false
+
+        const hardTimer =
+            this.spec.hardTimeoutSecs > 0
+                ? setTimeout(() => {
+                      hardTimedOut = true
+                      this.currentOpenCode?.abort()
+                  }, this.spec.hardTimeoutSecs * 1000)
+                : null
+
+        try {
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+                if (hardTimedOut) {
+                    lastError = `hard timeout after ${this.spec.hardTimeoutSecs}s`
+                    break
+                }
+
+                if (attempt > 1) {
+                    this.transition(
+                        "waiting",
+                        `retrying (attempt ${attempt}/${maxAttempts})`,
+                    )
+                    await setTimeoutPromise(this.spec.retryDelayMs)
+                    if (hardTimedOut) {
+                        lastError = `hard timeout after ${this.spec.hardTimeoutSecs}s`
+                        break
+                    }
+                }
+
+                const result = await this.runOneAttempt(attempt)
+                lastSummary = result.summary
+                lastError = result.error
+
+                if (result.success) {
+                    const durationSecs = Math.round(
+                        (Date.now() - (this.startedAt ?? Date.now())) / 1000,
+                    )
+                    this.transition("done", `success on attempt ${attempt}`)
+                    this.emitStoryResult(true, attempt, durationSecs, null)
+                    this.resolveDone({
+                        storyId: this.spec.id,
+                        success: true,
+                        attempts: attempt,
+                        durationSecs,
+                        finalSummary: result.summary,
+                        error: null,
+                    })
+                    return
+                }
+
+                if (hardTimedOut) {
+                    lastError = `hard timeout after ${this.spec.hardTimeoutSecs}s`
+                    break
+                }
+            }
+        } finally {
+            if (hardTimer !== null) clearTimeout(hardTimer)
+        }
+
+        const durationSecs = Math.round(
+            (Date.now() - (this.startedAt ?? Date.now())) / 1000,
+        )
+        this.transition("failed", `exhausted ${maxAttempts} attempts`)
+        this.emitStoryResult(false, maxAttempts, durationSecs, lastError)
+        this.resolveDone({
+            storyId: this.spec.id,
+            success: false,
+            attempts: maxAttempts,
+            durationSecs,
+            finalSummary: lastSummary,
+            error: lastError,
+        })
+    }
+
+    private async runOneAttempt(
+        attempt: number,
+    ): Promise<{
+        success: boolean
+        summary: OpenCodeRunSummary | null
+        error: string | null
+    }> {
+        if (!this.envRef) {
+            return { success: false, summary: null, error: "no environment" }
+        }
+
+        this.transition("running", `attempt ${attempt}`)
+
+        const opencode = new OpenCodeCliParticipant(this.spec.id, {
+            cwd: this.spec.cwd,
+            prompt: this.spec.prompt,
+            model: this.spec.model,
+            skipPermissions: this.spec.skipPermissions,
+        })
+        this.currentOpenCode = opencode
+        opencode.join(this.envRef)
+        opencode.start(this.envRef)
+
+        let summary: OpenCodeRunSummary
+        try {
+            summary = await raceWithTimeout(
+                opencode.done,
+                this.spec.timeoutSecs * 1000,
+                `attempt ${attempt} timeout after ${this.spec.timeoutSecs}s`,
+            )
+        } catch (e) {
+            opencode.abort()
+            const error = e instanceof Error ? e.message : String(e)
+            try {
+                await opencode.done
+            } catch {
+                // ignore
+            }
+            opencode.leave(this.envRef)
+            this.currentOpenCode = null
+            return { success: false, summary: null, error }
+        }
+
+        opencode.leave(this.envRef)
+        this.currentOpenCode = null
+
+        const success =
+            summary.exitCode === 0 && summary.error == null
+
+        if (!success) {
+            const reason = summary.error
+                ? summary.error.message
+                : `non-zero exit ${summary.exitCode}`
+            return { success: false, summary, error: reason }
+        }
+
+        return { success: true, summary, error: null }
+    }
+
+    private emitStoryResult(
+        success: boolean,
+        attempts: number,
+        durationSecs: number,
+        error: string | null,
+    ): void {
+        if (!this.envRef) return
+        this.envRef.deliverSemanticEvent(
+            this,
+            StoryResult.create({
+                storyId: this.spec.id,
+                success,
+                attempts,
+                durationSecs,
+                error,
+            }),
+        )
+    }
+
+    private transition(next: AgentPhase, detail?: string): void {
+        if (next === this.currentPhase) return
+        this.currentPhase = next
+        if (this.envRef) {
+            this.envRef.deliverSemanticEvent(
+                this,
+                AgentState.create({
+                    agentId: this.spec.id,
+                    phase: next,
+                    detail,
+                }),
+            )
+        }
+    }
+}
+
+/**
+ * Race a promise against a timeout. Rejects with an Error carrying the
+ * label on timeout.
+ */
+function raceWithTimeout<T>(
+    p: Promise<T>,
+    ms: number,
+    label: string,
+): Promise<T> {
+    return Promise.race([
+        p,
+        new Promise<T>((_, rej) => setTimeout(() => rej(new Error(label)), ms)),
+    ])
+}

--- a/packages/baro-orchestrator/src/participants/opencode-story-agent.ts
+++ b/packages/baro-orchestrator/src/participants/opencode-story-agent.ts
@@ -362,8 +362,12 @@ function raceWithTimeout<T>(
     ms: number,
     label: string,
 ): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>
+    const timeout = new Promise<T>(
+        (_, rej) => { timer = setTimeout(() => rej(new Error(label)), ms) },
+    )
     return Promise.race([
-        p,
-        new Promise<T>((_, rej) => setTimeout(() => rej(new Error(label)), ms)),
+        p.then((v) => { clearTimeout(timer); return v }),
+        timeout,
     ])
 }

--- a/packages/baro-orchestrator/src/participants/story-factory.ts
+++ b/packages/baro-orchestrator/src/participants/story-factory.ts
@@ -25,6 +25,7 @@ import {
 } from "../semantic-events.js"
 import { CodexStoryAgent } from "./codex-story-agent.js"
 import { OpenAIStoryAgent } from "./openai-story-agent.js"
+import { OpenCodeStoryAgent } from "./opencode-story-agent.js"
 import { StoryAgent } from "./story-agent.js"
 import {
     formatRoute,
@@ -42,10 +43,12 @@ export interface StoryFactoryOptions {
      *               runner with our codebase tool layer
      *   "codex"   — CodexStoryAgent wrapping a `codex exec --json`
      *               subprocess (ChatGPT subscription billing path)
-     * Same bus contract for all three — Conductor, Critic, Surgeon,
+     *   "opencode" — OpenCodeStoryAgent wrapping an `opencode run --format json`
+     *               subprocess
+     * Same bus contract for all four — Conductor, Critic, Surgeon,
      * Sentry, Librarian, Cartographer don't notice the swap.
      */
-    llm?: "claude" | "openai" | "codex"
+    llm?: "claude" | "openai" | "codex" | "opencode"
     /**
      * Optional model name to pass to OpenAI agents. Default
      * `gpt-5.5` — StoryAgent's coding loop benefits from the largest
@@ -92,7 +95,7 @@ export class StoryFactory extends BaseObserver {
     private envRef: AgenticEnvironment | null = null
     private readonly active: Map<
         string,
-        StoryAgent | OpenAIStoryAgent | CodexStoryAgent
+        StoryAgent | OpenAIStoryAgent | CodexStoryAgent | OpenCodeStoryAgent
     > = new Map()
 
     constructor(private readonly opts: StoryFactoryOptions) {
@@ -148,43 +151,52 @@ export class StoryFactory extends BaseObserver {
                 "\n",
         )
 
-        const agent: StoryAgent | OpenAIStoryAgent | CodexStoryAgent =
-            route.backend === "codex"
-                ? new CodexStoryAgent({
+        const agent: StoryAgent | OpenAIStoryAgent | CodexStoryAgent | OpenCodeStoryAgent =
+            route.backend === "opencode"
+                ? new OpenCodeStoryAgent({
                       id: req.storyId,
                       prompt: req.prompt,
                       cwd: this.opts.cwd,
-                      // undefined → let Codex pick its account default.
                       model: route.model,
                       retries: req.retries,
                       timeoutSecs: req.timeoutSecs,
                   })
-                : route.backend === "openai"
-                    ? new OpenAIStoryAgent(
-                          {
-                              id: req.storyId,
-                              prompt: req.prompt,
-                              cwd: this.opts.cwd,
-                              model: route.model,
-                              retries: req.retries,
-                              timeoutSecs: req.timeoutSecs,
-                          },
-                          {
-                              model: route.model ?? this.opts.openaiModel,
-                              baseUrl: route.baseUrl,
-                              apiKey: route.apiKey,
-                          },
-                      )
-                    : new StoryAgent({
+                : route.backend === "codex"
+                    ? new CodexStoryAgent({
                           id: req.storyId,
                           prompt: req.prompt,
                           cwd: this.opts.cwd,
-                          // undefined → StoryAgent applies its own default.
+                          // undefined → let Codex pick its account default.
                           model: route.model,
-                          effort: this.opts.effort,
                           retries: req.retries,
                           timeoutSecs: req.timeoutSecs,
                       })
+                    : route.backend === "openai"
+                        ? new OpenAIStoryAgent(
+                              {
+                                  id: req.storyId,
+                                  prompt: req.prompt,
+                                  cwd: this.opts.cwd,
+                                  model: route.model,
+                                  retries: req.retries,
+                                  timeoutSecs: req.timeoutSecs,
+                              },
+                              {
+                                  model: route.model ?? this.opts.openaiModel,
+                                  baseUrl: route.baseUrl,
+                                  apiKey: route.apiKey,
+                              },
+                          )
+                        : new StoryAgent({
+                              id: req.storyId,
+                              prompt: req.prompt,
+                              cwd: this.opts.cwd,
+                              // undefined → StoryAgent applies its own default.
+                              model: route.model,
+                              effort: this.opts.effort,
+                              retries: req.retries,
+                              timeoutSecs: req.timeoutSecs,
+                          })
 
         agent.join(this.envRef)
         this.active.set(req.storyId, agent)

--- a/packages/baro-orchestrator/src/participants/surgeon-opencode.ts
+++ b/packages/baro-orchestrator/src/participants/surgeon-opencode.ts
@@ -1,0 +1,159 @@
+/**
+ * SurgeonOpenCode — adaptive DAG mutation via
+ * `opencode run --format json`. Sibling of `surgeon.ts` (Claude),
+ * `surgeon-openai.ts` (OpenAI API), and `surgeon-codex.ts` (Codex CLI).
+ *
+ * Same bus contract as the other variants: observes terminal story
+ * failures, asks the LLM for a structured replan (split / prereq /
+ * rewire / skip / abort), emits a ReplanItem the Conductor applies at
+ * the next level boundary. Falls back to deterministic skip if the LLM
+ * call fails or returns malformed JSON.
+ *
+ * Library-grade: reuses prompts + JSON-extractor + deterministic
+ * fallback from `surgeon.ts` directly so the four backends share one
+ * source of truth for the contract.
+ */
+
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import { runOpenCodeOneShot } from "../opencode-one-shot.js"
+import {
+    Replan,
+    type ReplanData,
+    type ReplanStoryAdd,
+    StoryResult,
+    type StoryResultData,
+} from "../semantic-events.js"
+import {
+    PrdSnapshot,
+    SURGEON_SYSTEM_PROMPT,
+    buildSurgeonPrompt,
+    extractJsonObject,
+    surgeonDeterministicReplan,
+} from "./surgeon.js"
+
+export interface SurgeonOpenCodeOptions {
+    /** Returns a fresh snapshot of the current PRD. */
+    snapshot: () => PrdSnapshot
+    /** Use OpenCode CLI to evaluate replans. Default: true. */
+    useLlm?: boolean
+    /**
+     * Model identifier in `provider/model` format
+     * (e.g. "anthropic/claude-sonnet-4"). Omit to use OpenCode's
+     * configured default.
+     */
+    model?: string
+    /** Max replans this Surgeon will emit per run. Default: 10. */
+    maxReplans?: number
+    /** Path to the `opencode` binary. Default: "opencode". */
+    opencodeBin?: string
+    /** Per-evaluation timeout in milliseconds. Default: 300_000 (5 min). */
+    timeoutMs?: number
+}
+
+export class SurgeonOpenCode extends BaseObserver {
+    private readonly opts: Required<
+        Omit<SurgeonOpenCodeOptions, "snapshot" | "model" | "opencodeBin">
+    > & {
+        snapshot: () => PrdSnapshot
+        model: string | undefined
+        opencodeBin: string
+    }
+
+    private replansEmitted = 0
+    private readonly pending = new Set<Promise<void>>()
+
+    constructor(opts: SurgeonOpenCodeOptions) {
+        super()
+        this.opts = {
+            useLlm: opts.useLlm ?? true,
+            model: opts.model,
+            maxReplans: opts.maxReplans ?? 10,
+            opencodeBin: opts.opencodeBin ?? "opencode",
+            timeoutMs: opts.timeoutMs ?? 300_000,
+            snapshot: opts.snapshot,
+        }
+    }
+
+    async idle(): Promise<void> {
+        await Promise.allSettled([...this.pending])
+    }
+
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (!StoryResult.is(event)) return
+        if (event.data.success) return
+        if (this.replansEmitted >= this.opts.maxReplans) return
+
+        const work = (async () => {
+            const replan = this.opts.useLlm
+                ? await this.evaluateWithLlm(event.data)
+                : surgeonDeterministicReplan(event.data)
+            if (!replan) return
+            this.replansEmitted += 1
+            for (const env of this.getEnvironments()) {
+                env.deliverSemanticEvent(this, Replan.create(replan))
+            }
+        })()
+
+        this.pending.add(work)
+        work.finally(() => this.pending.delete(work))
+        await work
+    }
+
+    private async evaluateWithLlm(
+        failure: StoryResultData,
+    ): Promise<ReplanData | null> {
+        const snap = this.opts.snapshot()
+        const userPrompt = buildSurgeonPrompt(snap, failure)
+        const prompt = `${SURGEON_SYSTEM_PROMPT}\n\n${userPrompt}`
+
+        try {
+            const text = await runOpenCodeOneShot({
+                prompt,
+                cwd: process.cwd(),
+                model: this.opts.model,
+                opencodeBin: this.opts.opencodeBin,
+                timeoutMs: this.opts.timeoutMs,
+                label: "opencode-surgeon",
+            })
+            const verdictText = text.trim()
+            if (!verdictText) throw new Error("empty result")
+
+            const verdictJson = extractJsonObject(verdictText)
+            const parsed = JSON.parse(verdictJson) as {
+                action: string
+                reason?: string
+                added?: ReplanStoryAdd[]
+                removed?: string[]
+                modifiedDeps?: { id: string; newDependsOn: string[] }[]
+            }
+
+            if (parsed.action === "abort") return null
+
+            const modifiedDeps: Record<string, readonly string[]> = {}
+            for (const m of parsed.modifiedDeps ?? []) {
+                if (typeof m.id === "string" && Array.isArray(m.newDependsOn)) {
+                    modifiedDeps[m.id] = [...m.newDependsOn]
+                }
+            }
+            return {
+                source: "surgeon",
+                reason: `${parsed.action}: ${parsed.reason ?? ""}`,
+                addedStories: parsed.added ?? [],
+                removedStoryIds: parsed.removed ?? [],
+                modifiedDeps,
+            }
+        } catch (err) {
+            // Fall back to deterministic so the run still has a chance
+            // to recover.
+            const fallback = surgeonDeterministicReplan(failure)
+            return {
+                ...fallback,
+                reason: `${fallback.reason} (opencode fallback after error: ${(err as Error)?.message ?? String(err)})`,
+            }
+        }
+    }
+}

--- a/packages/baro-orchestrator/src/planning/architect-opencode.ts
+++ b/packages/baro-orchestrator/src/planning/architect-opencode.ts
@@ -1,0 +1,66 @@
+/**
+ * ArchitectOpenCode — one-shot Architect call via `opencode run --format json`.
+ *
+ * Same prompt shape as ArchitectClaude / ArchitectCodex so the providers
+ * produce comparable decision documents. OpenCode's built-in tools
+ * (file read, grep, bash, etc.) handle codebase exploration; we don't
+ * ship a separate tool layer.
+ *
+ * Wire shape: combined `${SYSTEM}\n\n${USER}` prompt → opencode run
+ * → JSONL stream → final text output → return as markdown.
+ */
+
+import { runOpenCodeOneShot } from "../opencode-one-shot.js"
+import {
+    ARCHITECT_SYSTEM_PROMPT,
+    buildArchitectUserMessage,
+} from "./architect-prompts.js"
+
+/** Options for `runArchitectOpenCode`. */
+export interface RunArchitectOpenCodeOptions {
+    /** The user's goal — verbatim. */
+    goal: string
+    /** Working directory the Architect explores in. */
+    cwd: string
+    /** OpenCode model in `provider/model` format. Default: undefined (use OpenCode default). */
+    model?: string
+    /** Optional CLAUDE.md / project-context blob to prepend. */
+    projectContext?: string
+    /** Path to the `opencode` binary. Default: "opencode". */
+    opencodeBin?: string
+    /**
+     * Per-call timeout in milliseconds. Default: 600_000 (10 minutes).
+     * OpenCode with tool-call exploration can be materially slower than
+     * a direct API call — the original 3-minute timeout was killing runs
+     * mid-exploration.
+     */
+    timeoutMs?: number
+}
+
+/**
+ * Run the Architect phase using OpenCode as the backend.
+ *
+ * @returns The decision document (markdown) produced by the Architect.
+ * @throws Error if OpenCode returns empty or fails.
+ */
+export async function runArchitectOpenCode(
+    opts: RunArchitectOpenCodeOptions,
+): Promise<string> {
+    const userMessage = buildArchitectUserMessage(opts.goal, opts.projectContext)
+    const prompt = `${ARCHITECT_SYSTEM_PROMPT}\n\n${userMessage}`
+
+    const text = await runOpenCodeOneShot({
+        prompt,
+        cwd: opts.cwd,
+        model: opts.model,
+        opencodeBin: opts.opencodeBin,
+        timeoutMs: opts.timeoutMs ?? 600_000,
+        label: "opencode-architect",
+    })
+
+    const doc = text.trim()
+    if (!doc) {
+        throw new Error("ArchitectOpenCode: opencode returned empty result")
+    }
+    return doc
+}

--- a/packages/baro-orchestrator/src/planning/planner-opencode.ts
+++ b/packages/baro-orchestrator/src/planning/planner-opencode.ts
@@ -1,0 +1,100 @@
+/**
+ * PlannerOpenCode — one-shot Planner call via `opencode run --format json`.
+ *
+ * Same prompt shape as PlannerClaude / PlannerCodex. Returns the raw
+ * PRD JSON string for the Rust caller to deserialise.
+ */
+
+import { runOpenCodeOneShot } from "../opencode-one-shot.js"
+import {
+    PLANNER_SYSTEM_PROMPT,
+    buildPlannerUserMessage,
+} from "./planner-prompts.js"
+
+/** Options for `runPlannerOpenCode`. */
+export interface RunPlannerOpenCodeOptions {
+    /** The user's goal — verbatim. */
+    goal: string
+    /** Working directory. */
+    cwd: string
+    /** OpenCode model in `provider/model` format. */
+    model?: string
+    /** Optional project context blob. */
+    projectContext?: string
+    /** Optional decision document from the Architect phase. */
+    decisionDocument?: string
+    /** If true, use a shorter planning prompt. */
+    quick?: boolean
+    /** Path to the `opencode` binary. Default: "opencode". */
+    opencodeBin?: string
+    /**
+     * Per-call timeout in milliseconds. Default: 900_000 (15 minutes).
+     * Planner is the longest phase — large multi-story PRDs with strict
+     * JSON output frequently push models past shorter timeouts.
+     */
+    timeoutMs?: number
+}
+
+/**
+ * Run the Planner phase using OpenCode as the backend.
+ *
+ * @returns The PRD as a raw JSON string (a single `{ … }` object).
+ * @throws Error if OpenCode returns empty or the result contains no valid JSON.
+ */
+export async function runPlannerOpenCode(
+    opts: RunPlannerOpenCodeOptions,
+): Promise<string> {
+    const userMessage = buildPlannerUserMessage({
+        goal: opts.goal,
+        decisionDocument: opts.decisionDocument,
+        quick: opts.quick,
+        projectContext: opts.projectContext,
+    })
+    const prompt = `${PLANNER_SYSTEM_PROMPT}\n\n${userMessage}`
+
+    const text = await runOpenCodeOneShot({
+        prompt,
+        cwd: opts.cwd,
+        model: opts.model,
+        opencodeBin: opts.opencodeBin,
+        timeoutMs: opts.timeoutMs ?? 900_000,
+        label: "opencode-planner",
+    })
+
+    const planText = text.trim()
+    if (!planText) {
+        throw new Error("PlannerOpenCode: opencode returned empty result")
+    }
+    // Model sometimes wraps JSON in markdown fences or adds prose despite
+    // the "ONLY JSON" instruction — strip back to a bare `{ … }`.
+    return extractJsonObject(planText)
+}
+
+/**
+ * Pull the first balanced `{ … }` block out of a raw string. Tolerates
+ * markdown fences and leading prose.
+ */
+function extractJsonObject(text: string): string {
+    const trimmed = text.trim()
+    if (trimmed.startsWith("{") && trimmed.endsWith("}")) return trimmed
+    const fence = trimmed.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/)
+    if (fence) return fence[1]!
+    const start = trimmed.indexOf("{")
+    if (start < 0) {
+        throw new Error(
+            `PlannerOpenCode: no JSON object in response: ${trimmed.slice(0, 200)}`,
+        )
+    }
+    let depth = 0
+    for (let i = start; i < trimmed.length; i++) {
+        const ch = trimmed[i]
+        if (ch === "{") depth++
+        else if (ch === "}") {
+            depth--
+            if (depth === 0) return trimmed.slice(start, i + 1)
+        }
+    }
+    throw new Error(
+        `PlannerOpenCode: unbalanced JSON in response: ${trimmed.slice(0, 200)}`,
+    )
+}

--- a/packages/baro-orchestrator/src/routing.ts
+++ b/packages/baro-orchestrator/src/routing.ts
@@ -27,9 +27,9 @@
  * the same backend/model the old phase-level wiring produced.
  */
 
-export type Backend = "claude" | "openai" | "codex"
+export type Backend = "claude" | "openai" | "codex" | "opencode"
 
-const BACKENDS: readonly Backend[] = ["claude", "openai", "codex"]
+const BACKENDS: readonly Backend[] = ["claude", "openai", "codex", "opencode"]
 
 export function isBackend(s: string): s is Backend {
     return (BACKENDS as readonly string[]).includes(s)
@@ -239,6 +239,7 @@ function defaultRoute(backend: Backend, openaiDefaultModel?: string): StoryRoute
     if (backend === "openai") return { backend, model: openaiDefaultModel }
     // Claude → StoryAgent applies its own default ("opus").
     // Codex → its own account default.
+    // OpenCode → its configured default model.
     return { backend }
 }
 
@@ -272,7 +273,7 @@ export function parseTierMap(spec: string): TierMap {
         if (!backend) {
             throw new Error(
                 `--tier-map route "${route}" for tier "${tier}" must name a backend ` +
-                    `(claude: | openai: | codex:)`,
+                    `(claude: | openai: | codex: | opencode:)`,
             )
         }
         map[tier] = route

--- a/packages/baro-orchestrator/src/semantic-events.ts
+++ b/packages/baro-orchestrator/src/semantic-events.ts
@@ -349,3 +349,36 @@ export interface StoryResultData {
     error: string | null
 }
 export const StoryResult = defineSemanticEvent<StoryResultData>("story_result")
+
+// ─── OpenCode CLI passthrough types ───────────────────────────────────
+// OpenCode emits a stream of JSONL events with these envelope types:
+//   - step_start   → beginning of an inference step
+//   - text         → assistant text output
+//   - tool_call    → tool invocation
+//   - tool_result  → tool output
+//   - step_finish  → end of step with token/cost metadata
+
+export interface OpenCodeSystemData {
+    agentId: string
+    /** "step_start" | "step_finish" */
+    subtype: string
+    raw: Readonly<Record<string, unknown>>
+}
+export const OpenCodeSystem = defineSemanticEvent<OpenCodeSystemData>("opencode_system")
+
+export interface OpenCodeStepEventData {
+    agentId: string
+    /** "text" | "tool_call" | "tool_result" */
+    stepType: string
+    raw: Readonly<Record<string, unknown>>
+}
+export const OpenCodeStepEvent =
+    defineSemanticEvent<OpenCodeStepEventData>("opencode_step_event")
+
+export interface OpenCodeUnknownEventData {
+    agentId: string
+    openCodeType: string
+    raw: Readonly<Record<string, unknown>>
+}
+export const OpenCodeUnknownEvent =
+    defineSemanticEvent<OpenCodeUnknownEventData>("opencode_unknown_event")


### PR DESCRIPTION
## Summary

Adds **OpenCode** ([opencode.ai](https://opencode.ai)) as a fourth agentic backend alongside Claude Code, OpenAI Codex CLI, and the Mozaik-native OpenAI runner. OpenCode is an open-source coding agent that fronts any LLM provider, so `--llm opencode` lets a baro run use any model the user has configured in their opencode setup (Anthropic, OpenAI, local LM Studio/Ollama, etc.) with no API-key plumbing on baro's side.

Selectable via `--llm opencode`, per-phase flags (`--story-llm opencode`, …), the provider picker, and the Welcome-screen planner radio.

## What's included

**Core integration (TS orchestrator)**
- `opencode-cli-participant.ts` — wraps `opencode run --format json` as a Mozaik participant
- `opencode-stream-mapper.ts` — maps OpenCode's JSONL stream to typed bus items
- `opencode-one-shot.ts` — shared one-shot runner for planning phases
- `opencode-story-agent.ts`, `planner-opencode.ts`, `architect-opencode.ts` — phase implementations
- Routing / story-factory / CLI wiring

**TUI (Rust)**
- Provider picker + planner selector entries, doctor check, `--llm`/per-phase plumbing

**Tests**
- Live integration test exercising stream mapper, CLI participant, one-shot runner, and story agent against a real `opencode` process (24 assertions, skips live cases when opencode is absent)

## Quality pass

The backend went through an adversarial review before this PR. Fixes folded in:

- **Story success requires real evidence of work.** `opencode run` exits 0 even on a refusal/no-op, so success now requires a `step_finish` and at least one tool call rather than exit code alone — otherwise a refused story would report a false PASS that nothing downstream re-verifies.
- **`tool_use` event shape.** The live binary emits a single `tool_use` event carrying both call input and result; the mapper now handles that (the older `tool_call`/`tool_result` pair shape never matched real output and is kept only as a fallback).
- **`--model` accepts provider/model strings** (`-m anthropic/claude-sonnet-4`) for non-Claude backends, validated per-resolved-phase so Claude phases still reject non-Claude models.
- **Provider picker** is skipped based on whether `--llm` was passed, not `llm != Claude` — fixes `--llm hybrid` wrongly re-prompting and collapsing the per-phase split.
- **Welcome planner radio** now routes (reconciles into the `*_llm` fields) instead of silently running Claude.
- **Architect** runs for every backend (gated on `!quick`); the TS architect supports all four providers.
- One-shot rejects on timeout/abnormal exit instead of returning truncated text; the participant's `error` handler always settles `done` (no hang).

## Test plan

- `cargo build -p baro-tui` — clean
- `npm run typecheck` (orchestrator) — clean
- `npx tsx packages/baro-orchestrator/scripts/test-opencode-integration.ts` — 24/24 pass against the live opencode binary (including a regression guard that a zero-tool no-op story is NOT marked passed)

## Notes

`-m provider/model` is a global override applied to every phase, so it can't be combined with a Claude/OpenCode split — use it only when all phases run on a non-Claude backend. OpenCode runs with `--dangerously-skip-permissions` for unattended execution in baro's per-story worktrees.