### PR TITLE
fix(orchestrator): real per-story files_created/modified on story_complete (#39)

### DIFF
--- a/packages/baro-orchestrator/src/participants/forwarders/story-lifecycle.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/story-lifecycle.ts
@@ -1,4 +1,9 @@
-import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+import {
+    BaseObserver,
+    FunctionCallItem,
+    Participant,
+    SemanticEvent,
+} from "@mozaik-ai/core"
 
 import {
     AgentState,
@@ -8,15 +13,24 @@ import {
 } from "../../semantic-events.js"
 import { emit } from "../../tui-protocol.js"
 
+// Write-ish tools across all backends. "create" = a whole-file write
+// (Claude `Write`, story-tools `write_file`); "edit" = an in-place edit
+// (which implies the file pre-existed).
+const CREATE_TOOLS = new Set(["Write", "write_file"])
+const EDIT_TOOLS = new Set(["Edit", "MultiEdit", "NotebookEdit", "edit_file"])
+
 /**
  * Mirrors story lifecycle transitions as BaroEvents consumed by the Rust TUI.
  *
- * Subscribes to: AgentState, StoryResult.
+ * Subscribes to: AgentState, StoryResult, and per-agent function calls.
  * Emits: story_start, story_complete, story_error, story_retry.
  */
 export class StoryLifecycleForwarder extends BaseObserver {
     private startedStories = new Set<string>()
     private retryCounts = new Map<string, number>()
+    // storyId → (path → first-touch kind). Distinct paths per story, so a
+    // file touched many times counts once, classified by its first write.
+    private filesByStory = new Map<string, Map<string, "created" | "modified">>()
 
     override async onExternalEvent(
         _source: Participant,
@@ -29,6 +43,34 @@ export class StoryLifecycleForwarder extends BaseObserver {
         if (StoryResult.is(event)) {
             this.handleStoryResult(event.data)
             return
+        }
+    }
+
+    // Same signal the Sentry uses: a write/edit tool call from a story
+    // agent. We attribute the touched path to that agent's story and
+    // remember its first-touch kind so story_complete can report real
+    // per-story file counts instead of a hardcoded 0.
+    override async onExternalFunctionCall(
+        source: Participant,
+        item: FunctionCallItem,
+    ): Promise<void> {
+        const isCreate = CREATE_TOOLS.has(item.name)
+        const isEdit = EDIT_TOOLS.has(item.name)
+        if (!isCreate && !isEdit) return
+        const agentId = (source as unknown as { agentId?: string }).agentId
+        if (typeof agentId !== "string") return
+        const path = extractPath(item)
+        if (!path) return
+
+        let paths = this.filesByStory.get(agentId)
+        if (!paths) {
+            paths = new Map()
+            this.filesByStory.set(agentId, paths)
+        }
+        // Keep the FIRST touch's classification; a later edit of a file we
+        // saw created stays "created".
+        if (!paths.has(path)) {
+            paths.set(path, isCreate ? "created" : "modified")
         }
     }
 
@@ -46,14 +88,25 @@ export class StoryLifecycleForwarder extends BaseObserver {
 
     private handleStoryResult(item: StoryResultData): void {
         if (item.success) {
+            const paths = this.filesByStory.get(item.storyId)
+            let created = 0
+            let modified = 0
+            if (paths) {
+                for (const kind of paths.values()) {
+                    if (kind === "created") created++
+                    else modified++
+                }
+            }
+            this.filesByStory.delete(item.storyId)
             emit({
                 type: "story_complete",
                 id: item.storyId,
                 duration_secs: item.durationSecs,
-                files_created: 0,
-                files_modified: 0,
+                files_created: created,
+                files_modified: modified,
             })
         } else {
+            this.filesByStory.delete(item.storyId)
             emit({
                 type: "story_error",
                 id: item.storyId,
@@ -63,4 +116,19 @@ export class StoryLifecycleForwarder extends BaseObserver {
             })
         }
     }
+}
+
+/** Pull the file path out of a write/edit tool call's JSON args. */
+function extractPath(item: FunctionCallItem): string | null {
+    let args: Record<string, unknown>
+    try {
+        args = JSON.parse(item.args) as Record<string, unknown>
+    } catch {
+        return null
+    }
+    for (const key of ["file_path", "path", "notebook_path"]) {
+        const v = args[key]
+        if (typeof v === "string") return v
+    }
+    return null
 }

--- a/packages/baro-orchestrator/src/participants/forwarders/story-lifecycle.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/story-lifecycle.ts
@@ -30,6 +30,8 @@ export class StoryLifecycleForwarder extends BaseObserver {
     private retryCounts = new Map<string, number>()
     // storyId → (path → first-touch kind). Distinct paths per story, so a
     // file touched many times counts once, classified by its first write.
+    // Reset on each retry so story_complete reflects only the winning
+    // attempt's touches, not files a failed attempt wrote and abandoned.
     private filesByStory = new Map<string, Map<string, "created" | "modified">>()
 
     override async onExternalEvent(
@@ -82,6 +84,9 @@ export class StoryLifecycleForwarder extends BaseObserver {
         if (item.phase === "waiting" && item.detail?.includes("retrying")) {
             const count = (this.retryCounts.get(item.agentId) ?? 0) + 1
             this.retryCounts.set(item.agentId, count)
+            // Drop the failed attempt's file touches so the eventual
+            // story_complete counts only the attempt that actually lands.
+            this.filesByStory.delete(item.agentId)
             emit({ type: "story_retry", id: item.agentId, attempt: count })
         }
     }

--- a/packages/baro-orchestrator/test/story-file-stats.test.ts
+++ b/packages/baro-orchestrator/test/story-file-stats.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict"
 
 import { FunctionCallItem, type Participant } from "@mozaik-ai/core"
 
-import { StoryResult } from "../src/semantic-events.js"
+import { AgentState, StoryResult } from "../src/semantic-events.js"
 import { StoryLifecycleForwarder } from "../src/participants/forwarders/story-lifecycle.js"
 
 // The forwarder reads `source.agentId`; a story's agentId == its storyId.
@@ -17,6 +17,10 @@ function call(name: string, args: Record<string, unknown>): FunctionCallItem {
 
 function result(storyId: string, success: boolean) {
     return StoryResult.create({ storyId, success, attempts: 1, durationSecs: 3, error: success ? null : "boom" })
+}
+
+function retry(agentId: string) {
+    return AgentState.create({ agentId, phase: "waiting", detail: "retrying (1/2)" })
 }
 
 /**
@@ -109,6 +113,22 @@ describe("StoryLifecycleForwarder — per-story file stats (#39)", () => {
         })
         assert.equal(complete(events, "S5")!.files_created, 1)
         assert.equal(complete(events, "S6")!.files_created, 2)
+    })
+
+    it("counts only the winning attempt's touches across a retry", () => {
+        const f = new StoryLifecycleForwarder()
+        const events = capture(() => {
+            // Attempt 1 writes foo.ts, then fails and retries.
+            void f.onExternalFunctionCall(source("S8"), call("Write", { file_path: "foo.ts", content: "x" }))
+            void f.onExternalEvent(source("S8"), retry("S8"))
+            // Attempt 2 writes bar.ts and lands.
+            void f.onExternalFunctionCall(source("S8"), call("Write", { file_path: "bar.ts", content: "y" }))
+            void f.onExternalEvent(source("S8"), result("S8", true))
+        })
+        const ev = complete(events, "S8")
+        assert.equal(ev!.files_created, 1, "abandoned attempt-1 file not counted")
+        assert.equal(ev!.files_modified, 0)
+        assert.ok(events.some((e) => e.type === "story_retry" && e.id === "S8"), "story_retry emitted")
     })
 
     it("emits story_error (not story_complete) on failure and forgets the touches", () => {

--- a/packages/baro-orchestrator/test/story-file-stats.test.ts
+++ b/packages/baro-orchestrator/test/story-file-stats.test.ts
@@ -1,0 +1,123 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+
+import { FunctionCallItem, type Participant } from "@mozaik-ai/core"
+
+import { StoryResult } from "../src/semantic-events.js"
+import { StoryLifecycleForwarder } from "../src/participants/forwarders/story-lifecycle.js"
+
+// The forwarder reads `source.agentId`; a story's agentId == its storyId.
+function source(agentId: string): Participant {
+    return { agentId } as unknown as Participant
+}
+
+function call(name: string, args: Record<string, unknown>): FunctionCallItem {
+    return FunctionCallItem.rehydrate({ callId: "c", name, args: JSON.stringify(args) })
+}
+
+function result(storyId: string, success: boolean) {
+    return StoryResult.create({ storyId, success, attempts: 1, durationSecs: 3, error: success ? null : "boom" })
+}
+
+/**
+ * Run `fn` (which synchronously triggers `emit` → stdout) with stdout
+ * captured, then restore and return the parsed BaroEvents. Capturing only
+ * around the synchronous emit avoids swallowing the test runner's own output.
+ */
+function capture(fn: () => void): Array<Record<string, unknown>> {
+    const out: Array<Record<string, unknown>> = []
+    const orig = process.stdout.write.bind(process.stdout)
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+        const s = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString()
+        for (const line of s.split("\n")) {
+            const t = line.trim()
+            if (t) { try { out.push(JSON.parse(t)) } catch { /* not ours */ } }
+        }
+        return true
+    }) as typeof process.stdout.write
+    try {
+        fn()
+    } finally {
+        process.stdout.write = orig
+    }
+    return out
+}
+
+function complete(events: Array<Record<string, unknown>>, id: string) {
+    return events.filter((e) => e.type === "story_complete" && e.id === id).pop()
+}
+
+describe("StoryLifecycleForwarder — per-story file stats (#39)", () => {
+    it("classifies a whole-file write as created and an edit as modified", () => {
+        const f = new StoryLifecycleForwarder()
+        const events = capture(() => {
+            void f.onExternalFunctionCall(source("S1"), call("Write", { file_path: "a.ts", content: "x" }))
+            void f.onExternalFunctionCall(source("S1"), call("Edit", { file_path: "b.ts", old: "x", new: "y" }))
+            void f.onExternalEvent(source("S1"), result("S1", true))
+        })
+        const ev = complete(events, "S1")
+        assert.ok(ev, "story_complete emitted")
+        assert.equal(ev!.files_created, 1)
+        assert.equal(ev!.files_modified, 1)
+    })
+
+    it("counts a path once, keeping its first-touch classification", () => {
+        const f = new StoryLifecycleForwarder()
+        const events = capture(() => {
+            void f.onExternalFunctionCall(source("S2"), call("Write", { file_path: "a.ts", content: "1" }))
+            void f.onExternalFunctionCall(source("S2"), call("Edit", { file_path: "a.ts", old: "1", new: "2" }))
+            void f.onExternalFunctionCall(source("S2"), call("Write", { file_path: "a.ts", content: "3" }))
+            void f.onExternalEvent(source("S2"), result("S2", true))
+        })
+        const ev = complete(events, "S2")
+        assert.equal(ev!.files_created, 1, "distinct path counted once")
+        assert.equal(ev!.files_modified, 0, "stays created despite a later edit")
+    })
+
+    it("attributes the OpenAI/Codex story tools (write_file/edit_file, `path` arg)", () => {
+        const f = new StoryLifecycleForwarder()
+        const events = capture(() => {
+            void f.onExternalFunctionCall(source("S3"), call("write_file", { path: "new.ts", content: "x" }))
+            void f.onExternalFunctionCall(source("S3"), call("edit_file", { path: "old.ts", old: "a", new: "b" }))
+            void f.onExternalEvent(source("S3"), result("S3", true))
+        })
+        const ev = complete(events, "S3")
+        assert.equal(ev!.files_created, 1)
+        assert.equal(ev!.files_modified, 1)
+    })
+
+    it("ignores non-write tool calls", () => {
+        const f = new StoryLifecycleForwarder()
+        const events = capture(() => {
+            void f.onExternalFunctionCall(source("S4"), call("Bash", { command: "ls" }))
+            void f.onExternalFunctionCall(source("S4"), call("Read", { file_path: "a.ts" }))
+            void f.onExternalEvent(source("S4"), result("S4", true))
+        })
+        const ev = complete(events, "S4")
+        assert.equal(ev!.files_created, 0)
+        assert.equal(ev!.files_modified, 0)
+    })
+
+    it("does not attribute one story's touches to another", () => {
+        const f = new StoryLifecycleForwarder()
+        const events = capture(() => {
+            void f.onExternalFunctionCall(source("S5"), call("Write", { file_path: "a.ts", content: "x" }))
+            void f.onExternalFunctionCall(source("S6"), call("Write", { file_path: "b.ts", content: "y" }))
+            void f.onExternalFunctionCall(source("S6"), call("Write", { file_path: "c.ts", content: "z" }))
+            void f.onExternalEvent(source("S5"), result("S5", true))
+            void f.onExternalEvent(source("S6"), result("S6", true))
+        })
+        assert.equal(complete(events, "S5")!.files_created, 1)
+        assert.equal(complete(events, "S6")!.files_created, 2)
+    })
+
+    it("emits story_error (not story_complete) on failure and forgets the touches", () => {
+        const f = new StoryLifecycleForwarder()
+        const events = capture(() => {
+            void f.onExternalFunctionCall(source("S7"), call("Write", { file_path: "a.ts", content: "x" }))
+            void f.onExternalEvent(source("S7"), result("S7", false))
+        })
+        assert.equal(complete(events, "S7"), undefined, "no story_complete on failure")
+        assert.ok(events.some((e) => e.type === "story_error" && e.id === "S7"), "story_error emitted")
+    })
+})


### PR DESCRIPTION
## What & why

Closes #39. Every `story_complete` BaroEvent reported `files_created: 0, files_modified: 0` even when a story created/modified files — `StoryResultData` carries no per-story file stats, so `StoryLifecycleForwarder` had nothing to put there. The only real stats (`getGitFileStats`) are computed once for the run-level `done` event. The upcoming desktop UI (#37) wants a per-story "+N / ~M files" badge that's currently always 0.

## How

Attribute file touches per story from the **function-call stream** — the same `Write`/`Edit` signal the **Sentry** participant already consumes (`onExternalFunctionCall` → tool name + path from args + `agentId` from source). The forwarder accumulates **distinct paths per story** and classifies each by its **first-touch tool**:

- created: `Write` (Claude), `write_file` (OpenAI/Codex story-tools)
- modified: `Edit` / `MultiEdit` / `NotebookEdit` (Claude), `edit_file` (OpenAI/Codex)

`story_complete` then reports the real counts. Backend-agnostic; **no change to `StoryResultData` or any of the five story agents**. The arg-key extraction covers `file_path` (Claude), `path` (OpenAI/Codex `write_file`/`edit_file`), and `notebook_path` (NotebookEdit). The Rust TUI already consumes non-zero `files_created`/`files_modified` (`events.rs`/`app.rs`), so no Rust change is needed.

This mirrors the implementation already living on `feat/37-interactive-planning` (the #37 draft), lifted out as a focused standalone fix.

## Notes / limitations
- A `Write` to a pre-existing path is counted as *created* (first-touch-tool heuristic) — precise created-vs-modified would need a per-story pre-image snapshot, which parallel execution makes expensive. Same trade-off the issue describes.
- opencode/pi file edits land via their own tool names and aren't in the Write/Edit set (same coverage Sentry has today) — no worse than the current `0`, and those stories still commit in their worktrees.

## Tests
New deterministic `test/story-file-stats.test.ts` (no LLMs, no git): created-vs-modified classification, distinct-path dedup with first-touch retention, OpenAI/Codex `path`-arg attribution, non-write tools ignored, cross-story isolation, and failure cleanup (emits `story_error`, forgets touches). Orchestrator suite **48/48**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)