### PR TITLE
feat: add Pi (pi CLI) as a new agentic backend

### DIFF
--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -30,6 +30,7 @@ pub enum Planner {
     OpenAI,
     Codex,
     OpenCode,
+    Pi,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -129,6 +130,10 @@ pub enum LlmProvider {
     /// Implementation: `packages/baro-orchestrator/src/participants/
     /// opencode-cli-participant.ts`.
     OpenCode,
+    /// Pi CLI subprocess. Multi-provider agent shell similar to OpenCode.
+    /// Implementation: `packages/baro-orchestrator/src/participants/
+    /// pi-cli-participant.ts`.
+    Pi,
 }
 
 impl LlmProvider {
@@ -138,6 +143,7 @@ impl LlmProvider {
             Self::OpenAI => "openai",
             Self::Codex => "codex",
             Self::OpenCode => "opencode",
+            Self::Pi => "pi",
         }
     }
 
@@ -147,6 +153,7 @@ impl LlmProvider {
             "openai" => Some(Self::OpenAI),
             "codex" => Some(Self::Codex),
             "opencode" => Some(Self::OpenCode),
+            "pi" => Some(Self::Pi),
             _ => None,
         }
     }
@@ -387,6 +394,9 @@ impl App {
                 if which::which("opencode").is_ok() {
                     opts.push(LlmProvider::OpenCode);
                 }
+                if which::which("pi").is_ok() {
+                    opts.push(LlmProvider::Pi);
+                }
                 opts
             },
             api_key_input: String::new(),
@@ -530,13 +540,15 @@ impl App {
             Planner::Claude => Planner::OpenAI,
             Planner::OpenAI => Planner::Codex,
             Planner::Codex => Planner::OpenCode,
-            Planner::OpenCode => Planner::Claude,
+            Planner::OpenCode => Planner::Pi,
+            Planner::Pi => Planner::Claude,
         };
         let provider = match self.planner {
             Planner::Claude => LlmProvider::Claude,
             Planner::OpenAI => LlmProvider::OpenAI,
             Planner::Codex => LlmProvider::Codex,
             Planner::OpenCode => LlmProvider::OpenCode,
+            Planner::Pi => LlmProvider::Pi,
         };
         self.llm = provider;
         self.architect_llm = provider;
@@ -1060,6 +1072,9 @@ impl App {
                 // means the TS side passes no --model flag and opencode
                 // picks its own default provider + model.
                 (LlmProvider::OpenCode, _) => None,
+                // Pi: no hardcoded model — let it use whatever the
+                // user configured in their pi setup.
+                (LlmProvider::Pi, _) => None,
                 _ => None,
             };
         }

--- a/crates/baro-tui/src/doctor.rs
+++ b/crates/baro-tui/src/doctor.rs
@@ -47,6 +47,7 @@ pub async fn run() -> i32 {
     results.push(check_claude_print_call().await);
     results.push(check_codex_on_path().await);
     results.push(check_opencode_on_path().await);
+    results.push(check_pi_on_path().await);
     results.push(check_gh_on_path().await);
     results.push(check_audit_dir_writable().await);
 
@@ -217,6 +218,24 @@ async fn check_opencode_on_path() -> CheckResult {
             "opencode on PATH (optional, used for --llm opencode)",
             "binary not found",
             "Install opencode from https://opencode.ai if you want the `--llm opencode` multi-provider path; otherwise this check is informational and other routes still work.",
+        ),
+    }
+}
+
+/// Verify `pi` binary is reachable (optional — only needed for
+/// `baro --llm pi`). Soft failure: pi is optional
+/// infrastructure for the Pi backend; not having it doesn't
+/// block Claude, OpenAI, Codex, or OpenCode workflows.
+async fn check_pi_on_path() -> CheckResult {
+    match which::which("pi") {
+        Ok(path) => CheckResult::pass(
+            "pi on PATH (optional, used for --llm pi)",
+            format!("{}", path.display()),
+        ),
+        Err(_) => CheckResult::fail(
+            "pi on PATH (optional, used for --llm pi)",
+            "binary not found",
+            "Install pi if you want the `--llm pi` multi-provider path; otherwise this check is informational and other routes still work.",
         ),
     }
 }

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -309,7 +309,7 @@ struct Cli {
     ///                      Critic move to Codex (high-volume, cheap
     ///                      on ChatGPT subscription). Individual phase
     ///                      overrides win when set.
-    #[arg(long, default_value = "claude", value_parser = ["claude", "openai", "codex", "opencode", "hybrid"])]
+    #[arg(long, default_value = "claude", value_parser = ["claude", "openai", "codex", "opencode", "pi", "hybrid"])]
     llm: String,
 
     /// Custom base URL for OpenAI-compatible API endpoints. When set,
@@ -326,15 +326,15 @@ struct Cli {
     /// phase. Useful for surgical tuning: e.g. `--llm hybrid
     /// --critic-llm claude` for a hybrid run that uses Claude for
     /// Critic instead of Codex.
-    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode"])]
+    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode", "pi"])]
     architect_llm: Option<String>,
-    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode"])]
+    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode", "pi"])]
     planner_llm: Option<String>,
-    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode"])]
+    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode", "pi"])]
     story_llm: Option<String>,
-    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode"])]
+    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode", "pi"])]
     critic_llm: Option<String>,
-    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode"])]
+    #[arg(long, value_parser = ["claude", "openai", "codex", "opencode", "pi"])]
     surgeon_llm: Option<String>,
 
     /// Disable semantic memory (MemoryLibrarian). Uses tag-based
@@ -481,6 +481,7 @@ async fn run_app(
         Some("openai") => Planner::OpenAI,
         Some("codex") => Planner::Codex,
         Some("opencode") => Planner::OpenCode,
+        Some("pi") => Planner::Pi,
         _ => Planner::Claude,
     };
 
@@ -501,6 +502,7 @@ async fn run_app(
             "openai" => Planner::OpenAI,
             "codex" => Planner::Codex,
             "opencode" => Planner::OpenCode,
+            "pi" => Planner::Pi,
             _ => Planner::Claude,
         };
     }
@@ -511,6 +513,7 @@ async fn run_app(
         "openai" => app.planner = Planner::OpenAI,
         "codex" => app.planner = Planner::Codex,
         "opencode" => app.planner = Planner::OpenCode,
+        "pi" => app.planner = Planner::Pi,
         _ => {} // claude/hybrid keep the default or explicit --planner
     }
 
@@ -935,6 +938,7 @@ async fn run_app(
                                 app::LlmProvider::OpenAI => app::Planner::OpenAI,
                                 app::LlmProvider::Codex => app::Planner::Codex,
                                 app::LlmProvider::OpenCode => app::Planner::OpenCode,
+                                app::LlmProvider::Pi => app::Planner::Pi,
                             };
                             // OpenAI needs an API key — detour if missing
                             if chosen == app::LlmProvider::OpenAI && app.openai_api_key.is_none() {

--- a/crates/baro-tui/src/screens/planning.rs
+++ b/crates/baro-tui/src/screens/planning.rs
@@ -78,6 +78,7 @@ pub fn render(f: &mut Frame, app: &App) {
         crate::app::LlmProvider::OpenAI => "OpenAI",
         crate::app::LlmProvider::Codex => "Codex",
         crate::app::LlmProvider::OpenCode => "OpenCode",
+        crate::app::LlmProvider::Pi => "Pi",
     };
 
     if let Some(ref err) = app.planning_error {

--- a/crates/baro-tui/src/screens/provider_picker.rs
+++ b/crates/baro-tui/src/screens/provider_picker.rs
@@ -6,6 +6,7 @@
 //!   - Mozaik native    — always available (needs OPENAI_API_KEY)
 //!   - Codex            — shown when `codex` is on PATH
 //!   - OpenCode         — shown when `opencode` is on PATH
+//!   - Pi               — shown when `pi` is on PATH
 //!
 //! Up/Down to highlight, Enter to confirm. The picked
 //! `LlmProvider` lands in `app.llm`; the next screen is decided in
@@ -45,6 +46,11 @@ fn provider_description(provider: LlmProvider) -> &'static [&'static str] {
             "model you configured in opencode (any provider). No extra",
             "API keys needed, opencode manages its own credentials.",
         ],
+        LlmProvider::Pi => &[
+            "Pi CLI — multi-provider agent shell. Uses whatever",
+            "model you configured in pi (any provider). No extra",
+            "API keys needed, pi manages its own credentials.",
+        ],
     }
 }
 
@@ -54,6 +60,7 @@ fn provider_title(provider: LlmProvider) -> &'static str {
         LlmProvider::OpenAI => "Mozaik native — OpenAI",
         LlmProvider::Codex => "Codex CLI",
         LlmProvider::OpenCode => "OpenCode",
+        LlmProvider::Pi => "Pi",
     }
 }
 

--- a/crates/baro-tui/src/screens/welcome.rs
+++ b/crates/baro-tui/src/screens/welcome.rs
@@ -238,6 +238,8 @@ pub fn render(f: &mut Frame, app: &App) {
     planner_spans.extend(radio(app.planner == Planner::Codex, "codex", planner_focused));
     planner_spans.push(Span::raw("  "));
     planner_spans.extend(radio(app.planner == Planner::OpenCode, "opencode", planner_focused));
+    planner_spans.push(Span::raw("  "));
+    planner_spans.extend(radio(app.planner == Planner::Pi, "pi", planner_focused));
 
     let settings_lines = vec![
         Line::from(model_spans),

--- a/packages/baro-orchestrator/scripts/cli.ts
+++ b/packages/baro-orchestrator/scripts/cli.ts
@@ -23,6 +23,7 @@ import { resolve } from "path"
 
 import { orchestrate, type OrchestrateConfig } from "../src/orchestrate.js"
 import { ClaudeCliParticipant } from "../src/participants/claude-cli-participant.js"
+import { PiCliParticipant } from "../src/participants/pi-cli-participant.js"
 import {
     parseEndpoints,
     parseTierMap,
@@ -54,11 +55,11 @@ interface CliArgs {
     tierMap?: TierMap
     /** Raw `--openai-endpoint name=url` specs, resolved to a map later. */
     endpointSpecs: string[]
-    llm: "claude" | "openai" | "codex" | "opencode"
+    llm: "claude" | "openai" | "codex" | "opencode" | "pi"
     /** Optional per-phase overrides; each defaults to `llm`. */
-    storyLlm?: "claude" | "openai" | "codex" | "opencode"
-    criticLlm?: "claude" | "openai" | "codex" | "opencode"
-    surgeonLlm?: "claude" | "openai" | "codex" | "opencode"
+    storyLlm?: "claude" | "openai" | "codex" | "opencode" | "pi"
+    criticLlm?: "claude" | "openai" | "codex" | "opencode" | "pi"
+    surgeonLlm?: "claude" | "openai" | "codex" | "opencode" | "pi"
     help: boolean
 }
 
@@ -160,9 +161,9 @@ function parseArgs(argv: string[]): CliArgs {
                 break
             case "--llm": {
                 const v = required(argv, ++i, "--llm")
-                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode") {
+                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode" && v !== "pi") {
                     process.stderr.write(
-                        `[cli] --llm must be 'claude' | 'openai' | 'codex' | 'opencode', got '${v}'\n`,
+                        `[cli] --llm must be 'claude' | 'openai' | 'codex' | 'opencode' | 'pi', got '${v}'\n`,
                     )
                     process.exit(2)
                 }
@@ -173,9 +174,9 @@ function parseArgs(argv: string[]): CliArgs {
             case "--critic-llm":
             case "--surgeon-llm": {
                 const v = required(argv, ++i, a)
-                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode") {
+                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode" && v !== "pi") {
                     process.stderr.write(
-                        `[cli] ${a} must be 'claude' | 'openai' | 'codex' | 'opencode', got '${v}'\n`,
+                        `[cli] ${a} must be 'claude' | 'openai' | 'codex' | 'opencode' | 'pi', got '${v}'\n`,
                     )
                     process.exit(2)
                 }
@@ -401,11 +402,13 @@ let shuttingDown = false
 function shutdown(signal: NodeJS.Signals): void {
     if (shuttingDown) return
     shuttingDown = true
-    process.stderr.write(`[cli] received ${signal}, killing in-flight Claude children...\n`)
+    process.stderr.write(`[cli] received ${signal}, killing in-flight children...\n`)
     ClaudeCliParticipant.killAll("SIGTERM")
+    PiCliParticipant.killAll("SIGTERM")
     // Give children a moment to die cleanly, then escalate.
     setTimeout(() => {
         ClaudeCliParticipant.killAll("SIGKILL")
+        PiCliParticipant.killAll("SIGKILL")
         process.exit(signal === "SIGINT" ? 130 : 143)
     }, 1500).unref()
 }

--- a/packages/baro-orchestrator/scripts/cli.ts
+++ b/packages/baro-orchestrator/scripts/cli.ts
@@ -441,5 +441,13 @@ orphanWatchdog.unref()
 
 main().catch((e: unknown) => {
     process.stderr.write(`[cli] unhandled: ${(e as Error)?.stack ?? String(e)}\n`)
+    // Reap in-flight children before bailing. process.exit() gives no grace
+    // window for SIGTERM to land, so SIGKILL directly — otherwise an unhandled
+    // crash orphans live claude/codex/opencode/pi subprocesses that keep
+    // burning quota and holding worktrees with no parent to clean them up.
+    ClaudeCliParticipant.killAll("SIGKILL")
+    CodexCliParticipant.killAll("SIGKILL")
+    OpenCodeCliParticipant.killAll("SIGKILL")
+    PiCliParticipant.killAll("SIGKILL")
     process.exit(1)
 })

--- a/packages/baro-orchestrator/scripts/cli.ts
+++ b/packages/baro-orchestrator/scripts/cli.ts
@@ -23,6 +23,8 @@ import { resolve } from "path"
 
 import { orchestrate, type OrchestrateConfig } from "../src/orchestrate.js"
 import { ClaudeCliParticipant } from "../src/participants/claude-cli-participant.js"
+import { CodexCliParticipant } from "../src/participants/codex-cli-participant.js"
+import { OpenCodeCliParticipant } from "../src/participants/opencode-cli-participant.js"
 import { PiCliParticipant } from "../src/participants/pi-cli-participant.js"
 import {
     parseEndpoints,
@@ -404,10 +406,14 @@ function shutdown(signal: NodeJS.Signals): void {
     shuttingDown = true
     process.stderr.write(`[cli] received ${signal}, killing in-flight children...\n`)
     ClaudeCliParticipant.killAll("SIGTERM")
+    CodexCliParticipant.killAll("SIGTERM")
+    OpenCodeCliParticipant.killAll("SIGTERM")
     PiCliParticipant.killAll("SIGTERM")
     // Give children a moment to die cleanly, then escalate.
     setTimeout(() => {
         ClaudeCliParticipant.killAll("SIGKILL")
+        CodexCliParticipant.killAll("SIGKILL")
+        OpenCodeCliParticipant.killAll("SIGKILL")
         PiCliParticipant.killAll("SIGKILL")
         process.exit(signal === "SIGINT" ? 130 : 143)
     }, 1500).unref()

--- a/packages/baro-orchestrator/scripts/run-architect.ts
+++ b/packages/baro-orchestrator/scripts/run-architect.ts
@@ -23,6 +23,7 @@ import { runArchitectClaude } from "../src/planning/architect-claude.js"
 import { runArchitectCodex } from "../src/planning/architect-codex.js"
 import { runArchitectOpenAI } from "../src/planning/architect-openai.js"
 import { runArchitectOpenCode } from "../src/planning/architect-opencode.js"
+import { runArchitectPi } from "../src/planning/architect-pi.js"
 
 interface Args {
     goal: string
@@ -34,7 +35,7 @@ interface Args {
      * Codex covers the Story phase (which dominates token spend);
      * Architect and Planner stay on Claude.
      */
-    llm: "claude" | "openai" | "codex" | "opencode"
+    llm: "claude" | "openai" | "codex" | "opencode" | "pi"
     model?: string
     effort?: string
     contextFile?: string
@@ -43,7 +44,7 @@ interface Args {
 function parseArgs(argv: string[]): Args {
     let goal: string | undefined
     let cwd: string | undefined
-    let llm: "claude" | "openai" | "codex" | "opencode" | undefined
+    let llm: "claude" | "openai" | "codex" | "opencode" | "pi" | undefined
     let model: string | undefined
     let effort: string | undefined
     let contextFile: string | undefined
@@ -59,10 +60,10 @@ function parseArgs(argv: string[]): Args {
                 break
             case "--llm": {
                 const v = required(argv, ++i, "--llm")
-                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode") {
-                    fatal(`--llm must be 'claude' | 'openai' | 'codex' | 'opencode', got '${v}'`)
+                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode" && v !== "pi") {
+                    fatal(`--llm must be 'claude' | 'openai' | 'codex' | 'opencode' | 'pi', got '${v}'`)
                 }
-                llm = v as "claude" | "openai" | "codex" | "opencode"
+                llm = v as "claude" | "openai" | "codex" | "opencode" | "pi"
                 break
             }
             case "--model":
@@ -135,6 +136,13 @@ async function main(): Promise<void> {
             })
         } else if (args.llm === "opencode") {
             doc = await runArchitectOpenCode({
+                goal: args.goal,
+                cwd: args.cwd,
+                model: args.model,
+                projectContext,
+            })
+        } else if (args.llm === "pi") {
+            doc = await runArchitectPi({
                 goal: args.goal,
                 cwd: args.cwd,
                 model: args.model,

--- a/packages/baro-orchestrator/scripts/run-planner.ts
+++ b/packages/baro-orchestrator/scripts/run-planner.ts
@@ -24,6 +24,7 @@ import { runPlannerClaude } from "../src/planning/planner-claude.js"
 import { runPlannerCodex } from "../src/planning/planner-codex.js"
 import { runPlannerOpenAI } from "../src/planning/planner-openai.js"
 import { runPlannerOpenCode } from "../src/planning/planner-opencode.js"
+import { runPlannerPi } from "../src/planning/planner-pi.js"
 
 interface Args {
     goal: string
@@ -34,7 +35,7 @@ interface Args {
      * v1 positioning: Codex covers the Story phase; Architect and
      * Planner stay on Claude.
      */
-    llm: "claude" | "openai" | "codex" | "opencode"
+    llm: "claude" | "openai" | "codex" | "opencode" | "pi"
     model?: string
     effort?: string
     contextFile?: string
@@ -45,7 +46,7 @@ interface Args {
 function parseArgs(argv: string[]): Args {
     let goal: string | undefined
     let cwd: string | undefined
-    let llm: "claude" | "openai" | "codex" | "opencode" | undefined
+    let llm: "claude" | "openai" | "codex" | "opencode" | "pi" | undefined
     let model: string | undefined
     let effort: string | undefined
     let contextFile: string | undefined
@@ -63,10 +64,10 @@ function parseArgs(argv: string[]): Args {
                 break
             case "--llm": {
                 const v = required(argv, ++i, "--llm")
-                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode") {
-                    fatal(`--llm must be 'claude' | 'openai' | 'codex' | 'opencode', got '${v}'`)
+                if (v !== "claude" && v !== "openai" && v !== "codex" && v !== "opencode" && v !== "pi") {
+                    fatal(`--llm must be 'claude' | 'openai' | 'codex' | 'opencode' | 'pi', got '${v}'`)
                 }
-                llm = v as "claude" | "openai" | "codex" | "opencode"
+                llm = v as "claude" | "openai" | "codex" | "opencode" | "pi"
                 break
             }
             case "--model":
@@ -161,6 +162,15 @@ async function main(): Promise<void> {
             })
         } else if (args.llm === "opencode") {
             prdJson = await runPlannerOpenCode({
+                goal: args.goal,
+                cwd: args.cwd,
+                model: args.model,
+                projectContext,
+                decisionDocument,
+                quick: args.quick,
+            })
+        } else if (args.llm === "pi") {
+            prdJson = await runPlannerPi({
                 goal: args.goal,
                 cwd: args.cwd,
                 model: args.model,

--- a/packages/baro-orchestrator/scripts/test-pi-integration.ts
+++ b/packages/baro-orchestrator/scripts/test-pi-integration.ts
@@ -1,0 +1,412 @@
+/**
+ * Integration test: Pi backend.
+ *
+ * Exercises the full stack — stream mapper, CLI participant, story agent,
+ * and one-shot runner — against a real `pi` process in a temporary git
+ * repository. Validates that:
+ *
+ *   1. The stream mapper correctly parses Pi's JSONL output
+ *   2. The CLI participant transitions through expected phases
+ *   3. The one-shot runner returns assistant text
+ *   4. The story agent completes a simple task end-to-end
+ *
+ * Usage:
+ *   npx tsx packages/baro-orchestrator/scripts/test-pi-integration.ts
+ *
+ * Prerequisites:
+ *   - `pi` binary on PATH
+ *   - A configured LLM provider for pi (any will do)
+ *
+ * Exit code 0 = all tests passed, non-zero = failure.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "fs"
+import { execSync } from "child_process"
+import { join } from "path"
+import { tmpdir } from "os"
+
+import {
+    AgenticEnvironment,
+    FunctionCallItem,
+    FunctionCallOutputItem,
+    ModelMessageItem,
+} from "@mozaik-ai/core"
+
+import { mapPiEvent } from "../src/pi-stream-mapper.js"
+import { PiCliParticipant } from "../src/participants/pi-cli-participant.js"
+import { PiStoryAgent } from "../src/participants/pi-story-agent.js"
+import { runPiOneShot } from "../src/pi-one-shot.js"
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+let testDir: string
+let passed = 0
+let failed = 0
+let skipped = 0
+
+/** True when the `pi` binary is resolvable on PATH. */
+function piAvailable(): boolean {
+    try {
+        execSync("command -v pi", { stdio: "ignore" })
+        return true
+    } catch {
+        return false
+    }
+}
+
+function setup(): void {
+    testDir = mkdtempSync(join(tmpdir(), "baro-pi-test-"))
+    execSync("git init", { cwd: testDir, stdio: "ignore" })
+    writeFileSync(join(testDir, "README.md"), "# Integration test project\n")
+    execSync("git add . && git commit -m 'init'", {
+        cwd: testDir,
+        stdio: "ignore",
+    })
+    process.stderr.write(`[test] temp dir: ${testDir}\n`)
+}
+
+function teardown(): void {
+    try {
+        rmSync(testDir, { recursive: true, force: true })
+    } catch {
+        // best-effort
+    }
+}
+
+function assert(condition: boolean, msg: string): void {
+    if (condition) {
+        passed++
+        process.stderr.write(`  ✓ ${msg}\n`)
+    } else {
+        failed++
+        process.stderr.write(`  ✗ FAIL: ${msg}\n`)
+    }
+}
+
+// ─── Test 1: Stream Mapper ────────────────────────────────────────────
+
+function testStreamMapper(): void {
+    process.stderr.write("\n[test] 1. Stream mapper\n")
+
+    // session — the only event carrying the session id (`event.id`).
+    const sessionEvent = {
+        type: "session",
+        version: 3,
+        id: "019e9d13-pi-session",
+        timestamp: 1234,
+        cwd: "/tmp/pi-probe",
+    }
+    const sessionResult = mapPiEvent("agent-1", sessionEvent)
+    assert(sessionResult.sessionId === "019e9d13-pi-session", "extracts sessionId from session event")
+    assert(sessionResult.items.length >= 1, "session produces items")
+
+    // message_update with a text_delta — must NOT emit a ModelMessageItem
+    // (final text comes from message_end), only a non-empty item.
+    const deltaEvent = {
+        type: "message_update",
+        assistantMessageEvent: {
+            type: "text_delta",
+            contentIndex: 1,
+            delta: "Hello",
+        },
+        message: { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+    }
+    const deltaResult = mapPiEvent("agent-1", deltaEvent)
+    assert(deltaResult.items.length >= 1, "message_update text_delta produces items")
+    assert(
+        !deltaResult.items.some((i) => i instanceof ModelMessageItem),
+        "text_delta does NOT emit a ModelMessageItem (no dup with message_end)",
+    )
+
+    // message_end (assistant) with a text content block → ModelMessageItem.
+    const messageEndEvent = {
+        type: "message_end",
+        message: {
+            role: "assistant",
+            content: [
+                { type: "thinking", thinking: "thinking..." },
+                { type: "text", text: "Hello world" },
+            ],
+            usage: { input: 10, output: 5, totalTokens: 15 },
+        },
+    }
+    const endResult = mapPiEvent("agent-1", messageEndEvent)
+    const modelMsg = endResult.items.find(
+        (item): item is ModelMessageItem => item instanceof ModelMessageItem,
+    )
+    const modelMsgText = modelMsg
+        ? (JSON.parse(JSON.stringify(modelMsg)).content ?? [])
+              .map((p: { text?: string }) => p.text ?? "")
+              .join("")
+        : undefined
+    assert(
+        modelMsgText === "Hello world",
+        "message_end produces a ModelMessageItem with the correct text",
+    )
+
+    // message_end with a toolCall content block → FunctionCallItem.
+    // Uses the REAL block shape: {type:"toolCall",id,name,arguments}.
+    const realCallId = "call_0a69297a"
+    const toolCallEnd = {
+        type: "message_end",
+        message: {
+            role: "assistant",
+            content: [
+                {
+                    type: "toolCall",
+                    id: realCallId,
+                    name: "bash",
+                    arguments: { command: "echo hello42" },
+                },
+            ],
+        },
+    }
+    const toolCallResult = mapPiEvent("agent-1", toolCallEnd)
+    const fnCall = toolCallResult.items.find(
+        (i): i is FunctionCallItem => i instanceof FunctionCallItem,
+    )
+    assert(
+        fnCall !== undefined,
+        "message_end with a toolCall block produces a FunctionCallItem",
+    )
+
+    // tool_execution_end → FunctionCallOutputItem, using the REAL shape:
+    //   {type, toolCallId, toolName, result:{content:[{type:"text",text}]}, isError}
+    // The toolCallId EQUALS the toolCall block id from message_end, so the
+    // call and its output must reconcile to the same callId.
+    const toolExecEnd = {
+        type: "tool_execution_end",
+        toolCallId: realCallId,
+        toolName: "bash",
+        result: { content: [{ type: "text", text: "hello42\n" }] },
+        isError: false,
+    }
+    const execResult = mapPiEvent("agent-1", toolExecEnd)
+    assert(execResult.items.length >= 1, "tool_execution_end produces items (not dropped)")
+    const fnOut = execResult.items.find(
+        (i): i is FunctionCallOutputItem =>
+            i instanceof FunctionCallOutputItem,
+    )
+    assert(
+        fnOut !== undefined,
+        "tool_execution_end (real shape) emits a FunctionCallOutputItem",
+    )
+
+    // The load-bearing reconciliation assertion: call.call_id === output.call_id
+    // === the real toolCallId. Round-1 bug: tool_execution_end read `callId`
+    // (never present) so this item was never emitted at all.
+    // NB: the serialized Mozaik field is `call_id` (snake_case), and the
+    // output is an array of {type:"input_text",text}, not a bare string.
+    const callId = fnCall
+        ? (JSON.parse(JSON.stringify(fnCall)).call_id as string | undefined)
+        : undefined
+    const outCallId = fnOut
+        ? (JSON.parse(JSON.stringify(fnOut)).call_id as string | undefined)
+        : undefined
+    assert(
+        callId === realCallId,
+        `FunctionCallItem.call_id === ${realCallId} (got: ${callId})`,
+    )
+    assert(
+        outCallId === realCallId,
+        `FunctionCallOutputItem.call_id === ${realCallId} (got: ${outCallId})`,
+    )
+    assert(
+        callId !== undefined && callId === outCallId,
+        "call and output reconcile to the same call_id",
+    )
+
+    // The output text must come from result.content[].text, not a stringified
+    // result object.
+    const outParts = fnOut
+        ? (JSON.parse(JSON.stringify(fnOut)).output as
+              | Array<{ text?: string }>
+              | undefined)
+        : undefined
+    const outText = Array.isArray(outParts)
+        ? outParts.map((p) => p.text ?? "").join("")
+        : undefined
+    assert(
+        typeof outText === "string" && outText.includes("hello42"),
+        `output text extracted from result.content[].text (got: ${outText})`,
+    )
+
+    // agent_end (loop-done signal).
+    const agentEndEvent = { type: "agent_end", messages: [], willRetry: false }
+    const agentEndResult = mapPiEvent("agent-1", agentEndEvent)
+    assert(agentEndResult.items.length >= 1, "agent_end produces items")
+
+    // unknown
+    const unknownEvent = { type: "foobar", timestamp: 1239 }
+    const unknownResult = mapPiEvent("agent-1", unknownEvent)
+    assert(unknownResult.items.length >= 1, "unknown event produces items (not dropped)")
+}
+
+// ─── Test 2: One-Shot Runner (live) ───────────────────────────────────
+
+async function testOneShot(): Promise<void> {
+    process.stderr.write("\n[test] 2. One-shot runner (live pi invocation)\n")
+
+    try {
+        const result = await runPiOneShot({
+            prompt: 'Say exactly this text and nothing else: BARO_INTEGRATION_TEST_PASS',
+            cwd: testDir,
+            timeoutMs: 120_000,
+            label: "test-oneshot",
+        })
+        assert(result.includes("BARO_INTEGRATION_TEST_PASS"), "one-shot returns expected text")
+        assert(result.length > 0, "one-shot returns non-empty text")
+    } catch (e) {
+        assert(false, `one-shot threw: ${(e as Error).message}`)
+    }
+}
+
+// ─── Test 3: CLI Participant (live) ───────────────────────────────────
+
+async function testCliParticipant(): Promise<void> {
+    process.stderr.write("\n[test] 3. CLI participant (live pi invocation)\n")
+
+    const env = new AgenticEnvironment()
+    const participant = new PiCliParticipant("test-agent", {
+        cwd: testDir,
+        prompt: 'Say exactly: CLI_PARTICIPANT_OK',
+    })
+
+    participant.join(env)
+    participant.start(env)
+
+    try {
+        await participant.ready
+        assert(true, "participant becomes ready")
+        assert(participant.getPhase() === "running", `phase is running (got: ${participant.getPhase()})`)
+    } catch (e) {
+        assert(false, `participant.ready rejected: ${(e as Error).message}`)
+    }
+
+    const summary = await participant.done
+    assert(summary.exitCode === 0, `exit code is 0 (got: ${summary.exitCode})`)
+    assert(summary.error === null, "no error on summary")
+    assert(participant.getPhase() === "done", `final phase is done (got: ${participant.getPhase()})`)
+
+    participant.leave(env)
+}
+
+// ─── Test 4: Story Agent (live) ───────────────────────────────────────
+
+async function testStoryAgent(): Promise<void> {
+    process.stderr.write("\n[test] 4. Story agent (live pi invocation)\n")
+
+    // A story is real work: edit the worktree. Use a file-mutation prompt
+    // (not a prose echo) so success means the agent actually did something
+    // — and so the success predicate (which requires >=1 tool call) is
+    // exercised on a genuine task.
+    const targetFile = "STORY_AGENT_OK.txt"
+    const env = new AgenticEnvironment()
+    const agent = new PiStoryAgent({
+        id: "test-story-1",
+        prompt: `Create a file named ${targetFile} in the current directory containing exactly the text DONE. Use your file-writing tools.`,
+        cwd: testDir,
+        retries: 0,
+        timeoutSecs: 180,
+    })
+
+    agent.join(env)
+    const outcome = await agent.run(env)
+
+    assert(outcome.success === true, `story succeeded (got: ${outcome.success}, error: ${outcome.error})`)
+    assert(outcome.attempts === 1, `completed in 1 attempt (got: ${outcome.attempts})`)
+    assert(outcome.error === null, "no error in outcome")
+    assert(outcome.durationSecs >= 0, "duration is non-negative")
+    // The whole point of a story: the worktree changed.
+    assert(
+        existsSync(join(testDir, targetFile)),
+        `story agent actually created ${targetFile} in the worktree`,
+    )
+
+    agent.leave(env)
+}
+
+// ─── Test 5: Success predicate rejects no-op (regression guard) ───────
+//
+// `pi` exits 0 even when the model just talks and does no work. A
+// prose-only prompt invokes no tools, so the success predicate MUST
+// reject it — otherwise a refused/no-op story would be reported as a
+// false PASS to the Conductor. This guards that predicate against
+// regressing back to exit-code-only.
+async function testNoOpRejected(): Promise<void> {
+    process.stderr.write("\n[test] 5. No-op story is rejected (regression guard)\n")
+
+    const env = new AgenticEnvironment()
+    const agent = new PiStoryAgent({
+        id: "test-story-noop",
+        prompt: "Reply with the single word ACKNOWLEDGED and do nothing else. Do not use any tools.",
+        cwd: testDir,
+        retries: 0,
+        timeoutSecs: 120,
+    })
+
+    agent.join(env)
+    const outcome = await agent.run(env)
+
+    assert(
+        outcome.success === false,
+        `no-op (zero-tool) story is NOT marked passed (got success=${outcome.success})`,
+    )
+    assert(
+        outcome.error != null,
+        "no-op story carries a reason for the non-pass",
+    )
+
+    agent.leave(env)
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+    process.stderr.write("═══ Pi Backend Integration Test ═══\n")
+
+    setup()
+
+    try {
+        // Unit-level test (no live process needed)
+        testStreamMapper()
+
+        // Live integration tests need `pi` on PATH + a configured
+        // provider. Probe up front and SKIP (not fail) when it's absent,
+        // so CI / machines without pi don't conflate "environment not
+        // provisioned" with "code regression". A genuine failure still
+        // exits non-zero; a missing binary exits 0 after the unit test.
+        if (piAvailable()) {
+            await testOneShot()
+            await testCliParticipant()
+            await testStoryAgent()
+            await testNoOpRejected()
+        } else {
+            skipped += 4
+            process.stderr.write(
+                "\n[test] pi not found on PATH — SKIPPING live tests 2-5 " +
+                    "(install pi and configure a provider to run them).\n",
+            )
+        }
+    } finally {
+        teardown()
+    }
+
+    process.stderr.write(
+        `\n═══ Results: ${passed} passed, ${failed} failed, ${skipped} skipped ═══\n`,
+    )
+
+    if (failed > 0) {
+        process.exit(1)
+    }
+    process.stderr.write(
+        skipped > 0
+            ? "Unit tests passed (live tests skipped).\n"
+            : "All tests passed.\n",
+    )
+}
+
+main().catch((e) => {
+    process.stderr.write(`FATAL: ${(e as Error).message}\n`)
+    process.exit(2)
+})

--- a/packages/baro-orchestrator/scripts/test-pi-integration.ts
+++ b/packages/baro-orchestrator/scripts/test-pi-integration.ts
@@ -231,6 +231,90 @@ function testStreamMapper(): void {
         `output text extracted from result.content[].text (got: ${outText})`,
     )
 
+    // Regression (HIGH-1): an empty-but-successful tool result (e.g. bash with
+    // no stdout → content:[{type:"text",text:""}]) must STILL emit a
+    // FunctionCallOutputItem (reconciled to the callId), not fall through to a
+    // stringified-envelope dump and not be dropped.
+    const emptyOutEnd = {
+        type: "tool_execution_end",
+        toolCallId: realCallId,
+        toolName: "bash",
+        result: { content: [{ type: "text", text: "" }] },
+        isError: false,
+    }
+    const emptyRes = mapPiEvent("agent-1", emptyOutEnd)
+    const emptyFnOut = emptyRes.items.find(
+        (i): i is FunctionCallOutputItem => i instanceof FunctionCallOutputItem,
+    )
+    assert(
+        emptyFnOut !== undefined,
+        "empty-success tool result still emits a FunctionCallOutputItem (HIGH-1)",
+    )
+    const emptyParts = emptyFnOut
+        ? (JSON.parse(JSON.stringify(emptyFnOut)).output as
+              | Array<{ text?: string }>
+              | undefined)
+        : undefined
+    const emptyText = Array.isArray(emptyParts)
+        ? emptyParts.map((p) => p.text ?? "").join("")
+        : undefined
+    assert(
+        emptyText === "" && !String(emptyText).includes("content"),
+        `empty result yields empty output, not a stringified envelope (got: ${JSON.stringify(emptyText)})`,
+    )
+
+    // Regression (HIGH-1, load-bearing): a tool_execution_end with NO `result`
+    // field at all (interrupted/cancelled/error path) — this is the shape that
+    // makes extractToolOutput return undefined. The OLD emit guard
+    // (`callId !== undefined && outputStr !== undefined`) would DROP the
+    // FunctionCallOutputItem here, orphaning the FunctionCallItem from
+    // message_end. The fix emits it anyway (body defaults to ""/"no output").
+    // This assertion FAILS if the fix is reverted.
+    const noBodyEnd = {
+        type: "tool_execution_end",
+        toolCallId: realCallId,
+        toolName: "bash",
+        isError: false,
+    }
+    const noBodyRes = mapPiEvent("agent-1", noBodyEnd)
+    const noBodyFnOut = noBodyRes.items.find(
+        (i): i is FunctionCallOutputItem => i instanceof FunctionCallOutputItem,
+    )
+    assert(
+        noBodyFnOut !== undefined,
+        "tool_execution_end with NO result field still emits a FunctionCallOutputItem (HIGH-1, fails on revert)",
+    )
+
+    // Regression (HIGH-1): same shape but isError → output must be the explicit
+    // failure sentinel, not dropped. The 'no output' default branch is only
+    // reachable when result is entirely absent, so this exercises it.
+    const errEnd = {
+        type: "tool_execution_end",
+        toolCallId: realCallId,
+        toolName: "bash",
+        isError: true,
+    }
+    const errRes = mapPiEvent("agent-1", errEnd)
+    const errFnOut = errRes.items.find(
+        (i): i is FunctionCallOutputItem => i instanceof FunctionCallOutputItem,
+    )
+    assert(
+        errFnOut !== undefined,
+        "errored tool_execution_end with no result still emits a FunctionCallOutputItem (HIGH-1, fails on revert)",
+    )
+    const errParts = errFnOut
+        ? (JSON.parse(JSON.stringify(errFnOut)).output as
+              | Array<{ text?: string }>
+              | undefined)
+        : undefined
+    const errText = Array.isArray(errParts)
+        ? errParts.map((p) => p.text ?? "").join("")
+        : undefined
+    assert(
+        errText === "[error] no output",
+        `errored no-result output is the explicit '[error] no output' sentinel (got: ${JSON.stringify(errText)})`,
+    )
+
     // agent_end (loop-done signal).
     const agentEndEvent = { type: "agent_end", messages: [], willRetry: false }
     const agentEndResult = mapPiEvent("agent-1", agentEndEvent)

--- a/packages/baro-orchestrator/src/main.ts
+++ b/packages/baro-orchestrator/src/main.ts
@@ -65,6 +65,26 @@ export {
 
 export { runOpenCodeOneShot, type RunOpenCodeOneShotOptions } from "./opencode-one-shot.js"
 
+export {
+    PiCliParticipant,
+    type PiCliParticipantOptions,
+    type PiRunSummary,
+} from "./participants/pi-cli-participant.js"
+
+export {
+    PiStoryAgent,
+    type PiStorySpec,
+    type PiStoryOutcome,
+} from "./participants/pi-story-agent.js"
+
+export {
+    mapPiEvent,
+    type PiMapResult,
+    type MappedPiItem,
+} from "./pi-stream-mapper.js"
+
+export { runPiOneShot, type RunPiOneShotOptions } from "./pi-one-shot.js"
+
 export { Auditor, type AuditorOptions } from "./participants/auditor.js"
 
 export {

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -253,6 +253,23 @@ export async function orchestrate(
     const criticLlm = config.criticLlm ?? llm
     const surgeonLlm = config.surgeonLlm ?? llm
 
+    // The Critic only evaluates backends that emit an AgentResult on the bus.
+    // The CLI-subprocess backends (pi, opencode) emit StoryResult/AgentState
+    // instead, so a self-paired run (story AND critic on the same such
+    // backend) leaves the Critic permanently silent. Warn loudly rather than
+    // failing quietly — the valid use (e.g. `--critic-llm pi` evaluating
+    // Claude stories, which DO emit AgentResult) is unaffected.
+    if (config.withCritic) {
+        const noAgentResult = new Set(["pi", "opencode"])
+        if (noAgentResult.has(criticLlm) && criticLlm === storyLlm) {
+            process.stderr.write(
+                `[orchestrate] WARNING: --with-critic with story+critic both on '${criticLlm}' — ` +
+                    `the ${criticLlm} backend emits no AgentResult, so the Critic will never fire. ` +
+                    `Use a Claude/OpenAI story backend, or set --critic-llm to a different backend.\n`,
+            )
+        }
+    }
+
     // Provider banner so the stderr / audit log makes the actual
     // routing obvious. As of 0.33 every LLM-using phase (Architect,
     // Planner, Critic, Surgeon, StoryAgent) routes end-to-end to the

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -253,19 +253,21 @@ export async function orchestrate(
     const criticLlm = config.criticLlm ?? llm
     const surgeonLlm = config.surgeonLlm ?? llm
 
-    // The Critic only evaluates backends that emit an AgentResult on the bus.
-    // The CLI-subprocess backends (pi, opencode) emit StoryResult/AgentState
-    // instead, so a self-paired run (story AND critic on the same such
-    // backend) leaves the Critic permanently silent. Warn loudly rather than
-    // failing quietly — the valid use (e.g. `--critic-llm pi` evaluating
-    // Claude stories, which DO emit AgentResult) is unaffected.
+    // The Critic listens for AgentResult on the bus. The CLI-subprocess
+    // story backends (pi, opencode) emit StoryResult/AgentState and never
+    // AgentResult, so the Critic is silent whenever the STORY backend is one
+    // of them — regardless of which backend the Critic itself runs on. (The
+    // critic backend choice only affects which model evaluates; it can't
+    // observe what the story never emits.) Warn loudly rather than failing
+    // quietly. `--critic-llm pi` over a Claude/OpenAI story still works,
+    // because those story backends DO emit AgentResult.
     if (config.withCritic) {
         const noAgentResult = new Set(["pi", "opencode"])
-        if (noAgentResult.has(criticLlm) && criticLlm === storyLlm) {
+        if (noAgentResult.has(storyLlm)) {
             process.stderr.write(
-                `[orchestrate] WARNING: --with-critic with story+critic both on '${criticLlm}' — ` +
-                    `the ${criticLlm} backend emits no AgentResult, so the Critic will never fire. ` +
-                    `Use a Claude/OpenAI story backend, or set --critic-llm to a different backend.\n`,
+                `[orchestrate] WARNING: --with-critic with story backend '${storyLlm}' — ` +
+                    `the ${storyLlm} backend emits no AgentResult, so the Critic will never fire. ` +
+                    `Use a Claude/OpenAI story backend, or set --story-llm to a different backend.\n`,
             )
         }
     }

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -31,6 +31,7 @@ import { Critic } from "./participants/critic.js"
 import { CriticCodex } from "./participants/critic-codex.js"
 import { CriticOpenAI } from "./participants/critic-openai.js"
 import { CriticOpenCode } from "./participants/critic-opencode.js"
+import { CriticPi } from "./participants/critic-pi.js"
 import { Finalizer } from "./participants/finalizer.js"
 import { joinBaroEventForwarders } from "./participants/forwarders/index.js"
 import { Librarian } from "./participants/librarian.js"
@@ -43,6 +44,7 @@ import { Surgeon, type PrdSnapshot } from "./participants/surgeon.js"
 import { SurgeonCodex } from "./participants/surgeon-codex.js"
 import { SurgeonOpenAI } from "./participants/surgeon-openai.js"
 import { SurgeonOpenCode } from "./participants/surgeon-opencode.js"
+import { SurgeonPi } from "./participants/surgeon-pi.js"
 import { PrdFile, loadPrd } from "./prd.js"
 import { RunStartRequest } from "./semantic-events.js"
 import { emit } from "./tui-protocol.js"
@@ -142,16 +144,16 @@ export interface OrchestrateConfig {
      * Planner phases are wired up in the Rust TUI layer, not here —
      * orchestrate.ts doesn't see them.
      */
-    llm?: "claude" | "openai" | "codex" | "opencode"
+    llm?: "claude" | "openai" | "codex" | "opencode" | "pi"
     /**
      * Optional per-phase overrides. When set, win over `llm`. Each can
      * be any of the three providers, independent of the others. Used
      * by the `--llm hybrid` preset (Story+Critic on Codex bulk-savings,
      * Surgeon on Claude for rare-but-high-stakes failures).
      */
-    storyLlm?: "claude" | "openai" | "codex" | "opencode"
-    criticLlm?: "claude" | "openai" | "codex" | "opencode"
-    surgeonLlm?: "claude" | "openai" | "codex" | "opencode"
+    storyLlm?: "claude" | "openai" | "codex" | "opencode" | "pi"
+    criticLlm?: "claude" | "openai" | "codex" | "opencode" | "pi"
+    surgeonLlm?: "claude" | "openai" | "codex" | "opencode" | "pi"
     /**
      * Per-phase model override for StoryAgent. When set, wins over
      * each story's individual `model` field in the PRD as well as
@@ -242,7 +244,7 @@ export async function orchestrate(
 ): Promise<OrchestrateResult> {
     const env = new AgenticEnvironment()
     const emitTui = config.emitTuiEvents ?? true
-    const llm: "claude" | "openai" | "codex" | "opencode" = config.llm ?? "claude"
+    const llm: "claude" | "openai" | "codex" | "opencode" | "pi" = config.llm ?? "claude"
     // Per-phase resolution: each falls back to global `llm` when no
     // explicit override is provided. This is the central place where
     // hybrid configurations land — every downstream factory branches
@@ -293,6 +295,11 @@ export async function orchestrate(
         process.stderr.write(
             "[orchestrate] llm=opencode: Story, Critic, Surgeon all shelling out to " +
                 "`opencode run --format json` (OpenCode CLI path).\n",
+        )
+    } else if (llm === "pi") {
+        process.stderr.write(
+            "[orchestrate] llm=pi: Story, Critic, Surgeon all shelling out to " +
+                "`pi --mode json -p` (Pi CLI path).\n",
         )
     } else {
         process.stderr.write(
@@ -366,7 +373,7 @@ export async function orchestrate(
     // Phase-4 observer — Surgeon (adaptive DAG mutation). Opt-in.
     // Joins early so it sees StoryResultItem-s from the moment the
     // Conductor starts running.
-    let surgeon: Surgeon | SurgeonOpenAI | SurgeonCodex | SurgeonOpenCode | null = null
+    let surgeon: Surgeon | SurgeonOpenAI | SurgeonCodex | SurgeonOpenCode | SurgeonPi | null = null
     if (config.withSurgeon) {
         const snapshot = (): PrdSnapshot => {
             const current = loadPrd(config.prdPath)
@@ -404,6 +411,12 @@ export async function orchestrate(
                 useLlm: config.surgeonUseLlm ?? true,
                 model: config.surgeonModel,
             })
+        } else if (surgeonLlm === "pi") {
+            surgeon = new SurgeonPi({
+                snapshot,
+                useLlm: config.surgeonUseLlm ?? true,
+                model: config.surgeonModel,
+            })
         } else {
             surgeon = new Surgeon({
                 snapshot,
@@ -417,7 +430,7 @@ export async function orchestrate(
     // Phase-3 observer — Critic (live acceptance-criteria evaluator).
     // Opt-in (default OFF). Spawns `claude --model haiku` subprocesses
     // for each evaluation, inheriting Claude CLI auth.
-    let critic: Critic | CriticOpenAI | CriticCodex | CriticOpenCode | null = null
+    let critic: Critic | CriticOpenAI | CriticCodex | CriticOpenCode | CriticPi | null = null
     if (config.withCritic) {
         const prd = loadPrd(config.prdPath)
         const targets = new Map<string, readonly string[]>(
@@ -441,6 +454,11 @@ export async function orchestrate(
             })
         } else if (criticLlm === "opencode") {
             critic = new CriticOpenCode({
+                targets,
+                model: config.criticModel,
+            })
+        } else if (criticLlm === "pi") {
+            critic = new CriticPi({
                 targets,
                 model: config.criticModel,
             })

--- a/packages/baro-orchestrator/src/participants/critic-pi.ts
+++ b/packages/baro-orchestrator/src/participants/critic-pi.ts
@@ -1,0 +1,186 @@
+/**
+ * CriticPi — live acceptance-criteria evaluator via the `pi` CLI.
+ * Sibling of `critic.ts` (Claude), `critic-openai.ts`, `critic-codex.ts`,
+ * and `critic-opencode.ts`.
+ *
+ * Same bus contract as the other variants: observes AgentResultItem
+ * events, evaluates the agent's output against acceptance criteria,
+ * publishes a CritiqueItem (audit trail), and emits an
+ * AgentTargetedMessageItem corrective when the verdict is "fail" (up
+ * to maxEmissionsPerAgent). The only difference is which subprocess
+ * the verdict call shells to.
+ *
+ * Library-grade: no imports from prd.ts, story-agent.ts, or
+ * conductor.ts.
+ */
+
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import { runPiOneShot } from "../pi-one-shot.js"
+import {
+    AgentResult,
+    AgentTargetedMessage,
+    Critique,
+} from "../semantic-events.js"
+import {
+    VERDICT_SYSTEM_PROMPT,
+    buildEvalPrompt,
+    buildCorrectiveMessage,
+    extractVerdictJson,
+} from "./critic.js"
+
+export interface CriticPiOptions {
+    /** Map from agentId to its acceptance-criteria strings. */
+    targets: ReadonlyMap<string, readonly string[]>
+    /** Max corrective AgentTargetedMessageItem-s per agent. Default: 2. */
+    maxEmissionsPerAgent?: number
+    /**
+     * Provider to use (e.g. "anthropic", "openai"). Omit to use Pi's
+     * configured default.
+     */
+    provider?: string
+    /**
+     * Model identifier. Omit to use Pi's configured default.
+     */
+    model?: string
+    /** Path to the `pi` binary. Default: "pi". */
+    piBin?: string
+    /** Per-evaluation timeout in milliseconds. Default: 180_000 (3 min). */
+    timeoutMs?: number
+}
+
+export class CriticPi extends BaseObserver {
+    private readonly opts: Required<
+        Omit<CriticPiOptions, "targets" | "provider" | "model" | "piBin">
+    > & {
+        targets: ReadonlyMap<string, readonly string[]>
+        provider: string | undefined
+        model: string | undefined
+        piBin: string
+    }
+    private readonly emissions = new Map<string, number>()
+    private readonly turnCount = new Map<string, number>()
+    private readonly pending = new Set<Promise<void>>()
+
+    constructor(opts: CriticPiOptions) {
+        super()
+        this.opts = {
+            maxEmissionsPerAgent: opts.maxEmissionsPerAgent ?? 2,
+            provider: opts.provider,
+            model: opts.model,
+            piBin: opts.piBin ?? "pi",
+            timeoutMs: opts.timeoutMs ?? 180_000,
+            targets: opts.targets,
+        }
+    }
+
+    /** Resolves once every in-flight evaluation has emitted its CritiqueItem. */
+    async idle(): Promise<void> {
+        await Promise.allSettled([...this.pending])
+    }
+
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (!AgentResult.is(event)) return
+        const { agentId, isError, resultText } = event.data
+        if (isError || !resultText) return
+
+        const criteria = this.opts.targets.get(agentId)
+        if (!criteria || criteria.length === 0) return
+
+        const turn = (this.turnCount.get(agentId) ?? 0) + 1
+        this.turnCount.set(agentId, turn)
+
+        const work = (async () => {
+            const { verdict, reasoning, violatedCriteria } = await this.evaluate(
+                resultText,
+                criteria,
+            )
+
+            const critiqueEvent = Critique.create({
+                agentId,
+                verdict,
+                reasoning,
+                violatedCriteria,
+                turn,
+                modelUsed: this.opts.model ?? "pi-default",
+            })
+            for (const env of this.getEnvironments()) {
+                env.deliverSemanticEvent(this, critiqueEvent)
+            }
+
+            if (verdict === "fail") {
+                const emitted = this.emissions.get(agentId) ?? 0
+                if (emitted < this.opts.maxEmissionsPerAgent) {
+                    this.emissions.set(agentId, emitted + 1)
+                    const text = buildCorrectiveMessage(reasoning, violatedCriteria)
+                    const msg = AgentTargetedMessage.create({
+                        recipientId: agentId,
+                        text,
+                        metadata: {
+                            criticTurn: turn,
+                            emissionIndex: emitted + 1,
+                        },
+                    })
+                    for (const env of this.getEnvironments()) {
+                        env.deliverSemanticEvent(this, msg)
+                    }
+                }
+            }
+        })()
+
+        this.pending.add(work)
+        work.finally(() => {
+            this.pending.delete(work)
+        })
+
+        await work
+    }
+
+    private async evaluate(
+        resultText: string,
+        criteria: readonly string[],
+    ): Promise<{
+        verdict: "pass" | "fail"
+        reasoning: string
+        violatedCriteria: string[]
+    }> {
+        const userPrompt = buildEvalPrompt(criteria, resultText)
+        const prompt = `${VERDICT_SYSTEM_PROMPT}\n\n${userPrompt}`
+
+        try {
+            const text = await runPiOneShot({
+                prompt,
+                cwd: process.cwd(),
+                provider: this.opts.provider,
+                model: this.opts.model,
+                piBin: this.opts.piBin,
+                timeoutMs: this.opts.timeoutMs,
+                label: "pi-critic",
+            })
+
+            const verdictJson = extractVerdictJson(text.trim())
+            const parsed = JSON.parse(verdictJson) as {
+                verdict: "pass" | "fail"
+                reasoning: string
+                violated_criteria: string[]
+            }
+
+            return {
+                verdict: parsed.verdict === "pass" ? "pass" : "fail",
+                reasoning: parsed.reasoning ?? "",
+                violatedCriteria: Array.isArray(parsed.violated_criteria)
+                    ? parsed.violated_criteria
+                    : [],
+            }
+        } catch (err) {
+            return {
+                verdict: "fail",
+                reasoning: `CriticPi LLM call failed: ${String((err as Error)?.message ?? err)}`,
+                violatedCriteria: ["[critic error — could not evaluate]"],
+            }
+        }
+    }
+}

--- a/packages/baro-orchestrator/src/participants/pi-cli-participant.ts
+++ b/packages/baro-orchestrator/src/participants/pi-cli-participant.ts
@@ -261,6 +261,11 @@ export class PiCliParticipant extends BaseObserver {
         proc.stdout!.setEncoding("utf8")
         proc.stderr!.setEncoding("utf8")
         proc.stdout!.on("data", (chunk: string) => this.handleStdout(chunk))
+        // Flush any trailing line that arrived without a newline before the
+        // stream closed — a Pi build/wrapper omitting the final `\n` would
+        // otherwise drop its last event (e.g. agent_end), corrupting the
+        // success predicate. 'end' fires after the last 'data', before 'exit'.
+        proc.stdout!.on("end", () => this.flushStdout())
         proc.stderr!.on("data", (chunk: string) => this.handleStderr(chunk))
         proc.on("error", (err) => {
             // Async process error (e.g. EACCES/EPIPE surfaced after a
@@ -390,6 +395,17 @@ export class PiCliParticipant extends BaseObserver {
             )
             this.buffer = ""
         }
+    }
+
+    /**
+     * Process any trailing buffered bytes left when stdout closes without a
+     * final newline. Called from the stream's 'end' handler so a final
+     * `message_end`/`agent_end` line that lacks a trailing `\n` is not lost.
+     */
+    private flushStdout(): void {
+        const line = this.buffer.trim()
+        this.buffer = ""
+        if (line) this.processLine(line)
     }
 
     private handleStderr(chunk: string): void {

--- a/packages/baro-orchestrator/src/participants/pi-cli-participant.ts
+++ b/packages/baro-orchestrator/src/participants/pi-cli-participant.ts
@@ -1,0 +1,471 @@
+/**
+ * PiCliParticipant — wraps a Pi CLI process as a first-class Mozaik
+ * Participant. Sibling of `OpenCodeCliParticipant` and `CodexCliParticipant`.
+ *
+ * Spawned with `pi --mode json -p --no-session "PROMPT"`.
+ * Pi in `-p` mode is one-shot non-interactive: takes a single prompt as
+ * argv, streams JSONL events to stdout, exits when the agent finishes.
+ * There is no stdin event loop and no permissions prompt — Pi runs tools
+ * autonomously when invoked with `-p`. That makes this participant
+ * structurally identical to OpenCodeCliParticipant; the key differences
+ * are CLI flags, event shapes, and the completion evidence tokens
+ * (`agent_end` / `tool_execution_start` instead of `step_finish` /
+ * `tool_use`).
+ *
+ * Library-grade: knows nothing about baro, PRD, or stories. Only knows
+ * about agent IDs, working directories, and Pi.
+ */
+
+import { ChildProcess, spawn } from "child_process"
+
+import {
+    BaseObserver,
+    FunctionCallItem,
+    FunctionCallOutputItem,
+    ModelMessageItem,
+    Participant,
+    SemanticEvent,
+} from "@mozaik-ai/core"
+
+import { AgenticEnvironment } from "@mozaik-ai/core"
+import {
+    AgentState,
+    AgentTargetedMessage,
+    PiSystem,
+    type AgentPhase,
+} from "../semantic-events.js"
+import { mapPiEvent } from "../pi-stream-mapper.js"
+
+/** Options for constructing a PiCliParticipant. */
+export interface PiCliParticipantOptions {
+    /** Working directory for the Pi process. Required. */
+    cwd: string
+    /** Initial prompt — passed as the final argv to `pi`. */
+    prompt: string
+    /**
+     * Provider override (e.g. "google", "anthropic"). Pi's default is
+     * "google". Omit to use Pi's configured default.
+     */
+    provider?: string
+    /**
+     * Model identifier. Treated as an opaque string and forwarded via
+     * `--model`. Omit to use Pi's configured default.
+     */
+    model?: string
+    /** Path to the `pi` binary. Default: "pi" (resolved via PATH). */
+    piBin?: string
+}
+
+/** Summary emitted when the Pi process exits. */
+export interface PiRunSummary {
+    sessionId: string | null
+    exitCode: number | null
+    error: Error | null
+    /**
+     * True once at least one `agent_end` event was observed — i.e. the
+     * agent loop actually completed rather than the process simply exiting.
+     * Pi exits 0 even when the model produces no work, so exit code alone
+     * is NOT proof of task success. Callers should require this before
+     * treating exitCode 0 as a real completion.
+     */
+    sawAgentEnd: boolean
+    /**
+     * Number of `tool_execution_start` events observed. A code-writing
+     * story that claims success having invoked zero tools is suspect — the
+     * agent likely answered in prose instead of editing the worktree.
+     */
+    toolCallCount: number
+}
+
+/**
+ * Mozaik participant that wraps a single `pi -p` CLI subprocess.
+ * Streams JSONL events to the bus and manages lifecycle transitions.
+ */
+export class PiCliParticipant extends BaseObserver {
+    /**
+     * Process-wide registry of every Pi child currently running.
+     * Used by the orchestrator's SIGINT/SIGTERM handlers to nuke orphans
+     * so a killed baro doesn't leave background agents burning quota.
+     */
+    private static readonly active = new Set<PiCliParticipant>()
+
+    /**
+     * Send a signal to every active Pi child, then escalate to SIGKILL
+     * after a grace period for any child that ignored the soft signal.
+     * Idempotent. A Pi child that ignores SIGTERM (e.g. blocked in a
+     * syscall or holding its own child group) would otherwise outlive a
+     * killed baro and keep burning quota.
+     */
+    static killAll(signal: NodeJS.Signals = "SIGTERM"): void {
+        for (const p of PiCliParticipant.active) {
+            p.abort(signal)
+        }
+    }
+
+    private readonly options: Required<
+        Pick<PiCliParticipantOptions, "piBin">
+    > &
+        PiCliParticipantOptions
+
+    private proc: ChildProcess | null = null
+    private buffer = ""
+    private envRef: AgenticEnvironment | null = null
+    private currentPhase: AgentPhase = "idle"
+    private sessionId: string | null = null
+    private exitCode: number | null = null
+    private spawnError: Error | null = null
+    private sawAgentEnd = false
+    private toolCallCount = 0
+    private doneSettled = false
+    private readySettled = false
+    private killTimer: ReturnType<typeof setTimeout> | null = null
+    private resolveDone!: (summary: PiRunSummary) => void
+    private resolveReady!: () => void
+    private rejectReady!: (e: Error) => void
+
+    /**
+     * Grace period (ms) between SIGTERM and the SIGKILL escalation in
+     * {@link abort}. A Pi child wedged in a blocking syscall ignores
+     * SIGTERM; without escalation `await done` would hang forever.
+     */
+    private static readonly KILL_GRACE_MS = 5_000
+
+    /** Cap on the un-newlined stdout buffer (16 MiB). See handleStdout. */
+    private static readonly MAX_BUFFER_BYTES = 16 * 1024 * 1024
+
+    /** Resolves once Pi emits its first `agent_start` or `session` event. */
+    public readonly ready: Promise<void>
+    /** Resolves once the Pi process exits (regardless of success). */
+    public readonly done: Promise<PiRunSummary>
+
+    constructor(
+        public readonly agentId: string,
+        opts: PiCliParticipantOptions,
+    ) {
+        super()
+        this.options = {
+            piBin: "pi",
+            ...opts,
+        }
+        this.ready = new Promise<void>((res, rej) => {
+            this.resolveReady = res
+            this.rejectReady = rej
+        })
+        // Suppress UnhandledPromiseRejection when callers only await
+        // `done` and never attach a rejection handler to `ready`. The
+        // rejection is still observable by callers who do await `ready`;
+        // the no-op catch here only prevents the Node.js warning when no
+        // one is listening.
+        this.ready.catch(() => { /* suppressed — callers use `done` */ })
+        this.done = new Promise<PiRunSummary>((res) => {
+            this.resolveDone = res
+        })
+    }
+
+    /**
+     * Settle the `done` promise exactly once. Both the `exit` and
+     * `error` process listeners can fire (in either order, or one
+     * without the other), so every resolution path goes through here to
+     * avoid a double-resolve and, more importantly, to guarantee `done`
+     * always settles — the previous `error` handler rejected `ready` but
+     * never resolved `done`, so an async spawn error with no following
+     * `exit` left `done` pending forever and any awaiter hung.
+     */
+    private settleDone(summary: PiRunSummary): void {
+        if (this.doneSettled) return
+        this.doneSettled = true
+        // The process is gone (or never started); cancel any pending
+        // SIGKILL escalation so it can't fire against a recycled pid and
+        // so the timer doesn't keep the event loop alive.
+        if (this.killTimer !== null) {
+            clearTimeout(this.killTimer)
+            this.killTimer = null
+        }
+        this.resolveDone(summary)
+    }
+
+    /**
+     * Resolve `ready` exactly once (first `session`/`agent_start` seen).
+     */
+    private settleReady(): void {
+        if (this.readySettled) return
+        this.readySettled = true
+        this.resolveReady()
+    }
+
+    /**
+     * Reject `ready` exactly once. Used on spawn/async error AND on a clean
+     * process exit that never produced a `session`/`agent_start` — without
+     * this the public `ready` promise would stay pending forever for any
+     * caller that awaits it (e.g. a wedged Pi that exits 0 with no events).
+     */
+    private failReady(e: Error): void {
+        if (this.readySettled) return
+        this.readySettled = true
+        this.rejectReady(e)
+    }
+
+    getSessionId(): string | null {
+        return this.sessionId
+    }
+
+    getPhase(): AgentPhase {
+        return this.currentPhase
+    }
+
+    /**
+     * Spawn the Pi process and start streaming its events into the
+     * environment. Idempotent: subsequent calls are a no-op.
+     */
+    start(environment: AgenticEnvironment): void {
+        if (this.proc) return
+        this.envRef = environment
+
+        const args = this.buildArgs()
+        let proc: ChildProcess
+        try {
+            proc = spawn(this.options.piBin, args, {
+                cwd: this.options.cwd,
+                // stdin: "ignore" — one-shot, no interactive input
+                stdio: ["ignore", "pipe", "pipe"],
+            })
+        } catch (e) {
+            this.spawnError = e instanceof Error ? e : new Error(String(e))
+            this.transition("failed", this.spawnError.message)
+            this.failReady(this.spawnError)
+            this.settleDone({
+                sessionId: null,
+                exitCode: null,
+                error: this.spawnError,
+                sawAgentEnd: this.sawAgentEnd,
+                toolCallCount: this.toolCallCount,
+            })
+            return
+        }
+
+        this.proc = proc
+        PiCliParticipant.active.add(this)
+        this.transition("starting")
+
+        proc.stdout!.setEncoding("utf8")
+        proc.stderr!.setEncoding("utf8")
+        proc.stdout!.on("data", (chunk: string) => this.handleStdout(chunk))
+        proc.stderr!.on("data", (chunk: string) => this.handleStderr(chunk))
+        proc.on("error", (err) => {
+            // Async process error (e.g. EACCES/EPIPE surfaced after a
+            // successful spawn). An 'exit' event may NOT follow, so settle
+            // `done` here too — otherwise the story agent's `await pi.done`
+            // recovery path hangs until its outer timeout, or forever where
+            // there is none.
+            PiCliParticipant.active.delete(this)
+            this.spawnError = err
+            this.transition("failed", err.message)
+            this.failReady(err)
+            this.settleDone({
+                sessionId: this.sessionId,
+                exitCode: this.exitCode,
+                error: err,
+                sawAgentEnd: this.sawAgentEnd,
+                toolCallCount: this.toolCallCount,
+            })
+        })
+        proc.on("exit", (code) => {
+            PiCliParticipant.active.delete(this)
+            this.exitCode = code
+            const finalPhase: AgentPhase =
+                this.spawnError != null || (code != null && code !== 0)
+                    ? "failed"
+                    : "done"
+            this.transition(
+                finalPhase,
+                code != null ? `exit code ${code}` : "no exit code",
+            )
+            // If Pi exited without ever emitting session/agent_start, `ready`
+            // was never resolved. Settle it now so an awaiter can't hang:
+            // reject, because the agent provably never reached "running".
+            this.failReady(
+                new Error(
+                    `pi exited (code ${code}) before signalling ready`,
+                ),
+            )
+            this.settleDone({
+                sessionId: this.sessionId,
+                exitCode: code,
+                error: this.spawnError,
+                sawAgentEnd: this.sawAgentEnd,
+                toolCallCount: this.toolCallCount,
+            })
+        })
+    }
+
+    /**
+     * Kill the Pi process. `done` resolves once `exit`/`error` fires.
+     * Sends the soft signal first, then escalates to SIGKILL after a
+     * grace period if the child is still alive — otherwise a Pi process
+     * that ignores SIGTERM would leave any `await done` hanging forever.
+     */
+    abort(signal: NodeJS.Signals = "SIGTERM"): void {
+        this.transition("aborted")
+        const proc = this.proc
+        if (!proc) return
+        try {
+            proc.kill(signal)
+        } catch {
+            // best-effort
+        }
+        // SIGKILL is unconditional; if we're already escalating, don't
+        // stack timers.
+        if (signal === "SIGKILL" || this.killTimer !== null) return
+        this.killTimer = setTimeout(() => {
+            this.killTimer = null
+            if (this.doneSettled) return
+            try {
+                proc.kill("SIGKILL")
+            } catch {
+                // best-effort
+            }
+        }, PiCliParticipant.KILL_GRACE_MS)
+        // Don't let the escalation timer hold the process open if the
+        // story already settled through another path.
+        this.killTimer.unref?.()
+    }
+
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        // No-op. Pi `-p` is one-shot: it doesn't have a stdin user-message
+        // channel like Claude Code. AgentTargetedMessage delivery to a
+        // running Pi would require a new invocation.
+        if (
+            AgentTargetedMessage.is(event) &&
+            event.data.recipientId === this.agentId
+        ) {
+            process.stderr.write(
+                `[pi:${this.agentId}] received AgentTargetedMessage but Pi run is one-shot — dropped\n`,
+            )
+        }
+    }
+
+    private buildArgs(): string[] {
+        // `pi --mode json -p --no-session [--provider P] [--model M] PROMPT`
+        const args = ["--mode", "json", "-p", "--no-session"]
+        if (this.options.provider) args.push("--provider", this.options.provider)
+        if (this.options.model) args.push("--model", this.options.model)
+        // Prompt is the final positional. spawn() passes argv directly
+        // so no shell quoting needed.
+        args.push(this.options.prompt)
+        return args
+    }
+
+    private handleStdout(chunk: string): void {
+        this.buffer += chunk
+        let nl: number
+        while ((nl = this.buffer.indexOf("\n")) >= 0) {
+            const line = this.buffer.slice(0, nl).trim()
+            this.buffer = this.buffer.slice(nl + 1)
+            if (!line) continue
+            this.processLine(line)
+        }
+        // Guard against unbounded growth from a pathological newline-less
+        // stream (a wedged Pi, or a single enormous tool-result line). A
+        // bare JSONL event is never this large; drop the partial so memory
+        // can't balloon while still parsing well-formed lines that follow.
+        if (this.buffer.length > PiCliParticipant.MAX_BUFFER_BYTES) {
+            process.stderr.write(
+                `[pi:${this.agentId}] stdout buffer exceeded ${PiCliParticipant.MAX_BUFFER_BYTES} bytes without a newline — discarding partial line\n`,
+            )
+            this.buffer = ""
+        }
+    }
+
+    private handleStderr(chunk: string): void {
+        const trimmed = chunk.trimEnd()
+        if (!trimmed) return
+        process.stderr.write(`[pi:${this.agentId}/stderr] ${trimmed}\n`)
+    }
+
+    private processLine(line: string): void {
+        let parsed: Record<string, unknown>
+        try {
+            parsed = JSON.parse(line) as Record<string, unknown>
+        } catch {
+            process.stderr.write(
+                `[pi:${this.agentId}] non-JSON stdout: ${line.slice(0, 200)}\n`,
+            )
+            return
+        }
+
+        const { items, sessionId } = mapPiEvent(this.agentId, parsed)
+        if (sessionId && !this.sessionId) {
+            this.sessionId = sessionId
+        }
+
+        // Track completion evidence for the success predicate. exitCode 0
+        // is necessary but not sufficient — Pi exits 0 even on a refused
+        // or no-op turn — so the story agent additionally requires an
+        // agent_end (the agent loop actually completed) and at least one
+        // tool_execution_start (it did work rather than answering in prose).
+        if (parsed.type === "agent_end") this.sawAgentEnd = true
+        if (parsed.type === "tool_execution_start") this.toolCallCount += 1
+
+        for (const item of items) {
+            if (item instanceof SemanticEvent) {
+                // Lifecycle signals: agent_start / session → ready + running.
+                if (
+                    PiSystem.is(item) &&
+                    (item.data.subtype === "session" ||
+                        item.data.subtype === "agent_start")
+                ) {
+                    this.transition("running", "pi agent started")
+                    this.settleReady()
+                }
+                // Don't transition to "done" on agent_end — the
+                // process-exit listener owns that, so we observe the real
+                // exit code before locking in the AgentPhase.
+            }
+            this.dispatch(item)
+        }
+    }
+
+    /**
+     * Route a mapped event to the right Mozaik delivery channel.
+     * Assistant-side LLM items use Mozaik's typed channels; everything
+     * else goes through deliverSemanticEvent.
+     */
+    private dispatch(
+        item:
+            | ModelMessageItem
+            | FunctionCallItem
+            | FunctionCallOutputItem
+            | SemanticEvent<unknown>,
+    ): void {
+        if (!this.envRef) return
+        if (item instanceof ModelMessageItem) {
+            this.envRef.deliverModelMessage(this, item)
+            return
+        }
+        if (item instanceof FunctionCallItem) {
+            this.envRef.deliverFunctionCall(this, item)
+            return
+        }
+        if (item instanceof FunctionCallOutputItem) {
+            this.envRef.deliverFunctionCallOutput(this, item)
+            return
+        }
+        this.envRef.deliverSemanticEvent(this, item)
+    }
+
+    private transition(next: AgentPhase, detail?: string): void {
+        if (next === this.currentPhase) return
+        this.currentPhase = next
+        this.envRef?.deliverSemanticEvent(
+            this,
+            AgentState.create({
+                agentId: this.agentId,
+                phase: next,
+                detail,
+            }),
+        )
+    }
+}

--- a/packages/baro-orchestrator/src/participants/pi-cli-participant.ts
+++ b/packages/baro-orchestrator/src/participants/pi-cli-participant.ts
@@ -75,6 +75,15 @@ export interface PiRunSummary {
      * agent likely answered in prose instead of editing the worktree.
      */
     toolCallCount: number
+    /**
+     * Number of `tool_execution_end` events whose `isError` was NOT true —
+     * i.e. tools that actually succeeded. A story whose every tool call
+     * failed (all writes 500'd, etc.) still emits agent_end with
+     * toolCallCount > 0, so gating success on attempts alone marks a
+     * do-nothing run as passed. Callers should require at least one
+     * SUCCESSFUL tool, not merely one attempted.
+     */
+    toolSuccessCount: number
 }
 
 /**
@@ -116,6 +125,7 @@ export class PiCliParticipant extends BaseObserver {
     private spawnError: Error | null = null
     private sawAgentEnd = false
     private toolCallCount = 0
+    private toolSuccessCount = 0
     private doneSettled = false
     private readySettled = false
     private killTimer: ReturnType<typeof setTimeout> | null = null
@@ -239,6 +249,7 @@ export class PiCliParticipant extends BaseObserver {
                 error: this.spawnError,
                 sawAgentEnd: this.sawAgentEnd,
                 toolCallCount: this.toolCallCount,
+                toolSuccessCount: this.toolSuccessCount,
             })
             return
         }
@@ -267,6 +278,7 @@ export class PiCliParticipant extends BaseObserver {
                 error: err,
                 sawAgentEnd: this.sawAgentEnd,
                 toolCallCount: this.toolCallCount,
+                toolSuccessCount: this.toolSuccessCount,
             })
         })
         proc.on("exit", (code) => {
@@ -294,6 +306,7 @@ export class PiCliParticipant extends BaseObserver {
                 error: this.spawnError,
                 sawAgentEnd: this.sawAgentEnd,
                 toolCallCount: this.toolCallCount,
+                toolSuccessCount: this.toolSuccessCount,
             })
         })
     }
@@ -408,6 +421,12 @@ export class PiCliParticipant extends BaseObserver {
         // tool_execution_start (it did work rather than answering in prose).
         if (parsed.type === "agent_end") this.sawAgentEnd = true
         if (parsed.type === "tool_execution_start") this.toolCallCount += 1
+        // Count tools that actually succeeded (isError !== true) separately
+        // from attempts — the story success predicate gates on successes so a
+        // run where every tool failed is not reported as done.
+        if (parsed.type === "tool_execution_end" && parsed.isError !== true) {
+            this.toolSuccessCount += 1
+        }
 
         for (const item of items) {
             if (item instanceof SemanticEvent) {

--- a/packages/baro-orchestrator/src/participants/pi-story-agent.ts
+++ b/packages/baro-orchestrator/src/participants/pi-story-agent.ts
@@ -310,11 +310,14 @@ export class PiStoryAgent extends BaseObserver {
                 error: "pi exited 0 but emitted no agent_end — the agent loop did not complete",
             }
         }
-        if (summary.toolCallCount === 0) {
+        if (summary.toolSuccessCount === 0) {
             return {
                 success: false,
                 summary,
-                error: "pi exited 0 but invoked no tools — answered in prose without editing the worktree",
+                error:
+                    summary.toolCallCount === 0
+                        ? "pi exited 0 but invoked no tools — answered in prose without editing the worktree"
+                        : "pi exited 0 and invoked tools but every tool call failed (isError) — the worktree was not successfully edited",
             }
         }
 

--- a/packages/baro-orchestrator/src/participants/pi-story-agent.ts
+++ b/packages/baro-orchestrator/src/participants/pi-story-agent.ts
@@ -376,5 +376,11 @@ function raceWithTimeout<T>(
     // the fulfil branch only would leave the timer pending (and keeping the
     // event loop alive up to `ms`) on any rejection of `p`.
     const settled = p.finally(() => clearTimeout(timer))
+    // If the timeout wins the race, `settled` stays pending and would surface
+    // an UnhandledPromiseRejection should `p` later reject (Node ≥ 15). The
+    // race already propagates the real outcome to the caller, so swallow the
+    // now-unobserved rejection on the losing branch. Harmless for the current
+    // sole caller (`pi.done` never rejects); makes the helper safe to reuse.
+    settled.catch(() => { /* observed via the race; ignore late rejection */ })
     return Promise.race([settled, timeout])
 }

--- a/packages/baro-orchestrator/src/participants/pi-story-agent.ts
+++ b/packages/baro-orchestrator/src/participants/pi-story-agent.ts
@@ -1,0 +1,377 @@
+/**
+ * PiStoryAgent — story-level wrapper that drives a PiCliParticipant
+ * through a single piece of work, with retries and per-attempt timeout.
+ * Sibling of `opencode-story-agent.ts` (OpenCode) and `story-agent.ts`
+ * (Claude).
+ *
+ * Lifecycle mirrors OpenCodeStoryAgent because Pi `-p` is also one-shot:
+ * each attempt spawns a fresh process, which streams events and exits
+ * when the agent finishes. There is no multi-turn quiet-timer /
+ * stdin-injection dance.
+ *
+ *   idle ─► starting ─► running ─► done | failed
+ *                              ╰► retrying ─► running ─► …
+ *
+ * Outer retry budget and hard timeout match StoryAgent's defaults so
+ * the orchestrator-level semantics are uniform across backends.
+ */
+
+import { setTimeout as setTimeoutPromise } from "timers/promises"
+
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import { AgenticEnvironment } from "@mozaik-ai/core"
+import {
+    AgentState,
+    StoryResult,
+    type AgentPhase,
+} from "../semantic-events.js"
+import {
+    PiCliParticipant,
+    type PiRunSummary,
+} from "./pi-cli-participant.js"
+
+/** Specification for a Pi-backed story execution. */
+export interface PiStorySpec {
+    /** Story ID, used as agentId for observer attribution. */
+    id: string
+    /** The prompt sent to Pi as the initial user message. */
+    prompt: string
+    /** Working directory for Pi. */
+    cwd: string
+    /**
+     * Provider override (e.g. "google", "anthropic"). Pi's default is
+     * "google". Omit to use Pi's configured default.
+     */
+    provider?: string
+    /** Optional model override. Treated as an opaque string. */
+    model?: string
+    /** Retry budget (number of *additional* attempts after the first). */
+    retries?: number
+    /** Per-attempt timeout in seconds. Default: 600. */
+    timeoutSecs?: number
+    /** Delay between retries in milliseconds. Default: 1500. */
+    retryDelayMs?: number
+    /**
+     * Hard cap in seconds for the entire story across all attempts. The
+     * Pi process is aborted unconditionally when this fires. <= 0
+     * disables the absolute kill timer. Default: 0 (matches StoryAgent).
+     */
+    hardTimeoutSecs?: number
+}
+
+/** Outcome of a completed (passed or exhausted) story execution. */
+export interface PiStoryOutcome {
+    storyId: string
+    success: boolean
+    attempts: number
+    durationSecs: number
+    finalSummary: PiRunSummary | null
+    error: string | null
+}
+
+/**
+ * Mozaik observer that runs a story on the Pi backend with retry logic
+ * and timeout management.
+ */
+export class PiStoryAgent extends BaseObserver {
+    private readonly spec: Required<
+        Pick<
+            PiStorySpec,
+            | "retries"
+            | "timeoutSecs"
+            | "retryDelayMs"
+            | "hardTimeoutSecs"
+        >
+    > &
+        PiStorySpec
+
+    private envRef: AgenticEnvironment | null = null
+    private currentPi: PiCliParticipant | null = null
+    private currentPhase: AgentPhase = "idle"
+    private startedAt: number | null = null
+    private resolveDone!: (outcome: PiStoryOutcome) => void
+    public readonly done: Promise<PiStoryOutcome>
+
+    constructor(spec: PiStorySpec) {
+        super()
+        this.spec = {
+            retries: 2,
+            timeoutSecs: 600,
+            retryDelayMs: 1500,
+            hardTimeoutSecs: 0,
+            ...spec,
+        }
+        this.done = new Promise<PiStoryOutcome>((res) => {
+            this.resolveDone = res
+        })
+    }
+
+    get id(): string {
+        return this.spec.id
+    }
+
+    get agentId(): string {
+        return this.spec.id
+    }
+
+    getPhase(): AgentPhase {
+        return this.currentPhase
+    }
+
+    getCurrentPi(): PiCliParticipant | null {
+        return this.currentPi
+    }
+
+    /**
+     * Begin executing the story. Idempotent. Returns the `done` promise
+     * for the caller's convenience.
+     */
+    run(environment: AgenticEnvironment): Promise<PiStoryOutcome> {
+        if (this.startedAt != null) {
+            return this.done
+        }
+        this.envRef = environment
+        this.startedAt = Date.now()
+        this.transition("starting", "story queued")
+        void this.executeAllAttempts()
+        return this.done
+    }
+
+    /**
+     * No-op: Pi `-p` is one-shot, there's no stdin channel to forward
+     * mid-flight messages to.
+     */
+    override async onExternalEvent(
+        _source: Participant,
+        _event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        // Intentionally empty — Pi run doesn't have the multi-turn stdin
+        // lifecycle that StoryAgent uses for Claude.
+    }
+
+    /**
+     * Abort the story, killing the running Pi process (if any).
+     *
+     * Note: this does NOT itself settle the `done` promise. It only
+     * signals the in-flight Pi child to die; `done` settles later via the
+     * attempt's normal exit/timeout path in `executeAllAttempts`
+     * (`runOneAttempt` awaits `pi.done` and `resolveDone` runs once the
+     * loop resolves or exhausts). The phase transition to "aborted" here
+     * is cosmetic and does not short-circuit that flow.
+     */
+    abort(): void {
+        this.currentPi?.abort()
+        this.transition("aborted", "external abort")
+    }
+
+    private async executeAllAttempts(): Promise<void> {
+        const maxAttempts = this.spec.retries + 1
+        let lastSummary: PiRunSummary | null = null
+        let lastError: string | null = null
+        let hardTimedOut = false
+
+        const hardTimer =
+            this.spec.hardTimeoutSecs > 0
+                ? setTimeout(() => {
+                      hardTimedOut = true
+                      this.currentPi?.abort()
+                  }, this.spec.hardTimeoutSecs * 1000)
+                : null
+
+        try {
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+                if (hardTimedOut) {
+                    lastError = `hard timeout after ${this.spec.hardTimeoutSecs}s`
+                    break
+                }
+
+                if (attempt > 1) {
+                    this.transition(
+                        "waiting",
+                        `retrying (attempt ${attempt}/${maxAttempts})`,
+                    )
+                    await setTimeoutPromise(this.spec.retryDelayMs)
+                    if (hardTimedOut) {
+                        lastError = `hard timeout after ${this.spec.hardTimeoutSecs}s`
+                        break
+                    }
+                }
+
+                const result = await this.runOneAttempt(attempt)
+                lastSummary = result.summary
+                lastError = result.error
+
+                if (result.success) {
+                    const durationSecs = Math.round(
+                        (Date.now() - (this.startedAt ?? Date.now())) / 1000,
+                    )
+                    this.transition("done", `success on attempt ${attempt}`)
+                    this.emitStoryResult(true, attempt, durationSecs, null)
+                    this.resolveDone({
+                        storyId: this.spec.id,
+                        success: true,
+                        attempts: attempt,
+                        durationSecs,
+                        finalSummary: result.summary,
+                        error: null,
+                    })
+                    return
+                }
+
+                if (hardTimedOut) {
+                    lastError = `hard timeout after ${this.spec.hardTimeoutSecs}s`
+                    break
+                }
+            }
+        } finally {
+            if (hardTimer !== null) clearTimeout(hardTimer)
+        }
+
+        const durationSecs = Math.round(
+            (Date.now() - (this.startedAt ?? Date.now())) / 1000,
+        )
+        this.transition("failed", `exhausted ${maxAttempts} attempts`)
+        this.emitStoryResult(false, maxAttempts, durationSecs, lastError)
+        this.resolveDone({
+            storyId: this.spec.id,
+            success: false,
+            attempts: maxAttempts,
+            durationSecs,
+            finalSummary: lastSummary,
+            error: lastError,
+        })
+    }
+
+    private async runOneAttempt(
+        attempt: number,
+    ): Promise<{
+        success: boolean
+        summary: PiRunSummary | null
+        error: string | null
+    }> {
+        if (!this.envRef) {
+            return { success: false, summary: null, error: "no environment" }
+        }
+
+        this.transition("running", `attempt ${attempt}`)
+
+        const pi = new PiCliParticipant(this.spec.id, {
+            cwd: this.spec.cwd,
+            prompt: this.spec.prompt,
+            provider: this.spec.provider,
+            model: this.spec.model,
+        })
+        this.currentPi = pi
+        pi.join(this.envRef)
+        pi.start(this.envRef)
+
+        let summary: PiRunSummary
+        try {
+            summary = await raceWithTimeout(
+                pi.done,
+                this.spec.timeoutSecs * 1000,
+                `attempt ${attempt} timeout after ${this.spec.timeoutSecs}s`,
+            )
+        } catch (e) {
+            pi.abort()
+            const error = e instanceof Error ? e.message : String(e)
+            try {
+                await pi.done
+            } catch {
+                // ignore
+            }
+            pi.leave(this.envRef)
+            this.currentPi = null
+            return { success: false, summary: null, error }
+        }
+
+        pi.leave(this.envRef)
+        this.currentPi = null
+
+        // Success requires POSITIVE evidence of completed work, not
+        // merely the absence of a crash. Pi exits 0 even when the model
+        // refuses the task or produces no edits, so a clean exit alone
+        // would mark a no-op story as passed. We therefore also require
+        // the agent loop to have actually finished (`sawAgentEnd`) and to
+        // have invoked at least one tool — a code-writing story that
+        // claims success having touched no tools almost certainly answered
+        // in prose instead of editing the worktree.
+        if (summary.exitCode !== 0 || summary.error != null) {
+            const reason = summary.error
+                ? summary.error.message
+                : `non-zero exit ${summary.exitCode}`
+            return { success: false, summary, error: reason }
+        }
+        if (!summary.sawAgentEnd) {
+            return {
+                success: false,
+                summary,
+                error: "pi exited 0 but emitted no agent_end — the agent loop did not complete",
+            }
+        }
+        if (summary.toolCallCount === 0) {
+            return {
+                success: false,
+                summary,
+                error: "pi exited 0 but invoked no tools — answered in prose without editing the worktree",
+            }
+        }
+
+        return { success: true, summary, error: null }
+    }
+
+    private emitStoryResult(
+        success: boolean,
+        attempts: number,
+        durationSecs: number,
+        error: string | null,
+    ): void {
+        if (!this.envRef) return
+        this.envRef.deliverSemanticEvent(
+            this,
+            StoryResult.create({
+                storyId: this.spec.id,
+                success,
+                attempts,
+                durationSecs,
+                error,
+            }),
+        )
+    }
+
+    private transition(next: AgentPhase, detail?: string): void {
+        if (next === this.currentPhase) return
+        this.currentPhase = next
+        if (this.envRef) {
+            this.envRef.deliverSemanticEvent(
+                this,
+                AgentState.create({
+                    agentId: this.spec.id,
+                    phase: next,
+                    detail,
+                }),
+            )
+        }
+    }
+}
+
+/**
+ * Race a promise against a timeout. Rejects with an Error carrying the
+ * label on timeout.
+ */
+function raceWithTimeout<T>(
+    p: Promise<T>,
+    ms: number,
+    label: string,
+): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>
+    const timeout = new Promise<T>(
+        (_, rej) => { timer = setTimeout(() => rej(new Error(label)), ms) },
+    )
+    // Clear the timeout timer whether `p` fulfils OR rejects — clearing on
+    // the fulfil branch only would leave the timer pending (and keeping the
+    // event loop alive up to `ms`) on any rejection of `p`.
+    const settled = p.finally(() => clearTimeout(timer))
+    return Promise.race([settled, timeout])
+}

--- a/packages/baro-orchestrator/src/participants/story-factory.ts
+++ b/packages/baro-orchestrator/src/participants/story-factory.ts
@@ -26,6 +26,7 @@ import {
 import { CodexStoryAgent } from "./codex-story-agent.js"
 import { OpenAIStoryAgent } from "./openai-story-agent.js"
 import { OpenCodeStoryAgent } from "./opencode-story-agent.js"
+import { PiStoryAgent } from "./pi-story-agent.js"
 import { StoryAgent } from "./story-agent.js"
 import {
     formatRoute,
@@ -45,10 +46,11 @@ export interface StoryFactoryOptions {
      *               subprocess (ChatGPT subscription billing path)
      *   "opencode" — OpenCodeStoryAgent wrapping an `opencode run --format json`
      *               subprocess
-     * Same bus contract for all four — Conductor, Critic, Surgeon,
+     *   "pi"      — PiStoryAgent wrapping a `pi --mode json -p` subprocess
+     * Same bus contract for all — Conductor, Critic, Surgeon,
      * Sentry, Librarian, Cartographer don't notice the swap.
      */
-    llm?: "claude" | "openai" | "codex" | "opencode"
+    llm?: "claude" | "openai" | "codex" | "opencode" | "pi"
     /**
      * Optional model name to pass to OpenAI agents. Default
      * `gpt-5.5` — StoryAgent's coding loop benefits from the largest
@@ -95,7 +97,7 @@ export class StoryFactory extends BaseObserver {
     private envRef: AgenticEnvironment | null = null
     private readonly active: Map<
         string,
-        StoryAgent | OpenAIStoryAgent | CodexStoryAgent | OpenCodeStoryAgent
+        StoryAgent | OpenAIStoryAgent | CodexStoryAgent | OpenCodeStoryAgent | PiStoryAgent
     > = new Map()
 
     constructor(private readonly opts: StoryFactoryOptions) {
@@ -151,8 +153,17 @@ export class StoryFactory extends BaseObserver {
                 "\n",
         )
 
-        const agent: StoryAgent | OpenAIStoryAgent | CodexStoryAgent | OpenCodeStoryAgent =
-            route.backend === "opencode"
+        const agent: StoryAgent | OpenAIStoryAgent | CodexStoryAgent | OpenCodeStoryAgent | PiStoryAgent =
+            route.backend === "pi"
+                ? new PiStoryAgent({
+                      id: req.storyId,
+                      prompt: req.prompt,
+                      cwd: this.opts.cwd,
+                      model: route.model,
+                      retries: req.retries,
+                      timeoutSecs: req.timeoutSecs,
+                  })
+                : route.backend === "opencode"
                 ? new OpenCodeStoryAgent({
                       id: req.storyId,
                       prompt: req.prompt,

--- a/packages/baro-orchestrator/src/participants/surgeon-pi.ts
+++ b/packages/baro-orchestrator/src/participants/surgeon-pi.ts
@@ -1,0 +1,165 @@
+/**
+ * SurgeonPi — adaptive DAG mutation via the `pi` CLI.
+ * Sibling of `surgeon.ts` (Claude), `surgeon-openai.ts` (OpenAI API),
+ * `surgeon-codex.ts` (Codex CLI), and `surgeon-opencode.ts` (OpenCode CLI).
+ *
+ * Same bus contract as the other variants: observes terminal story
+ * failures, asks the LLM for a structured replan (split / prereq /
+ * rewire / skip / abort), emits a ReplanItem the Conductor applies at
+ * the next level boundary. Falls back to deterministic skip if the LLM
+ * call fails or returns malformed JSON.
+ *
+ * Library-grade: reuses prompts + JSON-extractor + deterministic
+ * fallback from `surgeon.ts` directly so the four backends share one
+ * source of truth for the contract.
+ */
+
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import { runPiOneShot } from "../pi-one-shot.js"
+import {
+    Replan,
+    type ReplanData,
+    type ReplanStoryAdd,
+    StoryResult,
+    type StoryResultData,
+} from "../semantic-events.js"
+import {
+    PrdSnapshot,
+    SURGEON_SYSTEM_PROMPT,
+    buildSurgeonPrompt,
+    extractJsonObject,
+    surgeonDeterministicReplan,
+} from "./surgeon.js"
+
+export interface SurgeonPiOptions {
+    /** Returns a fresh snapshot of the current PRD. */
+    snapshot: () => PrdSnapshot
+    /** Use Pi CLI to evaluate replans. Default: true. */
+    useLlm?: boolean
+    /**
+     * Provider to use (e.g. "anthropic", "openai"). Omit to use Pi's
+     * configured default.
+     */
+    provider?: string
+    /**
+     * Model identifier. Omit to use Pi's configured default.
+     */
+    model?: string
+    /** Max replans this Surgeon will emit per run. Default: 10. */
+    maxReplans?: number
+    /** Path to the `pi` binary. Default: "pi". */
+    piBin?: string
+    /** Per-evaluation timeout in milliseconds. Default: 300_000 (5 min). */
+    timeoutMs?: number
+}
+
+export class SurgeonPi extends BaseObserver {
+    private readonly opts: Required<
+        Omit<SurgeonPiOptions, "snapshot" | "provider" | "model" | "piBin">
+    > & {
+        snapshot: () => PrdSnapshot
+        provider: string | undefined
+        model: string | undefined
+        piBin: string
+    }
+
+    private replansEmitted = 0
+    private readonly pending = new Set<Promise<void>>()
+
+    constructor(opts: SurgeonPiOptions) {
+        super()
+        this.opts = {
+            useLlm: opts.useLlm ?? true,
+            provider: opts.provider,
+            model: opts.model,
+            maxReplans: opts.maxReplans ?? 10,
+            piBin: opts.piBin ?? "pi",
+            timeoutMs: opts.timeoutMs ?? 300_000,
+            snapshot: opts.snapshot,
+        }
+    }
+
+    async idle(): Promise<void> {
+        await Promise.allSettled([...this.pending])
+    }
+
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (!StoryResult.is(event)) return
+        if (event.data.success) return
+        if (this.replansEmitted >= this.opts.maxReplans) return
+
+        const work = (async () => {
+            const replan = this.opts.useLlm
+                ? await this.evaluateWithLlm(event.data)
+                : surgeonDeterministicReplan(event.data)
+            if (!replan) return
+            this.replansEmitted += 1
+            for (const env of this.getEnvironments()) {
+                env.deliverSemanticEvent(this, Replan.create(replan))
+            }
+        })()
+
+        this.pending.add(work)
+        work.finally(() => this.pending.delete(work))
+        await work
+    }
+
+    private async evaluateWithLlm(
+        failure: StoryResultData,
+    ): Promise<ReplanData | null> {
+        const snap = this.opts.snapshot()
+        const userPrompt = buildSurgeonPrompt(snap, failure)
+        const prompt = `${SURGEON_SYSTEM_PROMPT}\n\n${userPrompt}`
+
+        try {
+            const text = await runPiOneShot({
+                prompt,
+                cwd: process.cwd(),
+                provider: this.opts.provider,
+                model: this.opts.model,
+                piBin: this.opts.piBin,
+                timeoutMs: this.opts.timeoutMs,
+                label: "pi-surgeon",
+            })
+            const verdictText = text.trim()
+            if (!verdictText) throw new Error("empty result")
+
+            const verdictJson = extractJsonObject(verdictText)
+            const parsed = JSON.parse(verdictJson) as {
+                action: string
+                reason?: string
+                added?: ReplanStoryAdd[]
+                removed?: string[]
+                modifiedDeps?: { id: string; newDependsOn: string[] }[]
+            }
+
+            if (parsed.action === "abort") return null
+
+            const modifiedDeps: Record<string, readonly string[]> = {}
+            for (const m of parsed.modifiedDeps ?? []) {
+                if (typeof m.id === "string" && Array.isArray(m.newDependsOn)) {
+                    modifiedDeps[m.id] = [...m.newDependsOn]
+                }
+            }
+            return {
+                source: "surgeon",
+                reason: `${parsed.action}: ${parsed.reason ?? ""}`,
+                addedStories: parsed.added ?? [],
+                removedStoryIds: parsed.removed ?? [],
+                modifiedDeps,
+            }
+        } catch (err) {
+            // Fall back to deterministic so the run still has a chance
+            // to recover.
+            const fallback = surgeonDeterministicReplan(failure)
+            return {
+                ...fallback,
+                reason: `${fallback.reason} (pi fallback after error: ${(err as Error)?.message ?? String(err)})`,
+            }
+        }
+    }
+}

--- a/packages/baro-orchestrator/src/participants/surgeon-pi.ts
+++ b/packages/baro-orchestrator/src/participants/surgeon-pi.ts
@@ -145,11 +145,30 @@ export class SurgeonPi extends BaseObserver {
                     modifiedDeps[m.id] = [...m.newDependsOn]
                 }
             }
+            // Validate LLM-supplied added/removed before they reach the
+            // Conductor's DAG mutation. The `as ReplanStoryAdd[]` cast does
+            // not enforce shape at runtime — a malformed entry (missing
+            // dependsOn, non-string removal id) would otherwise be injected
+            // into the DAG and crash a later `dependsOn` access or silently
+            // mis-target a removal. Same element-by-element discipline as
+            // modifiedDeps above.
+            const addedStories = (parsed.added ?? []).filter(
+                (s): s is ReplanStoryAdd =>
+                    s != null &&
+                    typeof s.id === "string" &&
+                    typeof s.title === "string" &&
+                    typeof s.description === "string" &&
+                    typeof s.priority === "number" &&
+                    Array.isArray(s.dependsOn),
+            )
+            const removedStoryIds = (parsed.removed ?? []).filter(
+                (r): r is string => typeof r === "string",
+            )
             return {
                 source: "surgeon",
                 reason: `${parsed.action}: ${parsed.reason ?? ""}`,
-                addedStories: parsed.added ?? [],
-                removedStoryIds: parsed.removed ?? [],
+                addedStories,
+                removedStoryIds,
                 modifiedDeps,
             }
         } catch (err) {

--- a/packages/baro-orchestrator/src/pi-one-shot.ts
+++ b/packages/baro-orchestrator/src/pi-one-shot.ts
@@ -1,0 +1,262 @@
+/**
+ * Shared helper: run a one-shot `pi --mode json -p --no-session` invocation
+ * against a single combined prompt, collect the JSONL stream, and return
+ * the concatenated assistant `text` output. Used by planning phases so
+ * the spawn + parse logic lives in one place.
+ *
+ * Implementation note: uses `spawn()` + streaming rather than
+ * `execFile()` + buffer because execFile discards stdout on timeout.
+ * Streaming lets us:
+ *   - forward Pi's structured events to stderr live so the audit
+ *     log captures them even on timeout
+ *   - track which event subtypes were observed for the error message
+ *   - kill Pi with SIGTERM on timeout instead of execFile's
+ *     harsher escalation
+ */
+
+import { ChildProcess, spawn } from "child_process"
+
+/** Options for `runPiOneShot`. */
+export interface RunPiOneShotOptions {
+    /** Combined system+user prompt. Passed as the final positional argv. */
+    prompt: string
+    /** Working directory for the Pi process. */
+    cwd: string
+    /**
+     * Provider override (e.g. "google", "anthropic"). Pi's default is
+     * "google". Omit to use Pi's configured default.
+     */
+    provider?: string
+    /**
+     * Model identifier. Treated as an opaque string and forwarded via
+     * `--model`. Omit to use Pi's configured default.
+     */
+    model?: string
+    /** Path to the `pi` binary. Default: "pi". */
+    piBin?: string
+    /** Per-call timeout in milliseconds. Default: 600_000 (10 minutes). */
+    timeoutMs?: number
+    /**
+     * Per-phase label written into the live stderr stream so users can
+     * tell traffic apart in one log tail. Defaults to "pi".
+     */
+    label?: string
+}
+
+/**
+ * Spawn `pi --mode json -p --no-session`, collect all assistant `text`
+ * content from `message_end` events, and return the concatenated string.
+ *
+ * @throws Error if the process exits without producing any text output.
+ */
+export async function runPiOneShot(
+    opts: RunPiOneShotOptions,
+): Promise<string> {
+    const label = opts.label ?? "pi"
+    // Build args: flags first, then optional provider/model, then prompt.
+    const args = ["--mode", "json", "-p", "--no-session"]
+    if (opts.provider) args.push("--provider", opts.provider)
+    if (opts.model) args.push("--model", opts.model)
+    args.push(opts.prompt)
+
+    const timeoutMs = opts.timeoutMs ?? 600_000
+
+    return await new Promise<string>((resolve, reject) => {
+        let proc: ChildProcess
+        try {
+            proc = spawn(opts.piBin ?? "pi", args, {
+                cwd: opts.cwd,
+                // stdin: ignore (one-shot, no interactive input)
+                stdio: ["ignore", "pipe", "pipe"],
+            })
+        } catch (e) {
+            reject(e instanceof Error ? e : new Error(String(e)))
+            return
+        }
+
+        let assistantText = ""
+        let stdoutBuffer = ""
+        const eventTypesSeen: string[] = []
+        let timedOut = false
+        let killTimer: ReturnType<typeof setTimeout> | null = null
+
+        const clearTimers = (): void => {
+            clearTimeout(timer)
+            if (killTimer !== null) {
+                clearTimeout(killTimer)
+                killTimer = null
+            }
+        }
+
+        const startedAt = Date.now()
+        const timer = setTimeout(() => {
+            timedOut = true
+            try {
+                proc.kill("SIGTERM")
+            } catch {
+                /* noop */
+            }
+            // Escalate to SIGKILL if Pi ignores SIGTERM; otherwise neither
+            // `exit` nor `error` ever fires and this Promise hangs forever.
+            killTimer = setTimeout(() => {
+                killTimer = null
+                try {
+                    proc.kill("SIGKILL")
+                } catch {
+                    /* noop */
+                }
+            }, 5_000)
+            killTimer.unref?.()
+        }, timeoutMs)
+
+        const maxBufferBytes = 16 * 1024 * 1024
+
+        proc.stdout!.setEncoding("utf8")
+        proc.stdout!.on("data", (chunk: string) => {
+            stdoutBuffer += chunk
+            let nl: number
+            while ((nl = stdoutBuffer.indexOf("\n")) >= 0) {
+                const line = stdoutBuffer.slice(0, nl).trim()
+                stdoutBuffer = stdoutBuffer.slice(nl + 1)
+                if (!line) continue
+                let event: Record<string, unknown>
+                try {
+                    event = JSON.parse(line) as Record<string, unknown>
+                } catch {
+                    continue
+                }
+                const type = typeof event.type === "string" ? event.type : ""
+                if (type) eventTypesSeen.push(type)
+
+                // Pi emits final assembled text in message_end content blocks.
+                // Do NOT collect from deltas — message_end has the complete text.
+                if (type === "message_end") {
+                    const message = event.message as Record<string, unknown> | undefined
+                    if (message?.role === "assistant") {
+                        // Pi's usage keys are `input`/`output` (NOT
+                        // `input_tokens`/`output_tokens`) — verified against
+                        // live message_end output.
+                        const usage = message.usage as { input?: number; output?: number } | undefined
+                        if (usage) {
+                            process.stderr.write(
+                                `[${label}] usage: in=${usage.input ?? 0} out=${usage.output ?? 0}\n`,
+                            )
+                        }
+                        const content = message.content as Array<Record<string, unknown>> | undefined
+                        if (Array.isArray(content)) {
+                            for (const block of content) {
+                                if (block.type === "text" && typeof block.text === "string") {
+                                    assistantText = assistantText
+                                        ? `${assistantText}\n${block.text}`
+                                        : block.text
+                                }
+                            }
+                        }
+                    }
+                    continue
+                }
+
+                // Log tool executions so the audit trail shows agent activity.
+                // Real Pi field is `toolName` on tool_execution_start; keep
+                // `tool`/`name` only as defensive fallbacks.
+                if (type === "tool_execution_start") {
+                    const toolName =
+                        typeof event.toolName === "string"
+                            ? event.toolName.slice(0, 120)
+                            : typeof event.tool === "string"
+                              ? event.tool.slice(0, 120)
+                              : typeof event.name === "string"
+                                ? event.name.slice(0, 120)
+                                : "?"
+                    process.stderr.write(`[${label}] tool: ${toolName}\n`)
+                    continue
+                }
+                // Also catch the toolcall_start shape carried inside
+                // message_update.assistantMessageEvent. The tool name lives on
+                // the toolCall content block (`name`), not on the event itself.
+                if (type === "message_update") {
+                    const ame = event.assistantMessageEvent as Record<string, unknown> | undefined
+                    if (ame?.type === "toolcall_start") {
+                        const block = ame.toolCall as Record<string, unknown> | undefined
+                        const toolName =
+                            typeof block?.name === "string"
+                                ? block.name.slice(0, 120)
+                                : typeof ame.toolName === "string"
+                                  ? ame.toolName.slice(0, 120)
+                                  : typeof ame.name === "string"
+                                    ? ame.name.slice(0, 120)
+                                    : "?"
+                        process.stderr.write(`[${label}] tool: ${toolName}\n`)
+                    }
+                    continue
+                }
+            }
+            // Guard against unbounded growth from a newline-less stream
+            // (a wedged Pi or one enormous line). Drop the partial so
+            // memory can't balloon; well-formed lines that follow still parse.
+            if (stdoutBuffer.length > maxBufferBytes) {
+                process.stderr.write(
+                    `[${label}] stdout buffer exceeded ${maxBufferBytes} bytes without a newline — discarding partial line\n`,
+                )
+                stdoutBuffer = ""
+            }
+        })
+
+        proc.stderr!.setEncoding("utf8")
+        proc.stderr!.on("data", (chunk: string) => {
+            const trimmed = chunk.trimEnd()
+            if (trimmed) {
+                process.stderr.write(`[${label}/stderr] ${trimmed}\n`)
+            }
+        })
+
+        proc.on("error", (err) => {
+            clearTimers()
+            reject(err)
+        })
+
+        proc.on("exit", (code, signal) => {
+            clearTimers()
+            const elapsedMs = Date.now() - startedAt
+
+            const ctx = [
+                `elapsed=${elapsedMs}ms`,
+                `exit=${code}`,
+                signal ? `signal=${signal}` : null,
+                timedOut ? `timedOut=true (cap=${timeoutMs}ms)` : null,
+                `events=${eventTypesSeen.length}`,
+                eventTypesSeen.length > 0
+                    ? `event_types=[${[...new Set(eventTypesSeen)].join(",")}]`
+                    : null,
+            ]
+                .filter((x): x is string => x !== null)
+                .join(" ")
+
+            // Abnormal termination must fail even if SOME text accumulated.
+            // The callers feed the returned string into a markdown doc /
+            // JSON extractor — resolving partial text on a timeout (SIGTERM)
+            // or crash silently produces an incomplete doc with no error
+            // surfaced. Treat timeout, a terminating signal, or a non-zero
+            // exit as failure.
+            if (timedOut || signal != null || (code != null && code !== 0)) {
+                reject(
+                    new Error(
+                        `runPiOneShot: pi terminated abnormally before completing (${ctx})`,
+                    ),
+                )
+                return
+            }
+
+            if (assistantText.trim()) {
+                resolve(assistantText)
+                return
+            }
+
+            reject(
+                new Error(
+                    `runPiOneShot: pi produced no text output (${ctx})`,
+                ),
+            )
+        })
+    })
+}

--- a/packages/baro-orchestrator/src/pi-one-shot.ts
+++ b/packages/baro-orchestrator/src/pi-one-shot.ts
@@ -111,19 +111,17 @@ export async function runPiOneShot(
 
         const maxBufferBytes = 16 * 1024 * 1024
 
-        proc.stdout!.setEncoding("utf8")
-        proc.stdout!.on("data", (chunk: string) => {
-            stdoutBuffer += chunk
-            let nl: number
-            while ((nl = stdoutBuffer.indexOf("\n")) >= 0) {
-                const line = stdoutBuffer.slice(0, nl).trim()
-                stdoutBuffer = stdoutBuffer.slice(nl + 1)
-                if (!line) continue
+        // Process a single complete JSONL line. Pulled out of the data
+        // handler so the stream-`end` flush can reuse it for a final line
+        // that arrives without a trailing newline.
+        const processLine = (rawLine: string): void => {
+                const line = rawLine.trim()
+                if (!line) return
                 let event: Record<string, unknown>
                 try {
                     event = JSON.parse(line) as Record<string, unknown>
                 } catch {
-                    continue
+                    return
                 }
                 const type = typeof event.type === "string" ? event.type : ""
                 if (type) eventTypesSeen.push(type)
@@ -153,7 +151,7 @@ export async function runPiOneShot(
                             }
                         }
                     }
-                    continue
+                    return
                 }
 
                 // Log tool executions so the audit trail shows agent activity.
@@ -169,7 +167,7 @@ export async function runPiOneShot(
                                 ? event.name.slice(0, 120)
                                 : "?"
                     process.stderr.write(`[${label}] tool: ${toolName}\n`)
-                    continue
+                    return
                 }
                 // Also catch the toolcall_start shape carried inside
                 // message_update.assistantMessageEvent. The tool name lives on
@@ -188,8 +186,18 @@ export async function runPiOneShot(
                                     : "?"
                         process.stderr.write(`[${label}] tool: ${toolName}\n`)
                     }
-                    continue
+                    return
                 }
+        }
+
+        proc.stdout!.setEncoding("utf8")
+        proc.stdout!.on("data", (chunk: string) => {
+            stdoutBuffer += chunk
+            let nl: number
+            while ((nl = stdoutBuffer.indexOf("\n")) >= 0) {
+                const line = stdoutBuffer.slice(0, nl)
+                stdoutBuffer = stdoutBuffer.slice(nl + 1)
+                processLine(line)
             }
             // Guard against unbounded growth from a newline-less stream
             // (a wedged Pi or one enormous line). Drop the partial so
@@ -198,6 +206,16 @@ export async function runPiOneShot(
                 process.stderr.write(
                     `[${label}] stdout buffer exceeded ${maxBufferBytes} bytes without a newline — discarding partial line\n`,
                 )
+                stdoutBuffer = ""
+            }
+        })
+        // Flush a final line that arrives without a trailing newline — a Pi
+        // version or wrapper that omits the last `\n` would otherwise drop its
+        // `message_end`, leaving assistantText empty and failing a successful
+        // run. The 'end' event fires after the last 'data' and before 'exit'.
+        proc.stdout!.on("end", () => {
+            if (stdoutBuffer.length > 0) {
+                processLine(stdoutBuffer)
                 stdoutBuffer = ""
             }
         })

--- a/packages/baro-orchestrator/src/pi-stream-mapper.ts
+++ b/packages/baro-orchestrator/src/pi-stream-mapper.ts
@@ -46,8 +46,8 @@
  *                               from content blocks + PiTurnEvent "message_end".
  *   - "message_end" (user)    → PiTurnEvent "message_end" (turn lifecycle
  *                               record only; no content items extracted).
- *   - "tool_execution_start"  → PiItemEvent itemType "tool_result" (raw).
- *   - "tool_execution_update" → PiItemEvent itemType "tool_result" (raw).
+ *   - "tool_execution_start"  → PiItemEvent itemType "tool_start" (raw).
+ *   - "tool_execution_update" → PiItemEvent itemType "tool_update" (raw).
  *   - "tool_execution_end"    → FunctionCallOutputItem (callId from
  *                               `toolCallId`, output from result.content[].text)
  *                               + PiItemEvent itemType "tool_result".
@@ -335,11 +335,15 @@ export function mapPiEvent(
     }
 
     // ─── tool_execution_start ─────────────────────────────────────
+    // Distinct itemType per lifecycle phase ("tool_start"/"tool_update"/
+    // "tool_result") so audit-log readers and itemType-filtering observers
+    // can tell a tool starting from one mid-stream from a completed result
+    // without reaching into the opaque `raw` field.
     if (type === "tool_execution_start") {
         items.push(
             PiItemEvent.create({
                 agentId,
-                itemType: "tool_result",
+                itemType: "tool_start",
                 raw: event,
             }),
         )
@@ -351,7 +355,7 @@ export function mapPiEvent(
         items.push(
             PiItemEvent.create({
                 agentId,
-                itemType: "tool_result",
+                itemType: "tool_update",
                 raw: event,
             }),
         )

--- a/packages/baro-orchestrator/src/pi-stream-mapper.ts
+++ b/packages/baro-orchestrator/src/pi-stream-mapper.ts
@@ -114,10 +114,16 @@ function eventTimestamp(event: Record<string, unknown>): string {
 function extractToolOutput(event: Record<string, unknown>): string | undefined {
     const resultObj = event.result as Record<string, unknown> | undefined
 
-    // Primary: result.content[] of {type:"text",text}.
+    // Primary: result.content[] of {type:"text",text}. A content array that
+    // contains at least one text block is authoritative — return its joined
+    // text even when that text is the empty string (e.g. `bash` with no
+    // stdout is a legitimate empty success, NOT "no usable output"). Only
+    // fall through to the fallbacks when the array carried no text block at
+    // all, so we never mis-dump the whole envelope over a real empty result.
     const content = resultObj?.content
     if (Array.isArray(content)) {
         const texts: string[] = []
+        let sawTextBlock = false
         for (const block of content) {
             if (
                 block !== null &&
@@ -127,10 +133,11 @@ function extractToolOutput(event: Record<string, unknown>): string | undefined {
                 const b = block as Record<string, unknown>
                 if (b.type === "text" && typeof b.text === "string") {
                     texts.push(b.text)
+                    sawTextBlock = true
                 }
             }
         }
-        if (texts.length > 0) return texts.join("")
+        if (sawTextBlock) return texts.join("")
     }
 
     // Fallbacks (older/alternate shapes): plain string outputs first.
@@ -383,12 +390,19 @@ export function mapPiEvent(
 
         const outputStr = extractToolOutput(event)
 
-        if (callId !== undefined && outputStr !== undefined) {
+        // Emit the output whenever we have a callId — even if no output text
+        // could be extracted. The matching FunctionCallItem was already put on
+        // the bus from message_end; skipping the output here would leave a
+        // dangling, unreconciled tool call (breaks audit replay and any
+        // model-side transcript reconstruction). Default to empty string; on
+        // an error result with no body, surface the failure explicitly.
+        if (callId !== undefined) {
             const isError = event.isError === true
+            const body = outputStr ?? (isError ? "no output" : "")
             // Prefix on error so downstream readers can tell a failed tool
             // run apart from a successful one (the bus item carries no
             // dedicated error flag for this type).
-            const finalOutput = isError ? `[error] ${outputStr}` : outputStr
+            const finalOutput = isError ? `[error] ${body}` : body
             items.push(FunctionCallOutputItem.create(callId, finalOutput))
         }
 

--- a/packages/baro-orchestrator/src/pi-stream-mapper.ts
+++ b/packages/baro-orchestrator/src/pi-stream-mapper.ts
@@ -1,0 +1,439 @@
+/**
+ * Map Pi CLI `pi --mode json -p --no-session` stream events to typed
+ * items for bus delivery. Sibling of `opencode-stream-mapper.ts` (the
+ * OpenCode mapper) and `stream-json-mapper.ts` (the Claude mapper).
+ *
+ * Pi stream shape — observed against real `pi --mode json -p --no-session`
+ * output. Each stdout line is a JSONL envelope:
+ *
+ *   {"type":"session","version":3,"id":"<uuid>","timestamp":"ISO","cwd":"…"}
+ *   {"type":"agent_start"}
+ *   {"type":"turn_start"}
+ *   {"type":"message_start","message":{"role":"user"|"assistant","content":[…]}}
+ *   {"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"…",…},"message":{…}}
+ *   {"type":"tool_execution_start"}
+ *   {"type":"tool_execution_update"}
+ *   {"type":"tool_execution_end","result":…}
+ *   {"type":"message_end","message":{"role":"assistant","content":[…],"usage":{…}}}
+ *   {"type":"turn_end","message":{…},"toolResults":[…]}
+ *   {"type":"agent_end","messages":[…],"willRetry":false}
+ *
+ * NOTE: Pi differs from OpenCode in several important ways:
+ *  - Session id lives only on the "session" event (field `id`), not on
+ *    every envelope.
+ *  - Assistant content arrives as streaming deltas via message_update, then
+ *    is re-delivered as a finalised block list in message_end. We emit
+ *    PiItemEvent for every delta (so nothing is dropped from the bus) but
+ *    emit ModelMessageItem / FunctionCallItem only from the final message_end
+ *    to avoid duplicates.
+ *  - Tool calls and their results are split across separate events:
+ *    toolCall blocks (with field `id`) appear in message_end content, while
+ *    actual outputs appear in tool_execution_end (with field `toolCallId`).
+ *    Those two ids are equal, so call/output reconciliation is exact;
+ *    fallback fields are kept only for resilience against shape drift.
+ *
+ * Mapping strategy:
+ *
+ *   - "session"               → PiSystem subtype "session" (+ captures id).
+ *   - "agent_start"           → PiSystem subtype "agent_start".
+ *   - "turn_start"            → PiSystem subtype "turn_start".
+ *   - "message_start"         → PiTurnEvent turnType "message_start".
+ *   - "message_update"        → PiItemEvent (itemType derived from
+ *                               assistantMessageEvent.type: text_* → "text",
+ *                               thinking_* → "thinking", toolcall_* →
+ *                               "tool_call", other → raw subtype string).
+ *   - "message_end" (asst)    → ModelMessageItem(s) + FunctionCallItem(s)
+ *                               from content blocks + PiTurnEvent "message_end".
+ *   - "message_end" (user)    → PiTurnEvent "message_end" (turn lifecycle
+ *                               record only; no content items extracted).
+ *   - "tool_execution_start"  → PiItemEvent itemType "tool_result" (raw).
+ *   - "tool_execution_update" → PiItemEvent itemType "tool_result" (raw).
+ *   - "tool_execution_end"    → FunctionCallOutputItem (callId from
+ *                               `toolCallId`, output from result.content[].text)
+ *                               + PiItemEvent itemType "tool_result".
+ *   - "turn_end"              → PiTurnEvent turnType "turn_end".
+ *   - "agent_end"             → PiSystem subtype "agent_end".
+ *   - Unknown                 → PiUnknownEvent so nothing is silently dropped.
+ *
+ * Every input event maps to a non-empty array — we never silently drop
+ * data. Downstream observers (audit log, kaleidoskop replay, debug
+ * consoles) see every envelope Pi produces.
+ */
+
+import {
+    FunctionCallItem,
+    FunctionCallOutputItem,
+    ModelMessageItem,
+    SemanticEvent,
+} from "@mozaik-ai/core"
+
+import {
+    PiItemEvent,
+    PiSystem,
+    PiTurnEvent,
+    PiUnknownEvent,
+} from "./semantic-events.js"
+
+/** Union of all item types the Pi mapper can produce. */
+export type MappedPiItem =
+    | ModelMessageItem
+    | FunctionCallItem
+    | FunctionCallOutputItem
+    | SemanticEvent<unknown>
+
+/** Result of mapping a single Pi JSONL event. */
+export interface PiMapResult {
+    /** Mapped items to deliver on the bus. Always non-empty. */
+    items: MappedPiItem[]
+    /** Pi session id, present only when the "session" event is parsed. */
+    sessionId: string | null
+}
+
+/**
+ * Best-effort stable id suffix from an event's own timestamp field.
+ * Pi's `session` envelope carries an ISO-8601 *string* timestamp (unlike
+ * OpenCode's numeric one) and `message_end` carries none at all, so accept
+ * both number and string and fall back to "0" only when truly absent.
+ */
+function eventTimestamp(event: Record<string, unknown>): string {
+    if (typeof event.timestamp === "number") return String(event.timestamp)
+    if (typeof event.timestamp === "string" && event.timestamp) {
+        return event.timestamp
+    }
+    return "0"
+}
+
+/**
+ * Extract the human-readable output text from a tool_execution_end envelope.
+ *
+ * Real Pi shape: `event.result.content` is an array of {type:"text",text}.
+ * We concatenate every text block. Legacy/alternate shapes (a plain string
+ * output, or a nested `output` field) are honoured as fallbacks. Returns
+ * undefined only when no usable output could be found at all.
+ */
+function extractToolOutput(event: Record<string, unknown>): string | undefined {
+    const resultObj = event.result as Record<string, unknown> | undefined
+
+    // Primary: result.content[] of {type:"text",text}.
+    const content = resultObj?.content
+    if (Array.isArray(content)) {
+        const texts: string[] = []
+        for (const block of content) {
+            if (
+                block !== null &&
+                typeof block === "object" &&
+                !Array.isArray(block)
+            ) {
+                const b = block as Record<string, unknown>
+                if (b.type === "text" && typeof b.text === "string") {
+                    texts.push(b.text)
+                }
+            }
+        }
+        if (texts.length > 0) return texts.join("")
+    }
+
+    // Fallbacks (older/alternate shapes): plain string outputs first.
+    const outputObj = event.output as Record<string, unknown> | undefined
+    const toolResultObj = event.toolResult as
+        | Record<string, unknown>
+        | undefined
+    const candidates: unknown[] = [
+        event.output,
+        resultObj?.output,
+        outputObj?.output,
+        toolResultObj?.output,
+        resultObj?.result,
+    ]
+    for (const c of candidates) {
+        if (typeof c === "string") return c
+    }
+
+    // Last resort: stringify the whole result object so nothing is lost.
+    // Cap this fallback — a pathological tool result could be arbitrarily
+    // large, and unlike the real content[].text path above this is only a
+    // best-effort dump. Same defensive spirit as the .slice() guards used
+    // elsewhere. The normal output path is never truncated.
+    if (resultObj !== undefined) {
+        const dump = JSON.stringify(resultObj)
+        const MAX = 8 * 1024
+        return dump.length > MAX
+            ? `${dump.slice(0, MAX)}…[truncated]`
+            : dump
+    }
+    return undefined
+}
+
+/**
+ * Derive a PiItemEvent itemType string from the assistantMessageEvent.type
+ * field found inside a "message_update" envelope.
+ */
+function resolveUpdateItemType(subtype: string): string {
+    if (subtype.startsWith("text_")) return "text"
+    if (subtype.startsWith("thinking_")) return "thinking"
+    if (subtype.startsWith("toolcall_")) return "tool_call"
+    return subtype
+}
+
+/**
+ * Map a single parsed Pi JSONL event to typed Mozaik items.
+ *
+ * @param agentId - The baro agent ID (story ID) that owns this stream.
+ * @param event   - A parsed JSON object from Pi's stdout.
+ * @returns Mapped items and optional session ID.
+ */
+export function mapPiEvent(
+    agentId: string,
+    event: Record<string, unknown>,
+): PiMapResult {
+    const items: MappedPiItem[] = []
+    const type = typeof event.type === "string" ? event.type : ""
+
+    // sessionId is only present on the "session" envelope.
+    const sessionId =
+        type === "session" && typeof event.id === "string" ? event.id : null
+
+    // ─── session ───────────────────────────────────────────────────
+    if (type === "session") {
+        items.push(
+            PiSystem.create({
+                agentId,
+                subtype: "session",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── agent_start ───────────────────────────────────────────────
+    if (type === "agent_start") {
+        items.push(
+            PiSystem.create({
+                agentId,
+                subtype: "agent_start",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── turn_start ────────────────────────────────────────────────
+    if (type === "turn_start") {
+        items.push(
+            PiSystem.create({
+                agentId,
+                subtype: "turn_start",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── message_start ────────────────────────────────────────────
+    if (type === "message_start") {
+        items.push(
+            PiTurnEvent.create({
+                agentId,
+                turnType: "message_start",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── message_update (streaming deltas) ────────────────────────
+    // Deltas are noisy — we emit one PiItemEvent per update so the bus
+    // sees every packet, but we do NOT emit ModelMessageItem here to
+    // avoid duplicating the final text from message_end.
+    if (type === "message_update") {
+        const ame = event.assistantMessageEvent as
+            | Record<string, unknown>
+            | undefined
+        const subtype =
+            typeof ame?.type === "string" ? ame.type : "unknown_delta"
+        items.push(
+            PiItemEvent.create({
+                agentId,
+                itemType: resolveUpdateItemType(subtype),
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── message_end ──────────────────────────────────────────────
+    // The message object carries the final, resolved content blocks.
+    // For assistant messages we extract text + toolCall blocks into
+    // first-class Mozaik items. For user messages we just record a
+    // turn event for symmetry.
+    if (type === "message_end") {
+        const message = event.message as Record<string, unknown> | undefined
+        const role = typeof message?.role === "string" ? message.role : ""
+
+        if (role === "assistant") {
+            const content = Array.isArray(message?.content)
+                ? (message.content as unknown[])
+                : []
+
+            for (let i = 0; i < content.length; i++) {
+                const block = content[i]
+                if (
+                    block === null ||
+                    typeof block !== "object" ||
+                    Array.isArray(block)
+                ) {
+                    continue
+                }
+                const b = block as Record<string, unknown>
+                const blockType = typeof b.type === "string" ? b.type : ""
+
+                if (blockType === "text") {
+                    const text = typeof b.text === "string" ? b.text : ""
+                    if (text) {
+                        items.push(ModelMessageItem.rehydrate({ text }))
+                    }
+                } else if (blockType === "toolCall") {
+                    // Include the block index in the fallback so multiple
+                    // id-less toolCall blocks in one message_end don't all
+                    // collapse onto the same synthetic callId.
+                    const callId =
+                        typeof b.id === "string"
+                            ? b.id
+                            : `pi:${eventTimestamp(event)}:${i}`
+                    const name =
+                        typeof b.name === "string" ? b.name : "unknown"
+                    const args =
+                        b.arguments !== undefined
+                            ? typeof b.arguments === "string"
+                                ? b.arguments
+                                : JSON.stringify(b.arguments)
+                            : "{}"
+                    items.push(
+                        FunctionCallItem.rehydrate({ callId, name, args }),
+                    )
+                }
+            }
+        }
+
+        // Always emit the turn event regardless of role so the bus has
+        // a complete turn lifecycle record.
+        items.push(
+            PiTurnEvent.create({
+                agentId,
+                turnType: "message_end",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── tool_execution_start ─────────────────────────────────────
+    if (type === "tool_execution_start") {
+        items.push(
+            PiItemEvent.create({
+                agentId,
+                itemType: "tool_result",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── tool_execution_update ────────────────────────────────────
+    if (type === "tool_execution_update") {
+        items.push(
+            PiItemEvent.create({
+                agentId,
+                itemType: "tool_result",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── tool_execution_end ───────────────────────────────────────
+    // Real Pi shape (verified against live output):
+    //   {"type":"tool_execution_end","toolCallId":"call_…","toolName":"bash",
+    //    "result":{"content":[{"type":"text","text":"hello\n"}]},"isError":false}
+    // The `toolCallId` here EQUALS the `id` of the toolCall block emitted in
+    // message_end, so call/output reconciliation works. The output text lives
+    // in result.content[].text — concatenate those rather than stringifying
+    // the whole result object. Fallbacks remain for forward/backward compat.
+    if (type === "tool_execution_end") {
+        const resultObj = event.result as Record<string, unknown> | undefined
+        const outputObj = event.output as Record<string, unknown> | undefined
+        const toolResultObj = event.toolResult as
+            | Record<string, unknown>
+            | undefined
+
+        // Primary field is `toolCallId`; keep legacy `callId` candidates as
+        // fallbacks so we degrade gracefully if Pi's shape shifts.
+        const callId: string | undefined =
+            typeof event.toolCallId === "string"
+                ? event.toolCallId
+                : typeof event.callId === "string"
+                  ? event.callId
+                  : typeof resultObj?.callId === "string"
+                    ? resultObj.callId
+                    : typeof outputObj?.callId === "string"
+                      ? outputObj.callId
+                      : typeof toolResultObj?.callId === "string"
+                        ? toolResultObj.callId
+                        : undefined
+
+        const outputStr = extractToolOutput(event)
+
+        if (callId !== undefined && outputStr !== undefined) {
+            const isError = event.isError === true
+            // Prefix on error so downstream readers can tell a failed tool
+            // run apart from a successful one (the bus item carries no
+            // dedicated error flag for this type).
+            const finalOutput = isError ? `[error] ${outputStr}` : outputStr
+            items.push(FunctionCallOutputItem.create(callId, finalOutput))
+        }
+
+        // Always emit the item event — carries the raw envelope for audit.
+        items.push(
+            PiItemEvent.create({
+                agentId,
+                itemType: "tool_result",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── turn_end ─────────────────────────────────────────────────
+    if (type === "turn_end") {
+        items.push(
+            PiTurnEvent.create({
+                agentId,
+                turnType: "turn_end",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── agent_end ────────────────────────────────────────────────
+    if (type === "agent_end") {
+        items.push(
+            PiSystem.create({
+                agentId,
+                subtype: "agent_end",
+                raw: event,
+            }),
+        )
+        return { items, sessionId }
+    }
+
+    // ─── unknown / future event type ──────────────────────────────
+    items.push(
+        PiUnknownEvent.create({
+            agentId,
+            piType: type || "unspecified",
+            raw: event,
+        }),
+    )
+    return { items, sessionId }
+}

--- a/packages/baro-orchestrator/src/planning/architect-pi.ts
+++ b/packages/baro-orchestrator/src/planning/architect-pi.ts
@@ -1,0 +1,69 @@
+/**
+ * ArchitectPi — one-shot Architect call via the `pi` CLI.
+ *
+ * Same prompt shape as ArchitectClaude / ArchitectCodex / ArchitectOpenCode
+ * so the providers produce comparable decision documents. Pi's built-in
+ * tools (file read, grep, bash, etc.) handle codebase exploration; we don't
+ * ship a separate tool layer.
+ *
+ * Wire shape: combined `${SYSTEM}\n\n${USER}` prompt → pi run
+ * → final text output → return as markdown.
+ */
+
+import { runPiOneShot } from "../pi-one-shot.js"
+import {
+    ARCHITECT_SYSTEM_PROMPT,
+    buildArchitectUserMessage,
+} from "./architect-prompts.js"
+
+/** Options for `runArchitectPi`. */
+export interface RunArchitectPiOptions {
+    /** The user's goal — verbatim. */
+    goal: string
+    /** Working directory the Architect explores in. */
+    cwd: string
+    /** Provider to use (e.g. "anthropic", "openai"). Default: undefined (use Pi default). */
+    provider?: string
+    /** Pi model identifier. Default: undefined (use Pi default). */
+    model?: string
+    /** Optional CLAUDE.md / project-context blob to prepend. */
+    projectContext?: string
+    /** Path to the `pi` binary. Default: "pi". */
+    piBin?: string
+    /**
+     * Per-call timeout in milliseconds. Default: 600_000 (10 minutes).
+     * Pi with tool-call exploration can be materially slower than
+     * a direct API call — the original 3-minute timeout was killing runs
+     * mid-exploration.
+     */
+    timeoutMs?: number
+}
+
+/**
+ * Run the Architect phase using Pi as the backend.
+ *
+ * @returns The decision document (markdown) produced by the Architect.
+ * @throws Error if Pi returns empty or fails.
+ */
+export async function runArchitectPi(
+    opts: RunArchitectPiOptions,
+): Promise<string> {
+    const userMessage = buildArchitectUserMessage(opts.goal, opts.projectContext)
+    const prompt = `${ARCHITECT_SYSTEM_PROMPT}\n\n${userMessage}`
+
+    const text = await runPiOneShot({
+        prompt,
+        cwd: opts.cwd,
+        provider: opts.provider,
+        model: opts.model,
+        piBin: opts.piBin,
+        timeoutMs: opts.timeoutMs ?? 600_000,
+        label: "pi-architect",
+    })
+
+    const doc = text.trim()
+    if (!doc) {
+        throw new Error("ArchitectPi: pi returned empty result")
+    }
+    return doc
+}

--- a/packages/baro-orchestrator/src/planning/planner-pi.ts
+++ b/packages/baro-orchestrator/src/planning/planner-pi.ts
@@ -1,0 +1,103 @@
+/**
+ * PlannerPi — one-shot Planner call via the `pi` CLI.
+ *
+ * Same prompt shape as PlannerClaude / PlannerCodex / PlannerOpenCode.
+ * Returns the raw PRD JSON string for the Rust caller to deserialise.
+ */
+
+import { runPiOneShot } from "../pi-one-shot.js"
+import {
+    PLANNER_SYSTEM_PROMPT,
+    buildPlannerUserMessage,
+} from "./planner-prompts.js"
+
+/** Options for `runPlannerPi`. */
+export interface RunPlannerPiOptions {
+    /** The user's goal — verbatim. */
+    goal: string
+    /** Working directory. */
+    cwd: string
+    /** Provider to use (e.g. "anthropic", "openai"). Default: undefined (use Pi default). */
+    provider?: string
+    /** Pi model identifier. */
+    model?: string
+    /** Optional project context blob. */
+    projectContext?: string
+    /** Optional decision document from the Architect phase. */
+    decisionDocument?: string
+    /** If true, use a shorter planning prompt. */
+    quick?: boolean
+    /** Path to the `pi` binary. Default: "pi". */
+    piBin?: string
+    /**
+     * Per-call timeout in milliseconds. Default: 900_000 (15 minutes).
+     * Planner is the longest phase — large multi-story PRDs with strict
+     * JSON output frequently push models past shorter timeouts.
+     */
+    timeoutMs?: number
+}
+
+/**
+ * Run the Planner phase using Pi as the backend.
+ *
+ * @returns The PRD as a raw JSON string (a single `{ … }` object).
+ * @throws Error if Pi returns empty or the result contains no valid JSON.
+ */
+export async function runPlannerPi(
+    opts: RunPlannerPiOptions,
+): Promise<string> {
+    const userMessage = buildPlannerUserMessage({
+        goal: opts.goal,
+        decisionDocument: opts.decisionDocument,
+        quick: opts.quick,
+        projectContext: opts.projectContext,
+    })
+    const prompt = `${PLANNER_SYSTEM_PROMPT}\n\n${userMessage}`
+
+    const text = await runPiOneShot({
+        prompt,
+        cwd: opts.cwd,
+        provider: opts.provider,
+        model: opts.model,
+        piBin: opts.piBin,
+        timeoutMs: opts.timeoutMs ?? 900_000,
+        label: "pi-planner",
+    })
+
+    const planText = text.trim()
+    if (!planText) {
+        throw new Error("PlannerPi: pi returned empty result")
+    }
+    // Model sometimes wraps JSON in markdown fences or adds prose despite
+    // the "ONLY JSON" instruction — strip back to a bare `{ … }`.
+    return extractJsonObject(planText)
+}
+
+/**
+ * Pull the first balanced `{ … }` block out of a raw string. Tolerates
+ * markdown fences and leading prose.
+ */
+function extractJsonObject(text: string): string {
+    const trimmed = text.trim()
+    if (trimmed.startsWith("{") && trimmed.endsWith("}")) return trimmed
+    const fence = trimmed.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/)
+    if (fence) return fence[1]!
+    const start = trimmed.indexOf("{")
+    if (start < 0) {
+        throw new Error(
+            `PlannerPi: no JSON object in response: ${trimmed.slice(0, 200)}`,
+        )
+    }
+    let depth = 0
+    for (let i = start; i < trimmed.length; i++) {
+        const ch = trimmed[i]
+        if (ch === "{") depth++
+        else if (ch === "}") {
+            depth--
+            if (depth === 0) return trimmed.slice(start, i + 1)
+        }
+    }
+    throw new Error(
+        `PlannerPi: unbalanced JSON in response: ${trimmed.slice(0, 200)}`,
+    )
+}

--- a/packages/baro-orchestrator/src/routing.ts
+++ b/packages/baro-orchestrator/src/routing.ts
@@ -27,9 +27,9 @@
  * the same backend/model the old phase-level wiring produced.
  */
 
-export type Backend = "claude" | "openai" | "codex" | "opencode"
+export type Backend = "claude" | "openai" | "codex" | "opencode" | "pi"
 
-const BACKENDS: readonly Backend[] = ["claude", "openai", "codex", "opencode"]
+const BACKENDS: readonly Backend[] = ["claude", "openai", "codex", "opencode", "pi"]
 
 export function isBackend(s: string): s is Backend {
     return (BACKENDS as readonly string[]).includes(s)
@@ -273,7 +273,7 @@ export function parseTierMap(spec: string): TierMap {
         if (!backend) {
             throw new Error(
                 `--tier-map route "${route}" for tier "${tier}" must name a backend ` +
-                    `(claude: | openai: | codex: | opencode:)`,
+                    `(claude: | openai: | codex: | opencode: | pi:)`,
             )
         }
         map[tier] = route

--- a/packages/baro-orchestrator/src/semantic-events.ts
+++ b/packages/baro-orchestrator/src/semantic-events.ts
@@ -408,7 +408,7 @@ export const PiTurnEvent = defineSemanticEvent<PiTurnEventData>("pi_turn_event")
 
 export interface PiItemEventData {
     agentId: string
-    /** "text" | "thinking" | "tool_call" | "tool_result" */
+    /** "text" | "thinking" | "tool_call" | "tool_start" | "tool_update" | "tool_result" */
     itemType: string
     raw: Readonly<Record<string, unknown>>
 }

--- a/packages/baro-orchestrator/src/semantic-events.ts
+++ b/packages/baro-orchestrator/src/semantic-events.ts
@@ -382,3 +382,42 @@ export interface OpenCodeUnknownEventData {
 }
 export const OpenCodeUnknownEvent =
     defineSemanticEvent<OpenCodeUnknownEventData>("opencode_unknown_event")
+
+// ─── Pi CLI passthrough types ─────────────────────────────────────────
+// Pi emits a stream of JSONL events with these envelope types:
+//   - session / agent_start / turn_start / agent_end → lifecycle
+//   - message_start / message_end / turn_end          → turn boundaries
+//   - message_update (assistantMessageEvent deltas)    → streamed items
+//   - tool_execution_start / _update / _end           → tool activity
+
+export interface PiSystemData {
+    agentId: string
+    /** "session" | "agent_start" | "turn_start" | "agent_end" */
+    subtype: string
+    raw: Readonly<Record<string, unknown>>
+}
+export const PiSystem = defineSemanticEvent<PiSystemData>("pi_system")
+
+export interface PiTurnEventData {
+    agentId: string
+    /** "message_start" | "message_end" | "turn_end" */
+    turnType: string
+    raw: Readonly<Record<string, unknown>>
+}
+export const PiTurnEvent = defineSemanticEvent<PiTurnEventData>("pi_turn_event")
+
+export interface PiItemEventData {
+    agentId: string
+    /** "text" | "thinking" | "tool_call" | "tool_result" */
+    itemType: string
+    raw: Readonly<Record<string, unknown>>
+}
+export const PiItemEvent = defineSemanticEvent<PiItemEventData>("pi_item_event")
+
+export interface PiUnknownEventData {
+    agentId: string
+    piType: string
+    raw: Readonly<Record<string, unknown>>
+}
+export const PiUnknownEvent =
+    defineSemanticEvent<PiUnknownEventData>("pi_unknown_event")


### PR DESCRIPTION
## What your code does (plain English)

Adds **Pi** (the `pi` coding-agent CLI) as a selectable backend in baro, alongside Claude / OpenAI / Codex / OpenCode. Run `baro --llm pi "your goal"` (or pick Pi in the TUI provider/planner picker, or mix per-phase with `--story-llm pi` etc.) and baro drives the `pi` agent for that work instead of Claude. Pi appears only when the `pi` binary is on PATH. **No silent cross-backend fallback** — a failed Pi phase stays failed, it never quietly retries on Claude.

Tell it's really using Pi: logs show `[orchestrate] llm=pi: ... (Pi CLI path)`, `[story-factory] <id> → pi`, `[pi-architect]`/`[pi-planner]`/`[pi-critic]` labels; `pgrep -fl 'pi --mode json'` shows the live process.

## Technical summary

Clones the OpenCode backend pattern for `pi --mode json -p --no-session` (one-shot JSONL).

**New (baro-orchestrator):** `pi-stream-mapper.ts` (parses session/message_update/message_end/tool_execution_* ; reconciles toolCall `id` ↔ `tool_execution_end.toolCallId`; never drops events), `pi-one-shot.ts`, `participants/pi-cli-participant.ts`, `participants/pi-story-agent.ts`, `planning/architect-pi.ts`, `planning/planner-pi.ts`, `participants/critic-pi.ts`, `participants/surgeon-pi.ts`, Pi semantic events.

**Wiring:** routing Backend union, story-factory, orchestrate (surgeon+critic), main.ts exports, cli/run-architect/run-planner. **Rust:** `LlmProvider::Pi` + `Planner::Pi`, clap value-parsers, doctor `check_pi_on_path`, picker/planning/welcome screens.

**Completion evidence (no false-PASS):** done requires exit 0 AND `agent_end` AND ≥1 *successful* tool (`tool_execution_end` with `isError !== true`).

## Hardening (3 review rounds + adversarial)

- Correct usage keys (input/output); SIGTERM→SIGKILL escalation; all backends reaped on shutdown AND crash path; 16 MiB buffer caps; `ready` can't hang on clean exit
- Tool-output: empty-success returns `""` (not stringified envelope); `FunctionCallOutputItem` always reconciled (no orphaned calls), `[error]` prefix on failure
- Surgeon LLM replan validated element-by-element before DAG mutation

## Verification

`tsc --noEmit` clean · `cargo build -p baro-tui` clean · integration test **33/33** against live `pi` (incl. HIGH-1 regression tests proven to fail on revert).

Closes epic #3 (Pi.dev backend).