### PR TITLE
refactor(orchestrator): StoryExecutor seam for pluggable story execution

### DIFF
--- a/packages/baro-orchestrator/src/participants/story-executor.ts
+++ b/packages/baro-orchestrator/src/participants/story-executor.ts
@@ -1,0 +1,139 @@
+/**
+ * StoryExecutor — the seam between "decide a story should run" and "actually
+ * run its agent loop somewhere".
+ *
+ * The default implementation (`LocalStoryExecutor`) builds the right backend
+ * agent and runs it in-process — the historical behaviour. The seam lets that
+ * be swapped: a mock executor for tests, or an out-of-process / remote executor
+ * that runs the agent elsewhere and re-emits its streamed bus events onto the
+ * local `env`. Whatever the implementation, it must deliver the agent's events,
+ * including the terminal `StoryResult`, onto the bus — so Conductor / Critic /
+ * Surgeon / Sentry / Librarian / Cartographer can't tell which executor ran.
+ * That indistinguishability is the point: every other participant stays
+ * unchanged regardless of where execution happens.
+ */
+
+import { AgenticEnvironment } from "@mozaik-ai/core"
+
+import type { StorySpawnRequestData } from "../semantic-events.js"
+import type { StoryRoute } from "../routing.js"
+import { CodexStoryAgent } from "./codex-story-agent.js"
+import { OpenAIStoryAgent } from "./openai-story-agent.js"
+import { OpenCodeStoryAgent } from "./opencode-story-agent.js"
+import { PiStoryAgent } from "./pi-story-agent.js"
+import { StoryAgent } from "./story-agent.js"
+
+/** Backend-shaping knobs the factory owns and forwards to the executor. */
+export interface StoryExecOpts {
+    /** Default model for the OpenAI path when the route names none. */
+    openaiModel?: string
+    /** Effort level for the Claude path (`claude --effort`). */
+    effort?: string
+}
+
+/** A story that has started running. `dispose` detaches it once it settles. */
+export interface StoryExecution {
+    /** Release bus membership / resources after the StoryResult lands. */
+    dispose(env: AgenticEnvironment): void
+}
+
+/**
+ * Where a story's agent loop runs. `start` must kick off execution and ensure
+ * the agent's bus events (ending in `StoryResult`) reach `env`; it returns a
+ * handle the factory disposes when the story settles.
+ */
+export interface StoryExecutor {
+    start(
+        req: StorySpawnRequestData,
+        route: StoryRoute,
+        cwd: string,
+        env: AgenticEnvironment,
+        opts: StoryExecOpts,
+    ): StoryExecution
+}
+
+type AnyStoryAgent =
+    | StoryAgent
+    | OpenAIStoryAgent
+    | CodexStoryAgent
+    | OpenCodeStoryAgent
+    | PiStoryAgent
+
+/**
+ * In-process executor — the historical path. Builds the backend agent for the
+ * resolved route, joins it to the bus, and fire-and-forgets its run loop; the
+ * StoryResult arrives on the bus when it settles.
+ */
+export class LocalStoryExecutor implements StoryExecutor {
+    start(
+        req: StorySpawnRequestData,
+        route: StoryRoute,
+        cwd: string,
+        env: AgenticEnvironment,
+        opts: StoryExecOpts,
+    ): StoryExecution {
+        const agent: AnyStoryAgent =
+            route.backend === "pi"
+                ? new PiStoryAgent({
+                      id: req.storyId,
+                      prompt: req.prompt,
+                      cwd,
+                      model: route.model,
+                      retries: req.retries,
+                      timeoutSecs: req.timeoutSecs,
+                  })
+                : route.backend === "opencode"
+                ? new OpenCodeStoryAgent({
+                      id: req.storyId,
+                      prompt: req.prompt,
+                      cwd,
+                      model: route.model,
+                      retries: req.retries,
+                      timeoutSecs: req.timeoutSecs,
+                  })
+                : route.backend === "codex"
+                ? new CodexStoryAgent({
+                      id: req.storyId,
+                      prompt: req.prompt,
+                      cwd,
+                      // undefined → let Codex pick its account default.
+                      model: route.model,
+                      retries: req.retries,
+                      timeoutSecs: req.timeoutSecs,
+                  })
+                : route.backend === "openai"
+                ? new OpenAIStoryAgent(
+                      {
+                          id: req.storyId,
+                          prompt: req.prompt,
+                          cwd,
+                          model: route.model,
+                          retries: req.retries,
+                          timeoutSecs: req.timeoutSecs,
+                      },
+                      {
+                          model: route.model ?? opts.openaiModel,
+                          baseUrl: route.baseUrl,
+                          apiKey: route.apiKey,
+                      },
+                  )
+                : new StoryAgent({
+                      id: req.storyId,
+                      prompt: req.prompt,
+                      cwd,
+                      // undefined → StoryAgent applies its own default.
+                      model: route.model,
+                      effort: opts.effort,
+                      retries: req.retries,
+                      timeoutSecs: req.timeoutSecs,
+                  })
+
+        agent.join(env)
+
+        // Fire-and-forget: the StoryResult event arrives on the bus when the
+        // run settles, and Conductor reacts to that.
+        void agent.run(env)
+
+        return { dispose: (e: AgenticEnvironment) => agent.leave(e) }
+    }
+}

--- a/packages/baro-orchestrator/src/participants/story-factory.ts
+++ b/packages/baro-orchestrator/src/participants/story-factory.ts
@@ -23,11 +23,11 @@ import {
     StorySpawned,
     type StorySpawnRequestData,
 } from "../semantic-events.js"
-import { CodexStoryAgent } from "./codex-story-agent.js"
-import { OpenAIStoryAgent } from "./openai-story-agent.js"
-import { OpenCodeStoryAgent } from "./opencode-story-agent.js"
-import { PiStoryAgent } from "./pi-story-agent.js"
-import { StoryAgent } from "./story-agent.js"
+import {
+    LocalStoryExecutor,
+    type StoryExecution,
+    type StoryExecutor,
+} from "./story-executor.js"
 import {
     formatRoute,
     resolveStoryRoute,
@@ -94,22 +94,26 @@ export interface StoryFactoryOptions {
      * names resolve on `llm` exactly as before.
      */
     tierMap?: TierMap
+    /**
+     * Where stories actually run. Default: in-process (`LocalStoryExecutor`).
+     * Inject an alternative — a mock for tests, or an out-of-process / remote
+     * executor — to run the agent loop elsewhere without touching any other
+     * participant.
+     */
+    executor?: StoryExecutor
 }
 
 export class StoryFactory extends BaseObserver {
-    // Typed as BaroEnvironment because StoryAgent.run() / join() still
-    // expect the old environment type. Once StoryAgent migrates, this
-    // narrows to vanilla AgenticEnvironment.
+    /** The bus environment, wired in before any spawn; passed to the executor. */
     private envRef: AgenticEnvironment | null = null
-    private readonly active: Map<
-        string,
-        StoryAgent | OpenAIStoryAgent | CodexStoryAgent | OpenCodeStoryAgent | PiStoryAgent
-    > = new Map()
+    private readonly active: Map<string, StoryExecution> = new Map()
     /** Story ids whose spawn is in progress (closes the await-create window). */
     private readonly spawning = new Set<string>()
+    private readonly executor: StoryExecutor
 
     constructor(private readonly opts: StoryFactoryOptions) {
         super()
+        this.executor = opts.executor ?? new LocalStoryExecutor()
     }
 
     setEnvironment(env: AgenticEnvironment): void {
@@ -125,12 +129,12 @@ export class StoryFactory extends BaseObserver {
             return
         }
 
-        // When a story finishes (passes or fails), drop our reference so
-        // we can clean up its bus membership.
+        // When a story finishes (passes or fails), dispose its execution so we
+        // can clean up its bus membership / executor resources.
         if (StoryResult.is(event)) {
-            const agent = this.active.get(event.data.storyId)
-            if (agent && this.envRef) {
-                agent.leave(this.envRef)
+            const exec = this.active.get(event.data.storyId)
+            if (exec && this.envRef) {
+                exec.dispose(this.envRef)
                 this.active.delete(event.data.storyId)
             }
         }
@@ -181,70 +185,14 @@ export class StoryFactory extends BaseObserver {
             ? (await this.opts.worktrees.create(req.storyId)) ?? this.opts.cwd
             : this.opts.cwd
 
-        const agent: StoryAgent | OpenAIStoryAgent | CodexStoryAgent | OpenCodeStoryAgent | PiStoryAgent =
-            route.backend === "pi"
-                ? new PiStoryAgent({
-                      id: req.storyId,
-                      prompt: req.prompt,
-                      cwd: storyCwd,
-                      model: route.model,
-                      retries: req.retries,
-                      timeoutSecs: req.timeoutSecs,
-                  })
-                : route.backend === "opencode"
-                ? new OpenCodeStoryAgent({
-                      id: req.storyId,
-                      prompt: req.prompt,
-                      cwd: storyCwd,
-                      model: route.model,
-                      retries: req.retries,
-                      timeoutSecs: req.timeoutSecs,
-                  })
-                : route.backend === "codex"
-                    ? new CodexStoryAgent({
-                          id: req.storyId,
-                          prompt: req.prompt,
-                          cwd: storyCwd,
-                          // undefined → let Codex pick its account default.
-                          model: route.model,
-                          retries: req.retries,
-                          timeoutSecs: req.timeoutSecs,
-                      })
-                    : route.backend === "openai"
-                        ? new OpenAIStoryAgent(
-                              {
-                                  id: req.storyId,
-                                  prompt: req.prompt,
-                                  cwd: storyCwd,
-                                  model: route.model,
-                                  retries: req.retries,
-                                  timeoutSecs: req.timeoutSecs,
-                              },
-                              {
-                                  model: route.model ?? this.opts.openaiModel,
-                                  baseUrl: route.baseUrl,
-                                  apiKey: route.apiKey,
-                              },
-                          )
-                        : new StoryAgent({
-                              id: req.storyId,
-                              prompt: req.prompt,
-                              cwd: storyCwd,
-                              // undefined → StoryAgent applies its own default.
-                              model: route.model,
-                              effort: this.opts.effort,
-                              retries: req.retries,
-                              timeoutSecs: req.timeoutSecs,
-                          })
-
-        agent.join(this.envRef)
-        this.active.set(req.storyId, agent)
-
-        // The agent's run() returns a Promise but we don't await it
-        // here — the StoryResult event will arrive on the bus when it
-        // settles, and Conductor reacts to that. Pure fire-and-forget
-        // event-driven flow.
-        void agent.run(this.envRef)
+        // Run the story — in-process by default, or via an injected executor
+        // that runs it elsewhere. Either way the StoryResult lands on the bus
+        // when it settles, and Conductor reacts.
+        const exec = this.executor.start(req, route, storyCwd, this.envRef, {
+            openaiModel: this.opts.openaiModel,
+            effort: this.opts.effort,
+        })
+        this.active.set(req.storyId, exec)
 
         // Emit the "yes, agent spawned" notification so observers can
         // see the lifecycle. Conductor doesn't actually need this, but

--- a/packages/baro-orchestrator/test/story-executor.test.ts
+++ b/packages/baro-orchestrator/test/story-executor.test.ts
@@ -1,0 +1,100 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+
+import type {
+    AgenticEnvironment,
+    Participant,
+    SemanticEvent,
+} from "@mozaik-ai/core"
+
+import {
+    StoryResult,
+    StorySpawnRequest,
+    StorySpawned,
+} from "../src/semantic-events.js"
+import { StoryFactory } from "../src/participants/story-factory.js"
+import { LocalStoryExecutor } from "../src/participants/story-executor.js"
+import type {
+    StoryExecOpts,
+    StoryExecution,
+    StoryExecutor,
+} from "../src/participants/story-executor.js"
+import type { StoryRoute } from "../src/routing.js"
+
+function source(id: string): Participant {
+    return { agentId: id } as unknown as Participant
+}
+
+function spawn(storyId: string, model = "sonnet") {
+    return StorySpawnRequest.create({
+        storyId,
+        prompt: "do it",
+        model,
+        retries: 1,
+        timeoutSecs: 60,
+    })
+}
+
+function settle(storyId: string) {
+    return StoryResult.create({
+        storyId,
+        success: true,
+        attempts: 1,
+        durationSecs: 1,
+        error: null,
+    })
+}
+
+describe("StoryFactory — StoryExecutor seam", () => {
+    it("delegates to the injected executor and disposes the execution on StoryResult", async () => {
+        const starts: Array<{ storyId: string; route: StoryRoute; cwd: string; opts: StoryExecOpts }> = []
+        const disposed: string[] = []
+
+        // An out-of-process-style executor: records the dispatch instead of
+        // running an agent in-process. The factory can't tell the difference.
+        const fake: StoryExecutor = {
+            start(req, route, cwd, _env, opts): StoryExecution {
+                starts.push({ storyId: req.storyId, route, cwd, opts })
+                return { dispose: () => disposed.push(req.storyId) }
+            },
+        }
+
+        const delivered: SemanticEvent<unknown>[] = []
+        const env = {
+            deliverSemanticEvent: (_s: unknown, e: SemanticEvent<unknown>) => {
+                delivered.push(e)
+            },
+        } as unknown as AgenticEnvironment
+
+        const factory = new StoryFactory({ cwd: "/work", executor: fake })
+        factory.setEnvironment(env)
+
+        await factory.onExternalEvent(source("conductor"), spawn("S1"))
+
+        assert.equal(starts.length, 1, "executor.start called once")
+        assert.equal(starts[0].storyId, "S1")
+        assert.equal(starts[0].cwd, "/work", "shared cwd passed when no worktrees")
+        assert.ok(starts[0].route, "resolved route handed to the executor")
+        assert.ok(
+            delivered.some((e) => StorySpawned.is(e)),
+            "StorySpawned emitted for observers",
+        )
+
+        // A duplicate spawn for the same story is ignored (idempotent).
+        await factory.onExternalEvent(source("conductor"), spawn("S1"))
+        assert.equal(starts.length, 1, "duplicate spawn does not start twice")
+
+        // When the story settles, the execution is disposed and forgotten.
+        await factory.onExternalEvent(source("S1"), settle("S1"))
+        assert.deepEqual(disposed, ["S1"], "execution disposed on StoryResult")
+    })
+
+    it("defaults to LocalStoryExecutor when none is injected", () => {
+        const factory = new StoryFactory({ cwd: "/work" })
+        const executor = (factory as unknown as { executor: unknown }).executor
+        assert.ok(
+            executor instanceof LocalStoryExecutor,
+            "wires the in-process executor by default",
+        )
+    })
+})


### PR DESCRIPTION
## What

Introduces a `StoryExecutor` seam between **deciding a story should run** and **running its agent loop somewhere**.

- `StoryFactory` now resolves the route + worktree cwd and **delegates** to a `StoryExecutor`.
- The historical in-process behaviour moves verbatim into `LocalStoryExecutor` (the default).
- Both paths must deliver the agent's bus events — including the terminal `StoryResult` — onto the bus, so Conductor / Critic / Surgeon / Sentry / Librarian / Cartographer can't tell which executor ran.

## Why

Makes execution **pluggable** without touching any other participant: a mock executor for tests, or an out-of-process / remote executor that runs the agent loop elsewhere and re-emits its events. The indistinguishability is the point — every other participant stays unchanged regardless of where execution happens.

## Risk

No behaviour change. Pure refactor + a new injectable seam.
- New `test/story-executor.test.ts` proves an alternative executor is delegated to + disposed, and that the default is `LocalStoryExecutor`.
- `tsc --noEmit` clean; full orchestrator suite **54/54**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
