### PR TITLE
fix(memory): reader reloads on-disk index so cross-process recall works (#51)

### DIFF
--- a/packages/baro-memory/src/__tests__/memory-store.test.ts
+++ b/packages/baro-memory/src/__tests__/memory-store.test.ts
@@ -242,6 +242,57 @@ describe('Cross-process persistence', () => {
     }, 60000)
 })
 
+describe('Cross-process recall on a live reader (#51 regression)', () => {
+    // The bug: a long-lived reader store, created BEFORE another process
+    // writes findings to the shared on-disk index, never saw those writes —
+    // Vectra's LocalIndex caches its data in-memory at first query and never
+    // reloads, so recall()/getStats() returned 0 forever. The fix reloads
+    // the index when its on-disk mtime changes. This test reproduces the
+    // exact ordering: reader opened first, writer (a SECOND store on the same
+    // session path, standing in for the subprocess CLI writer) writes after,
+    // then the pre-existing reader must see the finding.
+    it('reader created before an external write still recalls it after reload', async () => {
+        const sessionPath = mkdtempSync(join(tmpdir(), 'baro-memory-stale-'))
+
+        // Reader opens first, against an empty index — this is the instance
+        // that, pre-fix, froze on the empty snapshot.
+        const reader = await createMemoryStore({ sessionPath })
+
+        // Sanity: nothing there yet.
+        const before = await reader.getStats()
+        expect(before.totalFindings).toBe(0)
+
+        // A separate store on the same session path writes a finding (stands
+        // in for the out-of-process baro-memory CLI writer).
+        const writer = await createMemoryStore({ sessionPath })
+        await writer.remember({
+            tool: 'Codex',
+            agentId: 'writer-process',
+            content: 'Chemical hazard mitigation already applied in docx-generator',
+            filePath: 'packages/core/src/docx-generator.ts',
+        })
+        await writer.close()
+
+        // The pre-existing reader must now observe the write (mtime-triggered
+        // reload). Pre-fix this returned 0 / [].
+        const stats = await reader.getStats()
+        expect(stats.totalFindings).toBe(1)
+
+        const results = await reader.recall('chemical hazard docx', {
+            maxResults: 5,
+            minSimilarity: 0.2,
+        })
+        expect(results.length).toBeGreaterThan(0)
+        expect(results[0].metadata.agentId).toBe('writer-process')
+        expect(results[0].metadata.filePath).toBe(
+            'packages/core/src/docx-generator.ts',
+        )
+
+        await reader.close()
+        try { rmSync(sessionPath, { recursive: true }) } catch {}
+    }, 60000)
+})
+
 describe('Corruption recovery', () => {
     it('should handle corrupt cache.json gracefully', async () => {
         const sessionPath = mkdtempSync(join(tmpdir(), 'baro-memory-corrupt-'))

--- a/packages/baro-memory/src/vectra-store.ts
+++ b/packages/baro-memory/src/vectra-store.ts
@@ -209,9 +209,15 @@ async function embed(extractor: EmbeddingPipeline, text: string): Promise<number
 // ── VectraMemoryStore ────────────────────────────────────────────────────
 
 class VectraMemoryStore implements MemoryStore {
-    private readonly index: LocalIndex<VectraItemMetadata>
+    // Not readonly: the reader re-instantiates the index to pick up writes
+    // made by other processes (see refreshIndexIfChanged).
+    private index: LocalIndex<VectraItemMetadata>
     private readonly extractor: EmbeddingPipeline
     private readonly sessionPath: string
+    private readonly indexPath: string
+    private readonly indexFilePath: string
+    /** mtimeMs of index.json last time we (re)loaded; -1 = never seen. */
+    private lastIndexMtimeMs = -1
     private readonly cachePath: string
     private readonly lockPath: string
     private readonly config: Required<MemoryStoreConfig>
@@ -225,9 +231,43 @@ class VectraMemoryStore implements MemoryStore {
         this.index = index
         this.extractor = extractor
         this.sessionPath = sessionPath
+        this.indexPath = join(sessionPath, 'index')
+        // Vectra persists the index to <folder>/index.json.
+        this.indexFilePath = join(this.indexPath, 'index.json')
         this.cachePath = join(sessionPath, 'cache.json')
         this.lockPath = join(sessionPath, 'cache.lock')
         this.config = config
+    }
+
+    /**
+     * Pick up cross-process writes to the shared on-disk index.
+     *
+     * Vectra's LocalIndex loads the whole index into a private in-memory
+     * `_data` field on first query and never reloads it. Findings written by
+     * story agents in SEPARATE processes (via the baro-memory CLI) land on
+     * disk but stay invisible to this long-lived reader — so recall/getStats
+     * see a frozen (usually empty) snapshot and always return 0 (issue #51).
+     *
+     * There is no public reload on LocalIndex, so we detect a change via the
+     * index file's mtime and swap in a fresh LocalIndex, which lazily loads
+     * the current on-disk data on its next query. Throttled by mtime so we
+     * don't re-read every call — cheap relative to an LLM turn. Read paths
+     * only; writers (remember/upsertItem) already refresh Vectra's `_data`
+     * via beginUpdate, and reloading mid-write could clobber a pending batch.
+     *
+     * Never throws: on any stat/instantiation error we keep the current
+     * index and degrade gracefully.
+     */
+    private refreshIndexIfChanged(): void {
+        try {
+            if (!existsSync(this.indexFilePath)) return
+            const mtimeMs = statSync(this.indexFilePath).mtimeMs
+            if (mtimeMs === this.lastIndexMtimeMs) return
+            this.lastIndexMtimeMs = mtimeMs
+            this.index = new LocalIndex<VectraItemMetadata>(this.indexPath)
+        } catch {
+            // Keep the existing index on any error.
+        }
     }
 
     // ── Semantic memory ──────────────────────────────────────────
@@ -265,6 +305,9 @@ class VectraMemoryStore implements MemoryStore {
             const filterByTool = options?.filterByTool
 
             if (!query?.trim()) return []
+
+            // Reload the on-disk index if other processes wrote to it.
+            this.refreshIndexIfChanged()
 
             const vector = await embed(this.extractor, query)
 
@@ -388,6 +431,8 @@ class VectraMemoryStore implements MemoryStore {
 
     async getStats(): Promise<MemoryStats> {
         try {
+            // Reload the on-disk index if other processes wrote to it.
+            this.refreshIndexIfChanged()
             const items = await this.index.listItems<VectraItemMetadata>()
             const tools = new Set<string>()
             const agents = new Set<string>()

--- a/packages/baro-memory/src/vectra-store.ts
+++ b/packages/baro-memory/src/vectra-store.ts
@@ -263,8 +263,13 @@ class VectraMemoryStore implements MemoryStore {
             if (!existsSync(this.indexFilePath)) return
             const mtimeMs = statSync(this.indexFilePath).mtimeMs
             if (mtimeMs === this.lastIndexMtimeMs) return
+            // Create the new index BEFORE advancing the mtime watermark: if
+            // instantiation throws, we keep the old index AND the old mtime,
+            // so the next call retries instead of locking onto a stale
+            // snapshot for this mtime (Greptile #52 P2).
+            const newIndex = new LocalIndex<VectraItemMetadata>(this.indexPath)
             this.lastIndexMtimeMs = mtimeMs
-            this.index = new LocalIndex<VectraItemMetadata>(this.indexPath)
+            this.index = newIndex
         } catch {
             // Keep the existing index on any error.
         }


### PR DESCRIPTION
## What your code does (plain English)

Fixes the HIGH-severity bug where semantic memory recall always returned **0** on the subprocess backends (codex / opencode / pi) — the headline 0.49.0 cross-agent memory feature was effectively dead there. Findings WERE captured to disk, but the reader never saw them, so agents got zero benefit (pure overhead).

## Root cause

`VectraMemoryStore` (`packages/baro-memory/src/vectra-store.ts`) holds a Vectra `LocalIndex` created **once** at orchestrator startup. Vectra's `LocalIndex` loads its data into a private in-memory `_data` on first query — when the index is **empty** — and never reloads it. Story agents in **separate processes** write findings to the same on-disk index (`sessionPath/index/index.json`) via the `baro-memory` CLI, but the long-lived reader's cached index never picks up those cross-process writes. So `recall()` / `gatherContext()` / `getStats()` queried a frozen empty snapshot → `totalFindings = 0`, `recall → []` forever. (0.50.1 fixed *loading*; this is why it still did nothing once loaded.)

## Fix

- Added `refreshIndexIfChanged()`: stats `sessionPath/index/index.json` and, when its `mtimeMs` changed since last seen, swaps `this.index` for a fresh `new LocalIndex(indexPath)` (Vectra exposes no public reload; a new instance lazily loads current on-disk data on its next query). Throttled by mtime — only re-reads when the index actually changed, cheap vs an LLM turn. Wrapped in try/catch; keeps the current index on any error.
- Called at the start of `recall()` and `getStats()` (`gatherContext()` delegates to `recall`). **Read paths only** — writers (`remember` → `upsertItem`) already refresh Vectra's `_data` via `beginUpdate`, and reloading mid-write could clobber a pending batch.
- `this.index` changed from `readonly` to mutable; constructor derives `indexPath`/`indexFilePath` from the existing `sessionPath` field.

## Regression test

Reproduces the exact broken ordering: a reader store opened **before** an external write (a second store on the same session path, standing in for the subprocess CLI writer) must recall the finding **after** the write. Verified it **fails without the fix** (returns 0) and passes with it.

## Verification

`bun run typecheck` clean · `vitest run` **26/26** (the new #51 test + the existing 25).

Closes #51.