### PR TITLE
fix(orchestrator): Surgeon replan reason names the model that actually ran (#48)

### DIFF
--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -23,6 +23,11 @@ import {
 } from "./git.js"
 import { WorktreeManager } from "./worktree.js"
 import { buildDag } from "./dag.js"
+import {
+    formatRoute,
+    resolveStoryRoute,
+    type ResolveOpts,
+} from "./routing.js"
 import { Auditor } from "./participants/auditor.js"
 import {
     Conductor,
@@ -41,7 +46,11 @@ import { Operator } from "./participants/operator.js"
 import { Sentry } from "./participants/sentry.js"
 import { StoryFactory } from "./participants/story-factory.js"
 import { type StoryAgent } from "./participants/story-agent.js"
-import { Surgeon, type PrdSnapshot } from "./participants/surgeon.js"
+import {
+    Surgeon,
+    type PrdSnapshot,
+    type RouteDescriber,
+} from "./participants/surgeon.js"
 import { SurgeonCodex } from "./participants/surgeon-codex.js"
 import { SurgeonOpenAI } from "./participants/surgeon-openai.js"
 import { SurgeonOpenCode } from "./participants/surgeon-opencode.js"
@@ -449,6 +458,29 @@ export async function orchestrate(
                 })),
             }
         }
+        // Tell the Surgeon what a story's planner tier actually resolved to,
+        // so its replan reason names the model that ran rather than the tier
+        // an override replaced (issue #48). Only wired when an override is in
+        // play — on a plain run the tier IS the model, so we keep showing it.
+        const storyRouting: ResolveOpts = {
+            fallbackBackend: storyLlm,
+            openaiDefaultModel: config.storyModel ?? "gpt-5.5",
+            override: config.storyModel,
+            tierMap: config.tierMap,
+            endpoints: config.openaiEndpoints,
+            defaultApiKey: process.env.OPENAI_API_KEY,
+        }
+        const routingOverridden =
+            storyLlm !== "claude" || !!config.storyModel || !!config.tierMap
+        const resolveRoute: RouteDescriber | undefined = routingOverridden
+            ? (model) => {
+                  try {
+                      return formatRoute(resolveStoryRoute(model, storyRouting))
+                  } catch {
+                      return null
+                  }
+              }
+            : undefined
         // Factory by provider. Bus contract is identical across all
         // three — same ReplanItem shape — so downstream observers
         // (Conductor's replan-applier, Auditor, kaleidoskop) don't
@@ -456,29 +488,34 @@ export async function orchestrate(
         if (surgeonLlm === "openai") {
             surgeon = new SurgeonOpenAI({
                 snapshot,
+                resolveRoute,
                 model: config.surgeonModel ?? "gpt-5.5",
             })
         } else if (surgeonLlm === "codex") {
             surgeon = new SurgeonCodex({
                 snapshot,
+                resolveRoute,
                 useLlm: config.surgeonUseLlm ?? true,
                 model: config.surgeonModel,
             })
         } else if (surgeonLlm === "opencode") {
             surgeon = new SurgeonOpenCode({
                 snapshot,
+                resolveRoute,
                 useLlm: config.surgeonUseLlm ?? true,
                 model: config.surgeonModel,
             })
         } else if (surgeonLlm === "pi") {
             surgeon = new SurgeonPi({
                 snapshot,
+                resolveRoute,
                 useLlm: config.surgeonUseLlm ?? true,
                 model: config.surgeonModel,
             })
         } else {
             surgeon = new Surgeon({
                 snapshot,
+                resolveRoute,
                 useLlm: config.surgeonUseLlm ?? false,
                 model: config.surgeonModel ?? "opus",
             })

--- a/packages/baro-orchestrator/src/participants/surgeon-codex.ts
+++ b/packages/baro-orchestrator/src/participants/surgeon-codex.ts
@@ -25,6 +25,7 @@ import {
 } from "../semantic-events.js"
 import {
     PrdSnapshot,
+    type RouteDescriber,
     SURGEON_SYSTEM_PROMPT,
     buildSurgeonPrompt,
     extractJsonObject,
@@ -34,6 +35,8 @@ import {
 export interface SurgeonCodexOptions {
     /** Returns a fresh snapshot of the current PRD. */
     snapshot: () => PrdSnapshot
+    /** Describes the model a story actually ran on (issue #48). */
+    resolveRoute?: RouteDescriber
     /** Use Codex CLI to evaluate replans. Default: true. */
     useLlm?: boolean
     /** Model for LLM evaluations. Default: undefined (Codex picks). */
@@ -48,11 +51,12 @@ export interface SurgeonCodexOptions {
 
 export class SurgeonCodex extends BaseObserver {
     private readonly opts: Required<
-        Omit<SurgeonCodexOptions, "snapshot" | "model" | "codexBin">
+        Omit<SurgeonCodexOptions, "snapshot" | "model" | "codexBin" | "resolveRoute">
     > & {
         snapshot: () => PrdSnapshot
         model: string | undefined
         codexBin: string
+        resolveRoute?: RouteDescriber
     }
 
     private replansEmitted = 0
@@ -67,6 +71,7 @@ export class SurgeonCodex extends BaseObserver {
             codexBin: opts.codexBin ?? "codex",
             timeoutMs: opts.timeoutMs ?? 300_000,
             snapshot: opts.snapshot,
+            resolveRoute: opts.resolveRoute,
         }
     }
 
@@ -102,7 +107,7 @@ export class SurgeonCodex extends BaseObserver {
         failure: StoryResultData,
     ): Promise<ReplanData | null> {
         const snap = this.opts.snapshot()
-        const userPrompt = buildSurgeonPrompt(snap, failure)
+        const userPrompt = buildSurgeonPrompt(snap, failure, this.opts.resolveRoute)
         const prompt = `${SURGEON_SYSTEM_PROMPT}\n\n${userPrompt}`
 
         try {

--- a/packages/baro-orchestrator/src/participants/surgeon-openai.ts
+++ b/packages/baro-orchestrator/src/participants/surgeon-openai.ts
@@ -50,11 +50,14 @@ import {
     extractJsonObject,
     surgeonDeterministicReplan,
     type PrdSnapshot,
+    type RouteDescriber,
 } from "./surgeon.js"
 
 export interface SurgeonOpenAIOptions {
     /** PRD snapshot provider. Same shape as `Surgeon`. */
     snapshot: () => PrdSnapshot
+    /** Describes the model a story actually ran on (issue #48). */
+    resolveRoute?: RouteDescriber
     /** Max replans this Surgeon will emit per run. Default: 10. */
     maxReplans?: number
     /**
@@ -96,6 +99,7 @@ export class SurgeonOpenAI extends BaseObserver {
             maxReplans: opts.maxReplans ?? 10,
             model: opts.model ?? "gpt-5.5",
             snapshot: opts.snapshot,
+            resolveRoute: opts.resolveRoute,
         }
         this.model = pickModel(this.opts.model)
     }
@@ -135,7 +139,7 @@ export class SurgeonOpenAI extends BaseObserver {
      */
     private async evaluate(failure: StoryResultData): Promise<ReplanData | null> {
         const snap = this.opts.snapshot()
-        const userPrompt = buildSurgeonPrompt(snap, failure)
+        const userPrompt = buildSurgeonPrompt(snap, failure, this.opts.resolveRoute)
         const context = ModelContext.create("surgeon")
             .addContextItem(SystemMessageItem.create(SURGEON_SYSTEM_PROMPT))
             .addContextItem(UserMessageItem.create(userPrompt))

--- a/packages/baro-orchestrator/src/participants/surgeon-opencode.ts
+++ b/packages/baro-orchestrator/src/participants/surgeon-opencode.ts
@@ -26,6 +26,7 @@ import {
 } from "../semantic-events.js"
 import {
     PrdSnapshot,
+    type RouteDescriber,
     SURGEON_SYSTEM_PROMPT,
     buildSurgeonPrompt,
     extractJsonObject,
@@ -35,6 +36,8 @@ import {
 export interface SurgeonOpenCodeOptions {
     /** Returns a fresh snapshot of the current PRD. */
     snapshot: () => PrdSnapshot
+    /** Describes the model a story actually ran on (issue #48). */
+    resolveRoute?: RouteDescriber
     /** Use OpenCode CLI to evaluate replans. Default: true. */
     useLlm?: boolean
     /**
@@ -53,11 +56,12 @@ export interface SurgeonOpenCodeOptions {
 
 export class SurgeonOpenCode extends BaseObserver {
     private readonly opts: Required<
-        Omit<SurgeonOpenCodeOptions, "snapshot" | "model" | "opencodeBin">
+        Omit<SurgeonOpenCodeOptions, "snapshot" | "model" | "opencodeBin" | "resolveRoute">
     > & {
         snapshot: () => PrdSnapshot
         model: string | undefined
         opencodeBin: string
+        resolveRoute?: RouteDescriber
     }
 
     private replansEmitted = 0
@@ -72,6 +76,7 @@ export class SurgeonOpenCode extends BaseObserver {
             opencodeBin: opts.opencodeBin ?? "opencode",
             timeoutMs: opts.timeoutMs ?? 300_000,
             snapshot: opts.snapshot,
+            resolveRoute: opts.resolveRoute,
         }
     }
 
@@ -107,7 +112,7 @@ export class SurgeonOpenCode extends BaseObserver {
         failure: StoryResultData,
     ): Promise<ReplanData | null> {
         const snap = this.opts.snapshot()
-        const userPrompt = buildSurgeonPrompt(snap, failure)
+        const userPrompt = buildSurgeonPrompt(snap, failure, this.opts.resolveRoute)
         const prompt = `${SURGEON_SYSTEM_PROMPT}\n\n${userPrompt}`
 
         try {

--- a/packages/baro-orchestrator/src/participants/surgeon-pi.ts
+++ b/packages/baro-orchestrator/src/participants/surgeon-pi.ts
@@ -26,6 +26,7 @@ import {
 } from "../semantic-events.js"
 import {
     PrdSnapshot,
+    type RouteDescriber,
     SURGEON_SYSTEM_PROMPT,
     buildSurgeonPrompt,
     extractJsonObject,
@@ -35,6 +36,8 @@ import {
 export interface SurgeonPiOptions {
     /** Returns a fresh snapshot of the current PRD. */
     snapshot: () => PrdSnapshot
+    /** Describes the model a story actually ran on (issue #48). */
+    resolveRoute?: RouteDescriber
     /** Use Pi CLI to evaluate replans. Default: true. */
     useLlm?: boolean
     /**
@@ -56,12 +59,13 @@ export interface SurgeonPiOptions {
 
 export class SurgeonPi extends BaseObserver {
     private readonly opts: Required<
-        Omit<SurgeonPiOptions, "snapshot" | "provider" | "model" | "piBin">
+        Omit<SurgeonPiOptions, "snapshot" | "provider" | "model" | "piBin" | "resolveRoute">
     > & {
         snapshot: () => PrdSnapshot
         provider: string | undefined
         model: string | undefined
         piBin: string
+        resolveRoute?: RouteDescriber
     }
 
     private replansEmitted = 0
@@ -77,6 +81,7 @@ export class SurgeonPi extends BaseObserver {
             piBin: opts.piBin ?? "pi",
             timeoutMs: opts.timeoutMs ?? 300_000,
             snapshot: opts.snapshot,
+            resolveRoute: opts.resolveRoute,
         }
     }
 
@@ -112,7 +117,7 @@ export class SurgeonPi extends BaseObserver {
         failure: StoryResultData,
     ): Promise<ReplanData | null> {
         const snap = this.opts.snapshot()
-        const userPrompt = buildSurgeonPrompt(snap, failure)
+        const userPrompt = buildSurgeonPrompt(snap, failure, this.opts.resolveRoute)
         const prompt = `${SURGEON_SYSTEM_PROMPT}\n\n${userPrompt}`
 
         try {

--- a/packages/baro-orchestrator/src/participants/surgeon.ts
+++ b/packages/baro-orchestrator/src/participants/surgeon.ts
@@ -60,9 +60,20 @@ export interface PrdSnapshot {
     }[]
 }
 
+/**
+ * Renders a story's planner tier (its PRD `model`) as the backend:model that
+ * actually ran, accounting for `--story-model` / `--story-llm` / tier-map
+ * overrides. Returns null when the route can't be resolved. Wired from
+ * orchestrate() only when an override is active, so a plain run keeps showing
+ * just the tier (issue #48).
+ */
+export type RouteDescriber = (model: string | undefined) => string | null
+
 export interface SurgeonOptions {
     /** Returns a fresh snapshot of the current PRD. */
     snapshot: () => PrdSnapshot
+    /** Describes the model a story actually ran on (see RouteDescriber). */
+    resolveRoute?: RouteDescriber
     /** Use Claude CLI to evaluate replans. Default: false (deterministic). */
     useLlm?: boolean
     /** Model for LLM evaluations. Default: "opus". */
@@ -162,6 +173,7 @@ export class Surgeon extends BaseObserver {
             claudeBin: opts.claudeBin ?? "claude",
             timeoutMs: opts.timeoutMs ?? 90_000,
             snapshot: opts.snapshot,
+            resolveRoute: opts.resolveRoute,
         }
     }
 
@@ -213,7 +225,7 @@ export class Surgeon extends BaseObserver {
         failure: StoryResultData,
     ): Promise<ReplanData | null> {
         const snap = this.opts.snapshot()
-        const prompt = buildSurgeonPrompt(snap, failure)
+        const prompt = buildSurgeonPrompt(snap, failure, this.opts.resolveRoute)
         try {
             const { stdout } = await execFileAsync(
                 this.opts.claudeBin,
@@ -279,6 +291,7 @@ export class Surgeon extends BaseObserver {
 export function buildSurgeonPrompt(
     snap: PrdSnapshot,
     failure: StoryResultData,
+    resolveRoute?: RouteDescriber,
 ): string {
     const storyLines = snap.stories
         .map(
@@ -287,6 +300,11 @@ export function buildSurgeonPrompt(
         )
         .join("\n")
     const failureStory = snap.stories.find((s) => s.id === failure.storyId)
+    // The PRD `model` is the planner's blast-radius TIER, which a
+    // `--story-model`/`--story-llm`/tier-map override can replace at spawn
+    // time. Surface the model that actually ran so the reason doesn't
+    // misattribute the failure to a tier that never executed (issue #48).
+    const ranOn = resolveRoute ? resolveRoute(failureStory?.model) : null
     return [
         `# Project: ${snap.project}`,
         `Description: ${snap.description}`,
@@ -299,6 +317,12 @@ export function buildSurgeonPrompt(
         `Title: ${failureStory?.title ?? "(unknown)"}`,
         `Description: ${failureStory?.description ?? "(unknown)"}`,
         `Tier that just failed: ${failureStory?.model ?? "(default)"}`,
+        ...(ranOn
+            ? [
+                  `Model that actually ran: ${ranOn}  (an override replaced the ` +
+                      `planner tier above; refer to THIS model in your reason, not the tier)`,
+              ]
+            : []),
         `Attempts: ${failure.attempts}`,
         `Error: ${failure.error ?? "(no reason captured)"}`,
         "",

--- a/packages/baro-orchestrator/test/surgeon-prompt.test.ts
+++ b/packages/baro-orchestrator/test/surgeon-prompt.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+    buildSurgeonPrompt,
+    type PrdSnapshot,
+} from "../src/participants/surgeon.js"
+import { formatRoute, resolveStoryRoute } from "../src/routing.js"
+import type { StoryResultData } from "../src/semantic-events.js"
+
+const snap: PrdSnapshot = {
+    project: "demo",
+    description: "d",
+    stories: [
+        { id: "S1", title: "broad story", description: "does a lot", dependsOn: [], passes: false, model: "sonnet" },
+    ],
+}
+
+const failure: StoryResultData = {
+    storyId: "S1",
+    success: false,
+    attempts: 3,
+    durationSecs: 42,
+    error: "exit 1",
+}
+
+describe("buildSurgeonPrompt — names the model that actually ran (#48)", () => {
+    it("shows only the planner tier when no route describer is wired", () => {
+        const p = buildSurgeonPrompt(snap, failure)
+        assert.match(p, /Tier that just failed: sonnet/)
+        assert.doesNotMatch(p, /Model that actually ran/)
+    })
+
+    it("adds the actual model and tells the LLM to cite it, keeping the tier line", () => {
+        // Mirrors orchestrate(): --story-llm codex --story-model gpt-5.5.
+        const describe = (model: string | undefined) =>
+            formatRoute(
+                resolveStoryRoute(model, {
+                    fallbackBackend: "codex",
+                    override: "gpt-5.5",
+                    openaiDefaultModel: "gpt-5.5",
+                }),
+            )
+        const p = buildSurgeonPrompt(snap, failure, describe)
+        assert.match(p, /Model that actually ran: codex:gpt-5\.5/)
+        assert.match(p, /refer to THIS model in your reason, not the tier/)
+        // The planner tier stays (the escalation rule depends on it).
+        assert.match(p, /Tier that just failed: sonnet/)
+    })
+
+    it("omits the actual-model line when the describer can't resolve a route", () => {
+        const p = buildSurgeonPrompt(snap, failure, () => null)
+        assert.doesNotMatch(p, /Model that actually ran/)
+        assert.match(p, /Tier that just failed: sonnet/)
+    })
+})

--- a/packages/baro-orchestrator/test/surgeon-prompt.test.ts
+++ b/packages/baro-orchestrator/test/surgeon-prompt.test.ts
@@ -33,7 +33,7 @@ describe("buildSurgeonPrompt — names the model that actually ran (#48)", () =>
 
     it("adds the actual model and tells the LLM to cite it, keeping the tier line", () => {
         // Mirrors orchestrate(): --story-llm codex --story-model gpt-5.5.
-        const describe = (model: string | undefined) =>
+        const routeDescriber = (model: string | undefined) =>
             formatRoute(
                 resolveStoryRoute(model, {
                     fallbackBackend: "codex",
@@ -41,7 +41,7 @@ describe("buildSurgeonPrompt — names the model that actually ran (#48)", () =>
                     openaiDefaultModel: "gpt-5.5",
                 }),
             )
-        const p = buildSurgeonPrompt(snap, failure, describe)
+        const p = buildSurgeonPrompt(snap, failure, routeDescriber)
         assert.match(p, /Model that actually ran: codex:gpt-5\.5/)
         assert.match(p, /refer to THIS model in your reason, not the tier/)
         // The planner tier stays (the escalation rule depends on it).


### PR DESCRIPTION
## What & why

Closes #48. On a run with a story-routing override (`--llm claude --story-llm codex --story-model gpt-5.5`), the Surgeon's replan `reason` described failed stories by their **planner tier** — *"split: S36 … into one **sonnet** session and exhausted retries"* — even though every story executed on **codex / gpt-5.5**. The word "sonnet" is the planner's blast-radius tier stored in `story.model`, which the override replaces at spawn time; the Surgeon read that static tier and verbalized it, so the audit log misattributes failures to a model that never ran.

## How

The StoryFactory turns a story's tier into the effective `backend:model` via `resolveStoryRoute(model, opts)`. This PR gives the Surgeon the same view:

- New `RouteDescriber` type + optional `resolveRoute` on all five Surgeon variants (claude/openai/codex/opencode/pi), threaded into `buildSurgeonPrompt`.
- `orchestrate()` builds the describer from the **same story-routing inputs the StoryFactory uses** (`storyLlm`, `storyModel`, `tierMap`, `openaiEndpoints`, `OPENAI_API_KEY`) via `resolveStoryRoute` + `formatRoute`. It's only wired when an override is actually in play (`storyLlm !== "claude"` or `storyModel` or `tierMap`), so a plain run is unchanged.
- `buildSurgeonPrompt` adds a `Model that actually ran: <backend:model>` line that instructs the LLM to cite the real model in its reason. The existing `Tier that just failed: <tier>` line stays — the system prompt's escalation rule (replacement stories must bump the tier) legitimately depends on the planner tier.

No change to `ReplanData`, the bus contract, or the deterministic-skip path.

## Tests
New `test/surgeon-prompt.test.ts` (deterministic, no LLM): with no describer → only the tier line; with a `codex:gpt-5.5` describer (mirroring `--story-llm codex --story-model gpt-5.5`) → the "Model that actually ran: codex:gpt-5.5" line + the cite instruction, tier line preserved; describer returning null → no actual-model line. Orchestrator suite **45/45**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)