### PR TITLE
fix(orchestrator): real per-story git worktree isolation (#50)

### DIFF
--- a/packages/baro-orchestrator/src/git.ts
+++ b/packages/baro-orchestrator/src/git.ts
@@ -166,7 +166,10 @@ export async function safePullRebase(
         }
 
         try {
-            await exec("git", ["pull", "--rebase", "origin", branch], { cwd })
+            // --rebase=merges so per-story `--no-ff` merge commits (worktree
+            // isolation, issue #50) survive the replay instead of being
+            // flattened or dropped.
+            await exec("git", ["pull", "--rebase=merges", "origin", branch], { cwd })
             onLog?.("[git] pull ok")
         } catch {
             onLog?.("[git] pull conflict, continuing without pull")
@@ -229,7 +232,9 @@ export async function gitPushWithRetry(
                 `[git] push rejected (attempt ${attempt}/${max}), pulling and retrying...`,
             )
             try {
-                await exec("git", ["pull", "--rebase", "origin", branch], {
+                // --rebase=merges: preserve per-story `--no-ff` merge commits
+                // (worktree isolation, #50) when reconciling a rejected push.
+                await exec("git", ["pull", "--rebase=merges", "origin", branch], {
                     cwd: options.cwd,
                 })
             } catch {

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -369,9 +369,12 @@ export async function orchestrate(
     // worktree branch/dir names so concurrent runs and resumes never collide.
     const runId = `run-${Date.now()}-${process.pid}`
 
-    // Escape hatch: explicit config wins; else BARO_NO_WORKTREES disables it
-    // without needing the Rust CLI flag plumbing; else on by default.
-    const worktreesEnabled = config.withWorktrees ?? !process.env.BARO_NO_WORKTREES
+    // Escape hatch: explicit config wins; else the presence of
+    // BARO_NO_WORKTREES disables it (NO_COLOR-style — set to ANY value,
+    // including empty, to turn worktrees off) without needing Rust CLI flag
+    // plumbing; else on by default.
+    const worktreesEnabled =
+        config.withWorktrees ?? !("BARO_NO_WORKTREES" in process.env)
     const worktrees =
         useGit && worktreesEnabled
             ? new WorktreeManager(config.cwd, gitGate, runId, {

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -21,6 +21,7 @@ import {
     isInsideGitRepo,
     safePullRebase,
 } from "./git.js"
+import { WorktreeManager } from "./worktree.js"
 import { buildDag } from "./dag.js"
 import { Auditor } from "./participants/auditor.js"
 import {
@@ -126,6 +127,18 @@ export interface OrchestrateConfig {
      * Set to 0 to disable staggering.
      */
     intraLevelDelaySecs?: number
+    /**
+     * Run each story in its own git worktree (issue #50) instead of a shared
+     * working tree. Default: true when git lifecycle is on. Set false to keep
+     * the old shared-tree behaviour.
+     */
+    withWorktrees?: boolean
+    /**
+     * Symlink dependency dirs (node_modules, …) from the repo root into each
+     * story worktree so builds/tests resolve. Default: true. Only relevant
+     * when withWorktrees is on.
+     */
+    worktreeLinkDepDirs?: boolean
     /**
      * Which LLM provider drives the agents. `"claude"` (the current
      * default) uses the Claude Code CLI for Architect, Planner,
@@ -352,6 +365,25 @@ export async function orchestrate(
     const gitGate = new GitGate()
     let baseSha: string | null = null
 
+    // Unique per-run id, shared by the memory session path and the per-story
+    // worktree branch/dir names so concurrent runs and resumes never collide.
+    const runId = `run-${Date.now()}-${process.pid}`
+
+    // Escape hatch: explicit config wins; else BARO_NO_WORKTREES disables it
+    // without needing the Rust CLI flag plumbing; else on by default.
+    const worktreesEnabled = config.withWorktrees ?? !process.env.BARO_NO_WORKTREES
+    const worktrees =
+        useGit && worktreesEnabled
+            ? new WorktreeManager(config.cwd, gitGate, runId, {
+                  linkDepDirs: config.worktreeLinkDepDirs ?? true,
+                  onLog: (line) =>
+                      emitTui && emit({ type: "story_log", id: "_git", line }),
+              })
+            : null
+    // Story pushes run off the Conductor's critical path (see onStoryPassed);
+    // awaited before the run finishes so no push is lost.
+    const storyPushes: Promise<void>[] = []
+
     // Phase-2 observers — Librarian (cross-agent memory) and Sentry
     // (file conflict detection). Both default ON; either can be turned
     // off via the OrchestrateConfig flags.
@@ -364,7 +396,7 @@ export async function orchestrate(
     // Include PID to prevent collision if two orchestrators start simultaneously.
     const sessionsDir = join(process.env.HOME || "/tmp", ".baro", "sessions")
     const memorySessionPath = useMemory
-        ? join(sessionsDir, `run-${Date.now()}-${process.pid}`, "memory")
+        ? join(sessionsDir, runId, "memory")
         : undefined
 
     // Prune stale session directories (>24h old) to prevent unbounded growth.
@@ -527,6 +559,7 @@ export async function orchestrate(
                           (line) => emitTui && emit({ type: "story_log", id: "_git", line }),
                       )
                   }
+                  await worktrees?.cleanupStaleOnStart()
               }
             : undefined,
         onBeforeStoryLaunch: librarian
@@ -542,38 +575,54 @@ export async function orchestrate(
             : undefined,
         onStoryPassed: useGit
             ? async (storyId) => {
-                  await safePullRebase(
-                      config.cwd,
-                      (line) =>
-                          emitTui && emit({ type: "story_log", id: storyId, line }),
-                      gitGate,
-                  )
-                  try {
-                      await gitPushWithRetry(gitGate, {
-                          cwd: config.cwd,
-                          onLog: (line) =>
-                              emitTui &&
-                              emit({ type: "story_log", id: storyId, line }),
-                      })
-                      if (emitTui) {
-                          emit({
-                              type: "push_status",
-                              id: storyId,
-                              success: true,
-                              error: null,
-                          })
-                      }
-                  } catch (e) {
-                      if (emitTui) {
-                          emit({
-                              type: "push_status",
-                              id: storyId,
-                              success: false,
-                              error: (e as Error)?.message ?? String(e),
-                          })
+                  const log = (line: string) =>
+                      emitTui && emit({ type: "story_log", id: storyId, line })
+                  // Merge the story into the run branch on the critical path
+                  // (fast, local) so the next DAG level sees it. mergeBack
+                  // returns false when the story had no worktree (create()
+                  // fell back to the shared tree) — that story still needs the
+                  // shared-tree remote reconciliation.
+                  let merged = false
+                  if (worktrees) {
+                      try {
+                          merged = await worktrees.mergeBack(storyId)
+                      } catch (e) {
+                          // Unresolvable merge: keep the worktree + branch so
+                          // the passed work can be recovered, don't push/clean.
+                          log(`[git] merge-back failed; worktree preserved for recovery: ${(e as Error)?.message ?? String(e)}`)
+                          if (emitTui) {
+                              emit({ type: "push_status", id: storyId, success: false, error: (e as Error)?.message ?? String(e) })
+                          }
+                          return
                       }
                   }
+                  if (!merged) {
+                      await safePullRebase(config.cwd, log, gitGate)
+                  }
+                  // Push + worktree cleanup run off the Conductor's critical
+                  // path: a slow network push must not stall other stories'
+                  // merge-backs or slot freeing. gitGate still serializes the
+                  // actual push; orchestrate awaits storyPushes before finishing.
+                  storyPushes.push(
+                      (async () => {
+                          try {
+                              await gitPushWithRetry(gitGate, { cwd: config.cwd, onLog: log })
+                              if (emitTui) {
+                                  emit({ type: "push_status", id: storyId, success: true, error: null })
+                              }
+                          } catch (e) {
+                              if (emitTui) {
+                                  emit({ type: "push_status", id: storyId, success: false, error: (e as Error)?.message ?? String(e) })
+                              }
+                          } finally {
+                              if (merged) await worktrees?.cleanup(storyId)
+                          }
+                      })(),
+                  )
               }
+            : undefined,
+        onStoryFailed: worktrees
+            ? (storyId) => worktrees.cleanup(storyId)
             : undefined,
     })
     conductor.setEnvironment(env)
@@ -589,6 +638,7 @@ export async function orchestrate(
     // per-spawn, so future per-story overrides could live there too.
     const storyFactory = new StoryFactory({
         cwd: config.cwd,
+        worktrees: worktrees ?? undefined,
         llm: storyLlm,
         openaiModel: config.storyModel ?? "gpt-5.5",
         storyModelOverride: config.storyModel,
@@ -629,6 +679,14 @@ export async function orchestrate(
         RunStartRequest.create({ reason: "orchestrate" }),
     )
     const summary = await conductor.done
+
+    // Drain detached story pushes (and their worktree cleanups) before the
+    // backstop sweep, so no push is abandoned mid-flight.
+    await Promise.allSettled(storyPushes)
+
+    // Backstop: per-story worktrees are removed as each story settles, but
+    // sweep any stragglers + the temp dir + dangling branches here.
+    await worktrees?.cleanupAll()
 
     // Drain in-flight async observers so all side effects (CritiqueItem,
     // ReplanItem) land in the audit log before this function returns.

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -380,9 +380,14 @@ export async function orchestrate(
                       emitTui && emit({ type: "story_log", id: "_git", line }),
               })
             : null
-    // Story pushes run off the Conductor's critical path (see onStoryPassed);
-    // awaited before the run finishes so no push is lost.
+    // Fallback/non-worktree story pushes run off the Conductor's critical
+    // path (see onStoryPassed); awaited before the run finishes so none is
+    // lost. Worktree merge-backs accumulate on the LOCAL run branch and are
+    // pushed once at the end (worktreePushNeeded) instead — a per-story push
+    // would re-stall the Conductor, since it shares gitGate with the
+    // on-critical-path merge-back.
     const storyPushes: Promise<void>[] = []
+    let worktreePushNeeded = false
 
     // Phase-2 observers — Librarian (cross-agent memory) and Sentry
     // (file conflict detection). Both default ON; either can be turned
@@ -582,8 +587,8 @@ export async function orchestrate(
                   // returns false when the story had no worktree (create()
                   // fell back to the shared tree) — that story still needs the
                   // shared-tree remote reconciliation.
-                  let merged = false
                   if (worktrees) {
+                      let merged = false
                       try {
                           merged = await worktrees.mergeBack(storyId)
                       } catch (e) {
@@ -595,14 +600,21 @@ export async function orchestrate(
                           }
                           return
                       }
+                      if (merged) {
+                          // Cleanup is fast + local; the run branch is pushed
+                          // once after the run (worktreePushNeeded) so this
+                          // critical-path callback never waits on the network.
+                          await worktrees.cleanup(storyId)
+                          worktreePushNeeded = true
+                          if (emitTui) {
+                              emit({ type: "push_status", id: storyId, success: true, error: null })
+                          }
+                          return
+                      }
+                      // merged === false → story fell back to the shared tree;
+                      // reconcile + push it like the non-worktree path below.
                   }
-                  if (!merged) {
-                      await safePullRebase(config.cwd, log, gitGate)
-                  }
-                  // Push + worktree cleanup run off the Conductor's critical
-                  // path: a slow network push must not stall other stories'
-                  // merge-backs or slot freeing. gitGate still serializes the
-                  // actual push; orchestrate awaits storyPushes before finishing.
+                  await safePullRebase(config.cwd, log, gitGate)
                   storyPushes.push(
                       (async () => {
                           try {
@@ -614,8 +626,6 @@ export async function orchestrate(
                               if (emitTui) {
                                   emit({ type: "push_status", id: storyId, success: false, error: (e as Error)?.message ?? String(e) })
                               }
-                          } finally {
-                              if (merged) await worktrees?.cleanup(storyId)
                           }
                       })(),
                   )
@@ -680,9 +690,23 @@ export async function orchestrate(
     )
     const summary = await conductor.done
 
-    // Drain detached story pushes (and their worktree cleanups) before the
-    // backstop sweep, so no push is abandoned mid-flight.
+    // Drain detached fallback/non-worktree pushes before finishing.
     await Promise.allSettled(storyPushes)
+
+    // Push the accumulated run branch once (worktree merge-backs only touched
+    // the local branch during the run). Done after conductor.done so the slow
+    // network push can't stall the run; before the Finalizer so its PR sees
+    // every commit.
+    if (worktreePushNeeded) {
+        const log = (line: string) =>
+            emitTui && emit({ type: "story_log", id: "_git", line })
+        try {
+            await gitPushWithRetry(gitGate, { cwd: config.cwd, onLog: log })
+            if (emitTui) emit({ type: "push_status", id: "_git", success: true, error: null })
+        } catch (e) {
+            if (emitTui) emit({ type: "push_status", id: "_git", success: false, error: (e as Error)?.message ?? String(e) })
+        }
+    }
 
     // Backstop: per-story worktrees are removed as each story settles, but
     // sweep any stragglers + the temp dir + dangling branches here.

--- a/packages/baro-orchestrator/src/participants/codex-cli-participant.ts
+++ b/packages/baro-orchestrator/src/participants/codex-cli-participant.ts
@@ -52,10 +52,10 @@ export interface CodexCliParticipantOptions {
      * on the CLI. Replaces the deprecated `--full-auto` flag —
      * which was just sandbox=workspace-write + no-approvals, but
      * workspace-write blocks writes to `.git/` so the agent can't
-     * commit. Baro story workers run in per-story git worktrees
-     * (already isolated from the rest of the filesystem) so the
-     * "danger" is bounded; the agent NEEDS .git/ writes to land
-     * commits and let Finalizer push.
+     * commit. Baro story workers run in a per-story git worktree
+     * (WorktreeManager, #50) — an isolated tree merged back only on
+     * success — so the "danger" is bounded; the agent NEEDS .git/
+     * writes to land commits and let Finalizer push.
      *
      * Default: false. Callers that don't need autonomous .git
      * writes (e.g. read-only probes) should leave it off.
@@ -63,10 +63,10 @@ export interface CodexCliParticipantOptions {
     bypassSandbox?: boolean
     /**
      * If true, pass `--skip-git-repo-check`. Required when the cwd is
-     * not a git repo (Codex refuses to run otherwise). baro's
-     * story workers always run inside per-story git worktrees, so the
-     * default is false — set this only when wiring up tests or one-off
-     * runs from /tmp.
+     * not a git repo (Codex refuses to run otherwise). baro's story
+     * workers run inside a per-story git worktree (a valid git repo), so
+     * the default is false — set this only when wiring up tests or
+     * one-off runs from /tmp.
      */
     skipGitRepoCheck?: boolean
     /** Extra CLI arguments appended after the standard set. */
@@ -248,8 +248,8 @@ export class CodexCliParticipant extends BaseObserver {
             // workspace-write isn't enough — `.git/` is read-only
             // even in workspace-write mode (per openai/codex#15505).
             // baro stories need `.git/` writes to commit, so we go
-            // full bypass and rely on the per-story worktree for
-            // process-level isolation.
+            // full bypass and rely on the per-story worktree (#50) for
+            // isolation.
             args.push("--dangerously-bypass-approvals-and-sandbox")
         }
         if (this.options.model) args.push("--model", this.options.model)

--- a/packages/baro-orchestrator/src/participants/codex-story-agent.ts
+++ b/packages/baro-orchestrator/src/participants/codex-story-agent.ts
@@ -57,15 +57,15 @@ export interface CodexStorySpec {
      * `--dangerously-bypass-approvals-and-sandbox`). Required for
      * autonomous baro runs because Codex's `workspace-write` sandbox
      * mode blocks `.git/` writes — without bypass the agent can't
-     * commit. baro story workers run in per-story git worktrees, so
-     * the "danger" is bounded by worktree isolation.
-     * Default: true.
+     * commit. The "danger" is bounded by the per-story git worktree
+     * (WorktreeManager, #50): the agent's writes land in an isolated
+     * tree that's merged back only on success. Default: true.
      */
     bypassSandbox?: boolean
     /**
-     * Pass `--skip-git-repo-check`. baro story workers always run inside
-     * per-story git worktrees, so the default is false; set this only
-     * when wiring up tests or one-off runs.
+     * Pass `--skip-git-repo-check`. baro story workers run inside a
+     * per-story git worktree (a valid git repo), so the default is false;
+     * set this only when wiring up tests or one-off runs.
      */
     skipGitRepoCheck?: boolean
 }

--- a/packages/baro-orchestrator/src/participants/conductor.ts
+++ b/packages/baro-orchestrator/src/participants/conductor.ts
@@ -75,6 +75,12 @@ export interface ConductorOptions {
     defaultModel?: string
     promptTemplatePath?: string
     onStoryPassed?: (storyId: string) => Promise<void> | void
+    /**
+     * Called when a story fails terminally (after its retries). Used to
+     * discard the story's isolated worktree + branch (#50) without merging.
+     * Awaited so cleanup completes before the level boundary advances.
+     */
+    onStoryFailed?: (storyId: string) => Promise<void> | void
     onRunStart?: (prd: PrdFile) => Promise<void> | void
     onBeforeStoryLaunch?: (
         storyId: string,
@@ -185,6 +191,15 @@ export class Conductor extends BaseObserver {
     public readonly done: Promise<ConductorRunSummary>
     private resolveDone!: (summary: ConductorRunSummary) => void
 
+    /**
+     * Serializes event handling. Mozaik delivers events without awaiting the
+     * handler, so two StoryResults settling together could interleave — one
+     * spawning the next DAG level while another's `await onStoryPassed`
+     * (worktree merge-back, #50) is still in flight, leaving the dependent
+     * level without the merged work. Chaining handlers keeps them sequential.
+     */
+    private handleChain: Promise<void> = Promise.resolve()
+
     constructor(opts: ConductorOptions) {
         super()
         this.opts = {
@@ -229,7 +244,16 @@ export class Conductor extends BaseObserver {
         await this.handle(event)
     }
 
-    private async handle(event: SemanticEvent<unknown>): Promise<void> {
+    private handle(event: SemanticEvent<unknown>): Promise<void> {
+        // Run strictly after any in-flight handler. `.catch` on the stored
+        // chain keeps one handler's failure from poisoning the queue while
+        // still surfacing the rejection to this call's awaiter.
+        const run = this.handleChain.then(() => this.handleEvent(event))
+        this.handleChain = run.catch(() => {})
+        return run
+    }
+
+    private async handleEvent(event: SemanticEvent<unknown>): Promise<void> {
         if (RunStartRequest.is(event)) {
             await this.handleRunStart()
             return
@@ -409,6 +433,20 @@ export class Conductor extends BaseObserver {
         } else {
             this.currentLevel.failed.push(item.storyId)
             this.addGlobalFailed(item.storyId)
+            if (this.opts.onStoryFailed) {
+                try {
+                    await this.opts.onStoryFailed(item.storyId)
+                } catch (e) {
+                    this.emit(
+                        ConductorState.create({
+                            phase: "running_level",
+                            detail: `onStoryFailed hook for ${item.storyId} failed: ${(e as Error)?.message ?? String(e)}`,
+                            currentLevel: this.currentLevel.ordinal,
+                            totalLevels: this.currentLevel.totalLevelsHint,
+                        }),
+                    )
+                }
+            }
         }
 
         // Try to fill freed parallel slots with queued stories.

--- a/packages/baro-orchestrator/src/participants/sentry.ts
+++ b/packages/baro-orchestrator/src/participants/sentry.ts
@@ -14,6 +14,10 @@
  * we can prove the architecture works and measure how often it fires
  * in real runs.
  *
+ * Since per-story worktree isolation (#50), an overlap no longer means a
+ * live shared-tree collision — each agent writes its own worktree — but
+ * predicts a likely merge-back conflict, so the notice is still useful.
+ *
  * Library-grade: no PRD knowledge.
  */
 

--- a/packages/baro-orchestrator/src/participants/story-factory.ts
+++ b/packages/baro-orchestrator/src/participants/story-factory.ts
@@ -140,9 +140,20 @@ export class StoryFactory extends BaseObserver {
         if (!this.envRef) return
         // Idempotent across both the settled set and the in-progress set:
         // spawn awaits worktree creation, so a duplicate request must not slip
-        // through that window and create a second worktree + agent.
+        // through that window and create a second worktree + agent. The
+        // finally clears the in-progress marker even if construction throws,
+        // so a later recovery respawn of this story isn't blocked forever.
         if (this.active.has(req.storyId) || this.spawning.has(req.storyId)) return
         this.spawning.add(req.storyId)
+        try {
+            await this.buildAndLaunch(req)
+        } finally {
+            this.spawning.delete(req.storyId)
+        }
+    }
+
+    private async buildAndLaunch(req: StorySpawnRequestData): Promise<void> {
+        if (!this.envRef) return
 
         // Resolve which backend + model THIS story runs on. The route
         // can come from the story's own `model` field (a bare tier name
@@ -228,7 +239,6 @@ export class StoryFactory extends BaseObserver {
 
         agent.join(this.envRef)
         this.active.set(req.storyId, agent)
-        this.spawning.delete(req.storyId)
 
         // The agent's run() returns a Promise but we don't await it
         // here — the StoryResult event will arrive on the bus when it

--- a/packages/baro-orchestrator/src/participants/story-factory.ts
+++ b/packages/baro-orchestrator/src/participants/story-factory.ts
@@ -34,9 +34,15 @@ import {
     type EndpointMap,
     type TierMap,
 } from "../routing.js"
+import type { WorktreeManager } from "../worktree.js"
 
 export interface StoryFactoryOptions {
     cwd: string
+    /**
+     * When set, each story runs in its own isolated git worktree instead of
+     * the shared `cwd` (issue #50). create() falls back to `cwd` on failure.
+     */
+    worktrees?: WorktreeManager
     /**
      * Which LLM provider every story uses.
      *   "claude"  — StoryAgent wrapping a `claude` CLI subprocess
@@ -99,6 +105,8 @@ export class StoryFactory extends BaseObserver {
         string,
         StoryAgent | OpenAIStoryAgent | CodexStoryAgent | OpenCodeStoryAgent | PiStoryAgent
     > = new Map()
+    /** Story ids whose spawn is in progress (closes the await-create window). */
+    private readonly spawning = new Set<string>()
 
     constructor(private readonly opts: StoryFactoryOptions) {
         super()
@@ -130,7 +138,11 @@ export class StoryFactory extends BaseObserver {
 
     private async spawn(req: StorySpawnRequestData): Promise<void> {
         if (!this.envRef) return
-        if (this.active.has(req.storyId)) return // idempotent
+        // Idempotent across both the settled set and the in-progress set:
+        // spawn awaits worktree creation, so a duplicate request must not slip
+        // through that window and create a second worktree + agent.
+        if (this.active.has(req.storyId) || this.spawning.has(req.storyId)) return
+        this.spawning.add(req.storyId)
 
         // Resolve which backend + model THIS story runs on. The route
         // can come from the story's own `model` field (a bare tier name
@@ -153,12 +165,17 @@ export class StoryFactory extends BaseObserver {
                 "\n",
         )
 
+        // Per-story worktree isolation (#50); falls back to the shared cwd.
+        const storyCwd = this.opts.worktrees
+            ? (await this.opts.worktrees.create(req.storyId)) ?? this.opts.cwd
+            : this.opts.cwd
+
         const agent: StoryAgent | OpenAIStoryAgent | CodexStoryAgent | OpenCodeStoryAgent | PiStoryAgent =
             route.backend === "pi"
                 ? new PiStoryAgent({
                       id: req.storyId,
                       prompt: req.prompt,
-                      cwd: this.opts.cwd,
+                      cwd: storyCwd,
                       model: route.model,
                       retries: req.retries,
                       timeoutSecs: req.timeoutSecs,
@@ -167,7 +184,7 @@ export class StoryFactory extends BaseObserver {
                 ? new OpenCodeStoryAgent({
                       id: req.storyId,
                       prompt: req.prompt,
-                      cwd: this.opts.cwd,
+                      cwd: storyCwd,
                       model: route.model,
                       retries: req.retries,
                       timeoutSecs: req.timeoutSecs,
@@ -176,7 +193,7 @@ export class StoryFactory extends BaseObserver {
                     ? new CodexStoryAgent({
                           id: req.storyId,
                           prompt: req.prompt,
-                          cwd: this.opts.cwd,
+                          cwd: storyCwd,
                           // undefined → let Codex pick its account default.
                           model: route.model,
                           retries: req.retries,
@@ -187,7 +204,7 @@ export class StoryFactory extends BaseObserver {
                               {
                                   id: req.storyId,
                                   prompt: req.prompt,
-                                  cwd: this.opts.cwd,
+                                  cwd: storyCwd,
                                   model: route.model,
                                   retries: req.retries,
                                   timeoutSecs: req.timeoutSecs,
@@ -201,7 +218,7 @@ export class StoryFactory extends BaseObserver {
                         : new StoryAgent({
                               id: req.storyId,
                               prompt: req.prompt,
-                              cwd: this.opts.cwd,
+                              cwd: storyCwd,
                               // undefined → StoryAgent applies its own default.
                               model: route.model,
                               effort: this.opts.effort,
@@ -211,6 +228,7 @@ export class StoryFactory extends BaseObserver {
 
         agent.join(this.envRef)
         this.active.set(req.storyId, agent)
+        this.spawning.delete(req.storyId)
 
         // The agent's run() returns a Promise but we don't await it
         // here — the StoryResult event will arrive on the bus when it

--- a/packages/baro-orchestrator/src/worktree.ts
+++ b/packages/baro-orchestrator/src/worktree.ts
@@ -249,7 +249,8 @@ export class WorktreeManager {
     /**
      * Commit work the agent edited but didn't commit, so it isn't lost on
      * cleanup (passing is signalled by the agent, not by a commit existing).
-     * `git add -A` respects .gitignore, so symlinked node_modules etc. are safe.
+     * Never commits the symlinked dep dirs, and surfaces a warning rather than
+     * silently dropping work if any git step fails.
      */
     private async autoCommitLeftovers(
         storyId: string,
@@ -265,28 +266,52 @@ export class WorktreeManager {
             return
         }
         if (!dirty) return
+
+        // Stage all non-ignored work. No pathspec (so the exit code reflects
+        // real failures, not the benign "some paths are gitignored" advice
+        // that an explicit `.` pathspec triggers); .gitignore already keeps
+        // node_modules out in the common case.
+        try {
+            await exec("git", ["add", "-A"], { cwd: worktreePath })
+        } catch (e) {
+            this.log(
+                `WARNING: failed to stage story ${storyId}'s leftover work ` +
+                    `(${errMsg(e)}); it will not be included in the merge`,
+            )
+            return
+        }
+        // Belt for repos that DON'T gitignore the dep dirs: unstage them so
+        // their absolute-path symlinks never get committed.
+        await execQuiet("git", ["reset", "-q", "--", ...LINKED_DEP_DIRS], worktreePath)
+
+        let staged: string[] = []
+        try {
+            const { stdout } = await exec("git", ["diff", "--cached", "--name-only"], {
+                cwd: worktreePath,
+            })
+            staged = stdout.split("\n").map((l) => l.trim()).filter(Boolean)
+        } catch {
+            /* treat as nothing staged */
+        }
+        // If the reset didn't drop a dep dir, refuse to commit a broken symlink.
+        const depStaged = staged.filter((p) =>
+            LINKED_DEP_DIRS.some((d) => p === d || p.startsWith(`${d}/`)),
+        )
+        if (depStaged.length > 0) {
+            this.log(
+                `WARNING: could not keep dep dirs [${depStaged.join(", ")}] out of ` +
+                    `story ${storyId}'s auto-commit; skipping it to avoid committing symlinks`,
+            )
+            await execQuiet("git", ["reset", "-q"], worktreePath)
+            return
+        }
+        // Only a dep dir was dirty → nothing real to commit (benign).
+        if (staged.length === 0) return
+
         this.log(
             `WARNING: story ${storyId} passed with uncommitted changes; ` +
-                `auto-committing them before merge`,
+                `auto-committing ${staged.length} path(s) before merge`,
         )
-        // Stage everything EXCEPT the symlinked dep dirs (excluded at the add
-        // step, not a follow-up reset, so a silent reset failure can't leave a
-        // broken absolute-path symlink staged even if the repo doesn't ignore
-        // node_modules).
-        await execQuiet(
-            "git",
-            ["add", "-A", "--", ".", ...LINKED_DEP_DIRS.map((d) => `:(exclude)${d}`)],
-            worktreePath,
-        )
-        // Nothing staged (e.g. the only dirty entry was a dep-dir symlink we
-        // excluded) → benign, nothing to commit.
-        let hasStaged = false
-        try {
-            await exec("git", ["diff", "--cached", "--quiet"], { cwd: worktreePath })
-        } catch {
-            hasStaged = true
-        }
-        if (!hasStaged) return
         try {
             await exec(
                 "git",
@@ -294,8 +319,8 @@ export class WorktreeManager {
                 { cwd: worktreePath },
             )
         } catch (e) {
-            // Surface a real commit failure: the leftover work would otherwise
-            // be silently dropped (the branch is merged without it).
+            // Surface a real commit failure: the work would otherwise be
+            // silently dropped (the branch merges without it).
             this.log(
                 `WARNING: failed to auto-commit story ${storyId}'s leftover work ` +
                     `(${errMsg(e)}); it will not be included in the merge`,

--- a/packages/baro-orchestrator/src/worktree.ts
+++ b/packages/baro-orchestrator/src/worktree.ts
@@ -129,7 +129,7 @@ export class WorktreeManager {
                 // Any first-merge failure (content, modify/delete, rename, …)
                 // → abort and retry favouring the merging story.
                 const conflicts = await this.conflictedPaths()
-                await execQuiet("git", ["merge", "--abort"], this.repoRoot)
+                await this.abortMerge(storyId)
                 this.log(
                     `WARNING: story ${storyId} conflicts with already-merged work` +
                         (conflicts.length ? ` on [${conflicts.join(", ")}]` : "") +
@@ -143,7 +143,7 @@ export class WorktreeManager {
                     )
                     return true
                 } catch (e) {
-                    await execQuiet("git", ["merge", "--abort"], this.repoRoot)
+                    await this.abortMerge(storyId)
                     // Keep the branch out of the cleanup sweep so its commits
                     // survive the run and stay recoverable.
                     this.preserved.add(storyId)
@@ -154,6 +154,22 @@ export class WorktreeManager {
             }
         } finally {
             release()
+        }
+    }
+
+    /**
+     * Abort an in-progress merge, logging if the abort itself fails. A
+     * lingering MERGE_HEAD (e.g. a held index.lock) would otherwise make the
+     * NEXT story's merge fail and be misdiagnosed against the wrong story.
+     */
+    private async abortMerge(storyId: string): Promise<void> {
+        try {
+            await exec("git", ["merge", "--abort"], { cwd: this.repoRoot })
+        } catch (e) {
+            this.log(
+                `WARNING: 'git merge --abort' failed after story ${storyId} ` +
+                    `(${errMsg(e)}); run branch may have a lingering MERGE_HEAD`,
+            )
         }
     }
 
@@ -285,13 +301,21 @@ export class WorktreeManager {
         await execQuiet("git", ["reset", "-q", "--", ...LINKED_DEP_DIRS], worktreePath)
 
         let staged: string[] = []
+        let diffFailed = false
         try {
             const { stdout } = await exec("git", ["diff", "--cached", "--name-only"], {
                 cwd: worktreePath,
             })
             staged = stdout.split("\n").map((l) => l.trim()).filter(Boolean)
-        } catch {
-            /* treat as nothing staged */
+        } catch (e) {
+            // Don't treat an unreadable index as "nothing staged" — that would
+            // silently skip the commit and drop the work. Warn and commit
+            // whatever is staged instead (dep dirs were already reset above).
+            diffFailed = true
+            this.log(
+                `WARNING: could not inspect staged changes for story ${storyId} ` +
+                    `(${errMsg(e)}); committing whatever is staged`,
+            )
         }
         // If the reset didn't drop a dep dir, refuse to commit a broken symlink.
         const depStaged = staged.filter((p) =>
@@ -305,12 +329,14 @@ export class WorktreeManager {
             await execQuiet("git", ["reset", "-q"], worktreePath)
             return
         }
-        // Only a dep dir was dirty → nothing real to commit (benign).
-        if (staged.length === 0) return
+        // Only a dep dir was dirty → nothing real to commit (benign). When the
+        // diff couldn't be read we don't know, so fall through and let the
+        // commit (or its "nothing to commit" failure) decide.
+        if (!diffFailed && staged.length === 0) return
 
         this.log(
             `WARNING: story ${storyId} passed with uncommitted changes; ` +
-                `auto-committing ${staged.length} path(s) before merge`,
+                `auto-committing ${diffFailed ? "" : `${staged.length} path(s) `}before merge`,
         )
         try {
             await exec(

--- a/packages/baro-orchestrator/src/worktree.ts
+++ b/packages/baro-orchestrator/src/worktree.ts
@@ -42,6 +42,8 @@ export interface WorktreeManagerOptions {
  */
 export class WorktreeManager {
     private readonly paths = new Map<string, string>()
+    /** Stories whose merge-back failed: their branch is kept for recovery. */
+    private readonly preserved = new Set<string>()
     private readonly baseDir: string
     private readonly linkDepDirs: boolean
     private readonly log: (line: string) => void
@@ -142,6 +144,9 @@ export class WorktreeManager {
                     return true
                 } catch (e) {
                     await execQuiet("git", ["merge", "--abort"], this.repoRoot)
+                    // Keep the branch out of the cleanup sweep so its commits
+                    // survive the run and stay recoverable.
+                    this.preserved.add(storyId)
                     throw new Error(
                         `could not merge story ${storyId} even with -X theirs: ${errMsg(e)}`,
                     )
@@ -168,13 +173,25 @@ export class WorktreeManager {
         }
     }
 
-    /** Remove every worktree + branch this manager created, plus its temp dir. */
+    /**
+     * Remove every worktree this manager created, plus its temp dir. Branches
+     * are deleted too — EXCEPT those marked preserved (an unresolvable
+     * merge-back): their worktree dir is freed but the branch ref is kept so
+     * the commits stay recoverable after the run.
+     */
     async cleanupAll(): Promise<void> {
         const release = await this.gate.acquire()
         try {
             for (const [storyId, path] of this.paths) {
                 await this.removeWorktreeQuiet(path)
-                await this.deleteBranchQuiet(this.branchOf(storyId))
+                if (this.preserved.has(storyId)) {
+                    this.log(
+                        `kept branch ${this.branchOf(storyId)} for recovery ` +
+                            `(merge-back failed); inspect with: git log ${this.branchOf(storyId)}`,
+                    )
+                } else {
+                    await this.deleteBranchQuiet(this.branchOf(storyId))
+                }
             }
             this.paths.clear()
             await execQuiet("git", ["worktree", "prune"], this.repoRoot)
@@ -261,11 +278,29 @@ export class WorktreeManager {
             ["add", "-A", "--", ".", ...LINKED_DEP_DIRS.map((d) => `:(exclude)${d}`)],
             worktreePath,
         )
-        await execQuiet(
-            "git",
-            ["commit", "-m", `baro: auto-commit uncommitted work for story ${storyId}`],
-            worktreePath,
-        )
+        // Nothing staged (e.g. the only dirty entry was a dep-dir symlink we
+        // excluded) → benign, nothing to commit.
+        let hasStaged = false
+        try {
+            await exec("git", ["diff", "--cached", "--quiet"], { cwd: worktreePath })
+        } catch {
+            hasStaged = true
+        }
+        if (!hasStaged) return
+        try {
+            await exec(
+                "git",
+                ["commit", "-m", `baro: auto-commit uncommitted work for story ${storyId}`],
+                { cwd: worktreePath },
+            )
+        } catch (e) {
+            // Surface a real commit failure: the leftover work would otherwise
+            // be silently dropped (the branch is merged without it).
+            this.log(
+                `WARNING: failed to auto-commit story ${storyId}'s leftover work ` +
+                    `(${errMsg(e)}); it will not be included in the merge`,
+            )
+        }
     }
 
     private async conflictedPaths(): Promise<string[]> {

--- a/packages/baro-orchestrator/src/worktree.ts
+++ b/packages/baro-orchestrator/src/worktree.ts
@@ -1,0 +1,324 @@
+/**
+ * Per-story git worktree isolation (issue #50). Each story runs in its own
+ * `git worktree` on branch `baro-wt/<runId>/<storyId>` off the run-branch
+ * HEAD, commits in isolation, and merges back onto the run branch on success.
+ * Replaces the old shared-tree behaviour where parallel `git add -A` swept up
+ * siblings' in-flight edits.
+ *
+ * All state-mutating ops acquire the shared {@link GitGate} so they never race
+ * the per-story push/pull in git.ts. Agent commits inside a worktree touch
+ * only that worktree's private index and need no serialization.
+ */
+
+import { execFile } from "child_process"
+import { existsSync, rmSync, symlinkSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { promisify } from "util"
+
+import { GitGate } from "./git.js"
+
+const exec = promisify(execFile)
+
+// A fresh worktree only checks out git-tracked files, so it has no
+// node_modules. Symlink these dependency dirs from the repo root (best-effort)
+// so builds/tests resolve; they're read-mostly, so sharing is safe.
+const LINKED_DEP_DIRS = ["node_modules", ".venv", "vendor"] as const
+
+export interface WorktreeManagerOptions {
+    /** Symlink dependency dirs (node_modules, …) into each worktree. Default true. */
+    linkDepDirs?: boolean
+    /** Diagnostic logger (defaults to stderr). */
+    onLog?: (line: string) => void
+}
+
+/**
+ * Manages the lifecycle of per-story git worktrees for a single run.
+ * One instance per orchestrate() call; the run id scopes branch + dir names
+ * so concurrent runs never collide. (Crashed prior runs leave their worktree
+ * dirs behind; `git worktree prune` reclaims their admin entries once the
+ * dirs are gone, but their branch refs are not swept — they're inert and
+ * harmless since each run uses a fresh id.)
+ */
+export class WorktreeManager {
+    private readonly paths = new Map<string, string>()
+    private readonly baseDir: string
+    private readonly linkDepDirs: boolean
+    private readonly log: (line: string) => void
+
+    constructor(
+        private readonly repoRoot: string,
+        private readonly gate: GitGate,
+        private readonly runId: string,
+        opts: WorktreeManagerOptions = {},
+    ) {
+        this.baseDir = join(tmpdir(), "baro-worktrees", runId)
+        this.linkDepDirs = opts.linkDepDirs ?? true
+        this.log =
+            opts.onLog ?? ((line) => process.stderr.write(`[worktree] ${line}\n`))
+    }
+
+    private branchOf(storyId: string): string {
+        return `baro-wt/${this.runId}/${sanitize(storyId)}`
+    }
+
+    private pathOf(storyId: string): string {
+        return join(this.baseDir, sanitize(storyId))
+    }
+
+    /**
+     * Create an isolated worktree for a story, branched off the current
+     * run-branch HEAD. Returns the worktree path, or null on any failure so
+     * the caller can fall back to the shared repo cwd (preserving the old
+     * behavior rather than failing the story).
+     */
+    async create(storyId: string): Promise<string | null> {
+        const release = await this.gate.acquire()
+        try {
+            const branch = this.branchOf(storyId)
+            const path = this.pathOf(storyId)
+            // Defensive: a leftover dir/branch from a crash would make
+            // `worktree add` fail. Best-effort clear before adding.
+            await this.removeWorktreeQuiet(path)
+            await this.deleteBranchQuiet(branch)
+
+            await exec(
+                "git",
+                ["worktree", "add", "-b", branch, path, "HEAD"],
+                { cwd: this.repoRoot },
+            )
+            this.paths.set(storyId, path)
+            if (this.linkDepDirs) this.symlinkDepDirs(path)
+            this.log(`created ${branch} at ${path}`)
+            return path
+        } catch (e) {
+            this.log(
+                `could not create worktree for ${storyId} (${errMsg(e)}); ` +
+                    `falling back to shared tree`,
+            )
+            return null
+        } finally {
+            release()
+        }
+    }
+
+    /**
+     * Merge a passed story's branch onto the run branch. Returns true if a
+     * worktree merge happened, false if the story had no worktree (create()
+     * fell back to the shared tree). On any merge failure, retries once with
+     * `-X theirs` (the merging story wins). Throws — leaving the run branch
+     * clean (`merge --abort`) — only when even that can't resolve it; the
+     * caller must then preserve the branch rather than discard the work.
+     */
+    async mergeBack(storyId: string): Promise<boolean> {
+        const path = this.paths.get(storyId)
+        if (!path) return false
+        const branch = this.branchOf(storyId)
+        const release = await this.gate.acquire()
+        try {
+            await this.autoCommitLeftovers(storyId, path)
+            const msg = `baro: merge story ${storyId}`
+            try {
+                await exec("git", ["merge", "--no-ff", "-m", msg, branch], {
+                    cwd: this.repoRoot,
+                })
+                return true
+            } catch {
+                // Any first-merge failure (content, modify/delete, rename, …)
+                // → abort and retry favouring the merging story.
+                const conflicts = await this.conflictedPaths()
+                await execQuiet("git", ["merge", "--abort"], this.repoRoot)
+                this.log(
+                    `WARNING: story ${storyId} conflicts with already-merged work` +
+                        (conflicts.length ? ` on [${conflicts.join(", ")}]` : "") +
+                        `; auto-resolving with -X theirs (this story wins)`,
+                )
+                try {
+                    await exec(
+                        "git",
+                        ["merge", "--no-ff", "-X", "theirs", "-m", msg, branch],
+                        { cwd: this.repoRoot },
+                    )
+                    return true
+                } catch (e) {
+                    await execQuiet("git", ["merge", "--abort"], this.repoRoot)
+                    throw new Error(
+                        `could not merge story ${storyId} even with -X theirs: ${errMsg(e)}`,
+                    )
+                }
+            }
+        } finally {
+            release()
+        }
+    }
+
+    /** Remove a story's worktree + branch (after merge-back, or on failure). */
+    async cleanup(storyId: string): Promise<void> {
+        const path = this.paths.get(storyId)
+        const branch = this.branchOf(storyId)
+        const release = await this.gate.acquire()
+        try {
+            if (path) {
+                await this.removeWorktreeQuiet(path)
+                this.paths.delete(storyId)
+            }
+            await this.deleteBranchQuiet(branch)
+        } finally {
+            release()
+        }
+    }
+
+    /** Remove every worktree + branch this manager created, plus its temp dir. */
+    async cleanupAll(): Promise<void> {
+        const release = await this.gate.acquire()
+        try {
+            for (const [storyId, path] of this.paths) {
+                await this.removeWorktreeQuiet(path)
+                await this.deleteBranchQuiet(this.branchOf(storyId))
+            }
+            this.paths.clear()
+            await execQuiet("git", ["worktree", "prune"], this.repoRoot)
+            rmSyncQuiet(this.baseDir)
+        } finally {
+            release()
+        }
+    }
+
+    /**
+     * Reclaim worktree admin entries whose dirs are already gone
+     * (`git worktree prune`) and delete any branches under THIS run id
+     * (defensive re-entrancy guard — ids are unique per process, so this
+     * does not touch a concurrent run's worktrees).
+     */
+    async cleanupStaleOnStart(): Promise<void> {
+        const release = await this.gate.acquire()
+        try {
+            await execQuiet("git", ["worktree", "prune"], this.repoRoot)
+            const prefix = `baro-wt/${this.runId}/`
+            let branches: string[] = []
+            try {
+                const { stdout } = await exec(
+                    "git",
+                    ["branch", "--list", `${prefix}*`, "--format=%(refname:short)"],
+                    { cwd: this.repoRoot },
+                )
+                branches = stdout.split("\n").map((l) => l.trim()).filter(Boolean)
+            } catch {
+                /* no matching branches */
+            }
+            for (const branch of branches) {
+                await this.deleteBranchQuiet(branch)
+            }
+        } finally {
+            release()
+        }
+    }
+
+    // ── internals ────────────────────────────────────────────────────
+
+    private symlinkDepDirs(worktreePath: string): void {
+        for (const dir of LINKED_DEP_DIRS) {
+            const src = join(this.repoRoot, dir)
+            const dest = join(worktreePath, dir)
+            if (!existsSync(src) || existsSync(dest)) continue
+            try {
+                symlinkSync(src, dest, "dir")
+            } catch (e) {
+                this.log(`could not symlink ${dir} into worktree (${errMsg(e)})`)
+            }
+        }
+    }
+
+    /**
+     * Commit work the agent edited but didn't commit, so it isn't lost on
+     * cleanup (passing is signalled by the agent, not by a commit existing).
+     * `git add -A` respects .gitignore, so symlinked node_modules etc. are safe.
+     */
+    private async autoCommitLeftovers(
+        storyId: string,
+        worktreePath: string,
+    ): Promise<void> {
+        let dirty = false
+        try {
+            const { stdout } = await exec("git", ["status", "--porcelain"], {
+                cwd: worktreePath,
+            })
+            dirty = stdout.trim().length > 0
+        } catch {
+            return
+        }
+        if (!dirty) return
+        this.log(
+            `WARNING: story ${storyId} passed with uncommitted changes; ` +
+                `auto-committing them before merge`,
+        )
+        await execQuiet("git", ["add", "-A"], worktreePath)
+        // Never commit the symlinked dep dirs, even if the repo doesn't
+        // .gitignore them — they'd land as broken absolute-path symlinks.
+        await execQuiet("git", ["reset", "-q", "--", ...LINKED_DEP_DIRS], worktreePath)
+        await execQuiet(
+            "git",
+            ["commit", "-m", `baro: auto-commit uncommitted work for story ${storyId}`],
+            worktreePath,
+        )
+    }
+
+    private async conflictedPaths(): Promise<string[]> {
+        try {
+            const { stdout } = await exec(
+                "git",
+                ["diff", "--name-only", "--diff-filter=U"],
+                { cwd: this.repoRoot },
+            )
+            return stdout.split("\n").map((l) => l.trim()).filter(Boolean)
+        } catch {
+            return []
+        }
+    }
+
+    private async removeWorktreeQuiet(path: string): Promise<void> {
+        await execQuiet("git", ["worktree", "remove", "--force", path], this.repoRoot)
+        // If git refused (e.g. a still-running subprocess), force-remove the
+        // dir and prune the now-dangling administrative entry.
+        if (existsSync(path)) {
+            rmSyncQuiet(path)
+            await execQuiet("git", ["worktree", "prune"], this.repoRoot)
+        }
+    }
+
+    private async deleteBranchQuiet(branch: string): Promise<void> {
+        await execQuiet("git", ["branch", "-D", branch], this.repoRoot)
+    }
+}
+
+// ── module helpers ───────────────────────────────────────────────────
+
+function sanitize(storyId: string): string {
+    // Story ids are short slugs (S1, S2, …) but guard against anything that
+    // would break a ref name or a path segment.
+    return storyId.replace(/[^A-Za-z0-9._-]/g, "_")
+}
+
+async function execQuiet(
+    cmd: string,
+    args: readonly string[],
+    cwd: string,
+): Promise<void> {
+    try {
+        await exec(cmd, args, { cwd })
+    } catch {
+        /* best-effort */
+    }
+}
+
+function rmSyncQuiet(path: string): void {
+    try {
+        rmSync(path, { recursive: true, force: true })
+    } catch {
+        /* best-effort */
+    }
+}
+
+function errMsg(e: unknown): string {
+    return (e as Error)?.message ?? String(e)
+}

--- a/packages/baro-orchestrator/src/worktree.ts
+++ b/packages/baro-orchestrator/src/worktree.ts
@@ -252,10 +252,15 @@ export class WorktreeManager {
             `WARNING: story ${storyId} passed with uncommitted changes; ` +
                 `auto-committing them before merge`,
         )
-        await execQuiet("git", ["add", "-A"], worktreePath)
-        // Never commit the symlinked dep dirs, even if the repo doesn't
-        // .gitignore them — they'd land as broken absolute-path symlinks.
-        await execQuiet("git", ["reset", "-q", "--", ...LINKED_DEP_DIRS], worktreePath)
+        // Stage everything EXCEPT the symlinked dep dirs (excluded at the add
+        // step, not a follow-up reset, so a silent reset failure can't leave a
+        // broken absolute-path symlink staged even if the repo doesn't ignore
+        // node_modules).
+        await execQuiet(
+            "git",
+            ["add", "-A", "--", ".", ...LINKED_DEP_DIRS.map((d) => `:(exclude)${d}`)],
+            worktreePath,
+        )
         await execQuiet(
             "git",
             ["commit", "-m", `baro: auto-commit uncommitted work for story ${storyId}`],

--- a/packages/baro-orchestrator/test/worktree.test.ts
+++ b/packages/baro-orchestrator/test/worktree.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { GitGate } from "../src/git.js"
+import { WorktreeManager } from "../src/worktree.js"
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+function git(cwd: string, ...args: string[]): string {
+    return execFileSync("git", args, { cwd, encoding: "utf8" }).trim()
+}
+
+/** A git repo with an initial commit (a.txt, .gitignore) on branch `main`. */
+function initRepo(): string {
+    const repo = mkdtempSync(join(tmpdir(), "baro-wt-test-"))
+    git(repo, "init", "-b", "main")
+    git(repo, "config", "user.email", "t@t.t")
+    git(repo, "config", "user.name", "t")
+    writeFileSync(join(repo, "a.txt"), "line1\nline2\nline3\n")
+    writeFileSync(join(repo, ".gitignore"), "node_modules/\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-m", "init")
+    return repo
+}
+
+/** Commit a file into an already-created worktree, as a story agent would. */
+function commitInWorktree(wt: string, file: string, content: string): void {
+    writeFileSync(join(wt, file), content)
+    git(wt, "add", "-A")
+    git(wt, "commit", "-m", `edit ${file}`)
+}
+
+let repo: string
+let gate: GitGate
+let logs: string[]
+let mgr: WorktreeManager
+let runId: string
+let seq = 0
+
+beforeEach(() => {
+    repo = initRepo()
+    gate = new GitGate()
+    logs = []
+    // Unique per test: the worktree base dir lives in the OS tmpdir keyed by
+    // runId, so a shared id would collide across tests (in production the id
+    // is `run-<time>-<pid>`, unique per process).
+    runId = `run-test-${seq++}`
+    mgr = new WorktreeManager(repo, gate, runId, {
+        onLog: (l) => logs.push(l),
+    })
+})
+
+afterEach(async () => {
+    try { await mgr.cleanupAll() } catch { /* */ }
+    try { rmSync(repo, { recursive: true, force: true }) } catch { /* */ }
+})
+
+// ── tests ────────────────────────────────────────────────────────────
+
+describe("WorktreeManager — lifecycle", () => {
+    it("create → worktree + branch off HEAD; mergeBack lands the commit; cleanup removes everything", async () => {
+        const head = git(repo, "rev-parse", "HEAD")
+        const path = await mgr.create("S1")
+        assert.ok(path, "create returned a path")
+        assert.ok(existsSync(path!), "worktree dir exists")
+        assert.equal(git(path!, "rev-parse", "HEAD"), head, "worktree HEAD == repo HEAD")
+        assert.ok(
+            git(repo, "worktree", "list").includes(path!),
+            "git worktree list shows the new worktree",
+        )
+
+        commitInWorktree(path!, "f1.txt", "from S1\n")
+        await mgr.mergeBack("S1")
+
+        assert.ok(existsSync(join(repo, "f1.txt")), "merged file present on run branch")
+        assert.ok(
+            git(repo, "log", "--oneline", "-1").includes("merge story S1"),
+            "merge commit names the story",
+        )
+
+        await mgr.cleanup("S1")
+        assert.ok(!existsSync(path!), "worktree dir removed")
+        assert.ok(!git(repo, "worktree", "list").includes(path!), "worktree pruned")
+        const branches = git(repo, "branch", "--list", `baro-wt/${runId}/S1`)
+        assert.equal(branches, "", "branch deleted")
+    })
+})
+
+describe("WorktreeManager — isolation (#50)", () => {
+    it("parallel stories don't see each other's files until merge-back", async () => {
+        const p1 = (await mgr.create("S1"))!
+        const p2 = (await mgr.create("S2"))!
+
+        commitInWorktree(p1, "f1.txt", "S1\n")
+        commitInWorktree(p2, "f2.txt", "S2\n")
+
+        assert.ok(!existsSync(join(p1, "f2.txt")), "S1's tree does not see S2's file")
+        assert.ok(!existsSync(join(p2, "f1.txt")), "S2's tree does not see S1's file")
+
+        await mgr.mergeBack("S1")
+        await mgr.mergeBack("S2")
+
+        assert.ok(existsSync(join(repo, "f1.txt")), "run branch has S1's file")
+        assert.ok(existsSync(join(repo, "f2.txt")), "run branch has S2's file")
+    })
+
+    it("same file, non-overlapping lines, merges cleanly", async () => {
+        const p1 = (await mgr.create("S1"))!
+        const p2 = (await mgr.create("S2"))!
+        commitInWorktree(p1, "a.txt", "S1edit\nline2\nline3\n")
+        commitInWorktree(p2, "a.txt", "line1\nline2\nS2edit\n")
+
+        await mgr.mergeBack("S1")
+        await mgr.mergeBack("S2")
+
+        const merged = readFileSync(join(repo, "a.txt"), "utf8")
+        assert.ok(merged.includes("S1edit"), "S1's line survived")
+        assert.ok(merged.includes("S2edit"), "S2's line survived")
+    })
+})
+
+describe("WorktreeManager — conflict", () => {
+    it("same-line conflict auto-resolves with -X theirs (merging story wins) and warns", async () => {
+        const p1 = (await mgr.create("S1"))!
+        const p2 = (await mgr.create("S2"))!
+        commitInWorktree(p1, "a.txt", "S1wins\nline2\nline3\n")
+        commitInWorktree(p2, "a.txt", "S2wins\nline2\nline3\n")
+
+        await mgr.mergeBack("S1")
+        await mgr.mergeBack("S2")
+
+        const merged = readFileSync(join(repo, "a.txt"), "utf8")
+        assert.ok(merged.includes("S2wins"), "the merging story (S2) won")
+        assert.ok(!merged.includes("<<<<<<<"), "no conflict markers left")
+        assert.equal(git(repo, "status", "--porcelain"), "", "run branch clean")
+        assert.ok(
+            logs.some((l) => l.includes("conflict") && l.includes("S2")),
+            "a conflict warning was surfaced",
+        )
+    })
+})
+
+describe("WorktreeManager — uncommitted safety net", () => {
+    it("never commits the symlinked dep dirs, even if the repo doesn't gitignore them", async () => {
+        // Repo with NO node_modules ignore + a real root node_modules to link.
+        writeFileSync(join(repo, ".gitignore"), "")
+        git(repo, "commit", "-am", "drop gitignore")
+        mkdirSync(join(repo, "node_modules", "pkg"), { recursive: true })
+        writeFileSync(join(repo, "node_modules", "pkg", "i.js"), "1\n")
+
+        const p1 = (await mgr.create("S1"))!
+        writeFileSync(join(p1, "real.txt"), "real work\n") // uncommitted → triggers safety net
+        await mgr.mergeBack("S1")
+
+        const tracked = git(repo, "ls-files").split("\n")
+        assert.ok(tracked.includes("real.txt"), "real work committed")
+        assert.ok(
+            !tracked.some((f) => f.startsWith("node_modules")),
+            "symlinked node_modules never committed",
+        )
+    })
+
+    it("auto-commits tracked work the agent forgot, but never ignored files", async () => {
+        const p1 = (await mgr.create("S1"))!
+        // Agent edited files but never committed:
+        writeFileSync(join(p1, "f.txt"), "forgot to commit\n")
+        mkdirSync(join(p1, "node_modules"), { recursive: true })
+        writeFileSync(join(p1, "node_modules", "x"), "junk\n")
+
+        await mgr.mergeBack("S1")
+
+        assert.ok(existsSync(join(repo, "f.txt")), "forgotten work was preserved")
+        assert.ok(
+            !git(repo, "ls-files").split("\n").some((f) => f.startsWith("node_modules")),
+            "ignored node_modules not committed",
+        )
+        assert.ok(
+            logs.some((l) => l.includes("uncommitted")),
+            "a safety-net warning was surfaced",
+        )
+    })
+})
+
+describe("WorktreeManager — fallback", () => {
+    it("mergeBack returns false for a story that never got a worktree", async () => {
+        const merged = await mgr.mergeBack("never-created")
+        assert.equal(merged, false, "no worktree → no merge, signals shared-tree path")
+    })
+})
+
+describe("WorktreeManager — cleanup", () => {
+    it("cleanupAll removes every worktree + branch", async () => {
+        await mgr.create("S1")
+        await mgr.create("S2")
+        await mgr.create("S3")
+        await mgr.cleanupAll()
+
+        const list = git(repo, "worktree", "list")
+        assert.ok(!list.includes("[baro-wt/"), "no baro worktrees remain")
+        assert.equal(
+            git(repo, "branch", "--list", `baro-wt/${runId}/*`),
+            "",
+            "no baro-wt branches remain",
+        )
+    })
+
+    it("cleanupStaleOnStart removes leftover baro-wt branches under the run id", async () => {
+        // Simulate a crashed prior run: a dangling branch with our run id.
+        git(repo, "branch", `baro-wt/${runId}/old`)
+        await mgr.cleanupStaleOnStart()
+        assert.equal(
+            git(repo, "branch", "--list", `baro-wt/${runId}/old`),
+            "",
+            "stale branch pruned",
+        )
+        // And create still succeeds afterwards.
+        const p = await mgr.create("old")
+        assert.ok(p && existsSync(p), "create works after stale cleanup")
+    })
+})
+
+describe("WorktreeManager — dependency dir symlink", () => {
+    it("symlinks root node_modules into the worktree so deps resolve", async () => {
+        mkdirSync(join(repo, "node_modules", "pkg"), { recursive: true })
+        writeFileSync(join(repo, "node_modules", "pkg", "index.js"), "module.exports=1\n")
+
+        const p = (await mgr.create("S1"))!
+        assert.ok(
+            existsSync(join(p, "node_modules", "pkg", "index.js")),
+            "worktree sees root node_modules via symlink",
+        )
+    })
+
+    it("skips the symlink when disabled", async () => {
+        mkdirSync(join(repo, "node_modules"), { recursive: true })
+        const noLink = new WorktreeManager(repo, new GitGate(), "run-nolink", {
+            linkDepDirs: false,
+            onLog: () => {},
+        })
+        const p = (await noLink.create("S1"))!
+        assert.ok(!existsSync(join(p, "node_modules")), "no symlink when disabled")
+        await noLink.cleanupAll()
+    })
+})


### PR DESCRIPTION
## What & why

Closes #50. Story agents all ran in the **same** `cwd`, so parallel stories shared one working tree and one git index — `git add -A` in one story swept up siblings' in-flight edits, concurrent commits raced on `.git/index.lock`, and the codex `--dangerously-bypass-approvals-and-sandbox` flag was justified on "per-story git worktrees" that **were never created** (`git worktree` appeared in 0 lines of source).

This makes the isolation real.

## How

- **`WorktreeManager`** (`src/worktree.ts`): each story runs in its own `git worktree` on branch `baro-wt/<runId>/<storyId>` created off the run-branch HEAD, commits in isolation, and merges back onto the run branch on success — all state-mutating ops under the existing `GitGate`.
- **Conductor serialization** (`conductor.ts`): `@mozaik-ai/core` delivers events to handlers **without awaiting them** (`deliverToSubscribers`), so two `StoryResult`s settling together could interleave and spawn the next DAG level before a merge-back finished. A promise-chain mutex around `handle()` makes the state machine sequential, guaranteeing each level-N merge-back completes before level-N+1 stories spawn (so dependents see the merged work). New `onStoryFailed` hook discards a failed story's worktree.
- **`StoryFactory`** threads a per-story worktree path as each agent's `cwd` (falls back to the shared tree if `worktree add` fails). `git add -A` in agent prompts is now safe — isolation fixes the root cause without rewriting prompts.
- Comment fixes: the false worktree-isolation / sandbox-bypass rationale in `codex-story-agent.ts`, `codex-cli-participant.ts`, and `sentry.ts` is now **true**.

## Decisions
- **Conflicts** (two same-level stories editing the same lines): auto-resolve `-X theirs` (merging story wins) + loud warning — strictly better than the old silent last-writer-wins. On an *unresolvable* merge the branch is **preserved** (work isn't discarded).
- **node_modules**: best-effort symlink of `node_modules`/`.venv`/`vendor` into each worktree so builds/tests resolve (a fresh worktree only checks out tracked files). The auto-commit safety net never commits those symlinks.
- **Remote sync**: dropped `safePullRebase` from the worktree merge path (the local merge already integrated the story); `gitPushWithRetry`'s reconciliation switched to `pull --rebase=merges` so `--no-ff` merge commits survive. Push + worktree cleanup run **off the conductor's critical path** so a slow network push can't stall other stories; awaited before the run finishes.
- **Escape hatch**: `withWorktrees` config flag (default on with git) + `BARO_NO_WORKTREES` env (no Rust CLI plumbing needed).

## Review fixes folded in
A high-effort `/code-review` pass caught real bugs that are fixed here: silent work-loss when a non-conflict merge failed (now preserves the branch), `-X theirs` second-merge failure left mid-merge (now aborts), brittle `--diff-filter=U` conflict classification (now always retries `-X theirs`), fallback stories skipping remote reconciliation, dep-dir symlinks committed when not gitignored, the spawn idempotency window, and the push-stall serialization.

## Known follow-ups (not in scope)
- Project-level gitignored config (`.claude/`, `.env`) isn't symlinked into worktrees — agents/tests that depend on cwd-relative untracked config see a bare tree. Document or extend the symlink set later.
- No TTL GC of crashed-run worktree dirs (only `git worktree prune` of vanished ones); branch refs from crashes are inert.

## Verification
- New `test/worktree.test.ts` — deterministic, **real git in a temp dir, no LLMs**: lifecycle, isolation (proves #50), clean 3-way merge, `-X theirs` conflict, uncommitted-work safety net, dep-dir symlink + never-committed, fallback signalling, `cleanupAll`/`cleanupStaleOnStart`.
- Orchestrator suite **42/42**, `tsc --noEmit` clean. No Rust change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)