### PR TITLE
chore: add works.md confirming baro cloud e2e run

### DIFF
--- a/works.md
+++ b/works.md
@@ -1,0 +1,3 @@
+# It works
+
+This file confirms a successful end-to-end run of the baro cloud pipeline.


### PR DESCRIPTION
Adds `works.md` at the repository root confirming a successful end-to-end run of the baro cloud pipeline.

This is the marker artifact for the e2e smoke test of the run pipeline (story S1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)