### PR TITLE
fix(tui): render branch/planning errors on the Review screen (#47)

### DIFF
--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -1108,6 +1108,20 @@ async fn run_app(
                             KeyCode::Backspace => { app.refine_input.as_mut().unwrap().pop(); }
                             _ => {}
                         }
+                    } else if app.planning_error.is_some() {
+                        // A branch/planning error is shown on the Review
+                        // screen (#47). Enter/Esc dismisses it rather than
+                        // re-triggering the doomed run or quitting; any other
+                        // key is ignored while the error modal is up.
+                        match key.code {
+                            KeyCode::Enter
+                            | KeyCode::Char('\r')
+                            | KeyCode::Char('\n')
+                            | KeyCode::Esc => {
+                                app.planning_error = None;
+                            }
+                            _ => {}
+                        }
                     } else {
                         match key.code {
                         KeyCode::Char('r') => {

--- a/crates/baro-tui/src/screens/review.rs
+++ b/crates/baro-tui/src/screens/review.rs
@@ -303,7 +303,11 @@ pub fn render(f: &mut Frame, app: &App) {
             Style::default().fg(theme::MUTED),
         )));
 
-        let overlay_area = centered_rect(70, 11, area);
+        // 2 border rows + lines.len() content rows, capped to avoid
+        // overflowing very short terminals; minimum 5 to always fit the
+        // header + dismiss hint.
+        let modal_height = (2 + lines.len() as u16).clamp(5, 18).min(area.height);
+        let overlay_area = centered_rect(70, modal_height, area);
         f.render_widget(Clear, overlay_area);
         let paragraph = Paragraph::new(lines)
             .block(

--- a/crates/baro-tui/src/screens/review.rs
+++ b/crates/baro-tui/src/screens/review.rs
@@ -270,6 +270,54 @@ pub fn render(f: &mut Frame, app: &App) {
         );
         f.render_widget(paragraph, overlay_area);
     }
+
+    // Branch/planning error overlay. BranchError (e.g. a failed resume
+    // checkout) is delivered to the Review screen via app.planning_error,
+    // but without this the error was never rendered — pressing Enter on a
+    // doomed resume looked like a silent bounce. Show it as a prominent
+    // modal so the failure is visible and actionable. (#47)
+    if let Some(ref err) = app.planning_error {
+        let mut lines: Vec<Line> = vec![
+            Line::from(vec![
+                Span::styled(
+                    " \u{2716} ",
+                    Style::default().fg(theme::ERROR).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    "Cannot start run",
+                    Style::default().fg(theme::ERROR).add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(""),
+        ];
+        // Wrap handles long lines; render the full body so nothing is lost.
+        for body_line in err.lines() {
+            lines.push(Line::from(Span::styled(
+                body_line.to_string(),
+                Style::default().fg(theme::TEXT_DIM),
+            )));
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Enter/Esc: dismiss",
+            Style::default().fg(theme::MUTED),
+        )));
+
+        let overlay_area = centered_rect(70, 11, area);
+        f.render_widget(Clear, overlay_area);
+        let paragraph = Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(theme::ERROR_DIM))
+                    .title(Span::styled(
+                        " Error ",
+                        Style::default().fg(theme::ERROR).add_modifier(Modifier::BOLD),
+                    )),
+            )
+            .wrap(Wrap { trim: false });
+        f.render_widget(paragraph, overlay_area);
+    }
 }
 
 fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {


### PR DESCRIPTION
## What your code does (plain English)

Fixes the bug where `baro --resume` looked like "Enter does nothing." When a git branch problem stops a resume (missing branch, checkout failure, verification mismatch), baro already produced a clear error message — but the Review screen never showed it, so the user just saw a silent bounce back to the same screen. Now the error appears as a prominent red modal, and Enter/Esc dismisses it.

## Root cause

`BranchError` is delivered to the Review screen via `app.planning_error` (`main.rs:882`), but `screens/review.rs` never rendered `planning_error` (only `screens/planning.rs` did). Every swallowed `BranchError` from the Review→execute path (resume checkout failure `main.rs:~1173`, verification mismatch, fresh-run emitters) landed unrendered.

## Fix

- **`screens/review.rs`**: render `app.planning_error` as a centered error modal (Clear + bordered popup, mirrors the existing `planning.rs` error styling). Every previously-swallowed `BranchError` is now visible, with the full message wrapped.
- **`main.rs`**: on the Review screen, when an error is showing, **Enter/Esc dismisses it** (clears `planning_error`) instead of re-triggering the doomed run or quitting. Other keys are ignored while the modal is up.

## Scope note

This is the core fix from the issue (item 1: render the error). Items 2–3 (more actionable resume error strings, surfacing the implicit `baro/` prefixing) are left as follow-ups — the messages are produced at the `BranchError` emit sites and can be improved independently; this PR makes them *visible*, which is the actual bug.

## Verification

`cargo build -p baro-tui` clean. Manual: a resume against a non-existent `baro/<name>` branch now shows the error modal on Enter instead of bouncing silently.

Closes #47.