### PR TITLE
baro-orchestrator (4 stories)

### DIFF
--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -166,6 +166,20 @@ pub enum StoryStatus {
     Skipped,
 }
 
+/// How a replan touched a story (for the ✂ pill + DAG marks).
+#[derive(Debug, Clone, PartialEq)]
+pub enum ReplanMark {
+    Added,
+    Removed(String),
+}
+
+/// Level lifecycle from level_started/level_completed.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LevelRunState {
+    Running,
+    Done { failed: bool },
+}
+
 #[derive(Debug, Clone)]
 pub struct StoryState {
     pub id: String,
@@ -176,6 +190,39 @@ pub struct StoryState {
     pub error: Option<String>,
     pub files_created: u32,
     pub files_modified: u32,
+    /// Highest retry attempt seen; survives the Retrying→Running transition
+    /// so the ↻n pill persists.
+    pub retry_count: u32,
+    /// Last critic verdict (`critique` event); None until the critic speaks.
+    pub critic_pass: Option<bool>,
+    /// Supervisor intervention action (e.g. "aborted") when one fired.
+    pub intervened: Option<String>,
+    /// Some(true) merged, Some(false) merge failed (worktree preserved).
+    pub merge: Option<bool>,
+    pub replan: Option<ReplanMark>,
+    /// Routed "backend:model" lane from the `routed` event.
+    pub route: Option<String>,
+}
+
+impl StoryState {
+    pub fn new(id: String, title: String, depends_on: Vec<String>, status: StoryStatus) -> Self {
+        Self {
+            id,
+            title,
+            depends_on,
+            status,
+            duration_secs: None,
+            error: None,
+            files_created: 0,
+            files_modified: 0,
+            retry_count: 0,
+            critic_pass: None,
+            intervened: None,
+            merge: None,
+            replan: None,
+            route: None,
+        }
+    }
 }
 
 /// One condensed, typed entry in the structured Activity feed (replaces the
@@ -188,6 +235,22 @@ pub struct ActivityEntry {
     pub tool: Option<String>,
     pub op: Option<String>,
     pub ok: Option<bool>,
+    /// Run-machinery event (replan/intervention/recovery/merge) rather than
+    /// agent output — rendered with a distinct ▸ accent prefix.
+    pub system: bool,
+}
+
+impl ActivityEntry {
+    fn system(kind: &str, text: String) -> Self {
+        Self {
+            kind: kind.to_string(),
+            text,
+            tool: None,
+            op: None,
+            ok: None,
+            system: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -280,6 +343,13 @@ pub struct App {
     pub total_cost_usd: f64,
     pub stories: Vec<StoryState>,
     pub dag_levels: Vec<Vec<String>>,
+    /// Resolved execution mode from `init` (focused/sequential/parallel);
+    /// distinct from the `--mode` config knob below.
+    pub run_mode: Option<String>,
+    /// Level ordinal → lifecycle, from level_started/level_completed.
+    pub level_states: HashMap<usize, LevelRunState>,
+    /// Recovery levels: (attempt, story ids), in start order.
+    pub recoveries: Vec<(u32, Vec<String>)>,
     pub active_stories: HashMap<String, ActiveStory>,
     pub completed: u32,
     pub total: u32,
@@ -438,6 +508,9 @@ impl App {
             project: String::new(),
             stories: Vec::new(),
             dag_levels: Vec::new(),
+            run_mode: None,
+            level_states: HashMap::new(),
+            recoveries: Vec::new(),
             active_stories: HashMap::new(),
             completed: 0,
             total: 0,
@@ -545,6 +618,8 @@ impl App {
         self.story_diffs.clear();
         self.total_cost_usd = 0.0;
         self.stories.clear();
+        self.level_states.clear();
+        self.recoveries.clear();
     }
 
     pub fn planning_elapsed_secs(&self) -> u64 {
@@ -686,6 +761,11 @@ impl App {
             }
             count += 1; // trailing empty line
         }
+        // Recovery sections mirror the level layout: 3-line header + one
+        // line per story + trailing empty line (no error sub-lines).
+        for (_, ids) in &self.recoveries {
+            count += 3 + ids.len() as u16 + 1;
+        }
         count
     }
 
@@ -784,11 +864,33 @@ impl App {
         }
     }
 
+    /// Append a system entry to one story's feed, if that story is active.
+    fn push_story_activity(&mut self, id: &str, entry: ActivityEntry) {
+        if let Some(active) = self.active_stories.get_mut(id) {
+            active.activity.push(entry);
+            if active.activity.len() > MAX_LOG_LINES {
+                active.activity.remove(0);
+            }
+        }
+    }
+
+    /// Append a run-level system entry to every active feed so it shows up
+    /// regardless of which agent tab is selected.
+    fn push_run_activity(&mut self, entry: ActivityEntry) {
+        for active in self.active_stories.values_mut() {
+            active.activity.push(entry.clone());
+            if active.activity.len() > MAX_LOG_LINES {
+                active.activity.remove(0);
+            }
+        }
+    }
+
     pub fn handle_event(&mut self, event: BaroEvent) {
         match event {
-            BaroEvent::Init { project, stories, runner } => {
+            BaroEvent::Init { project, stories, runner, mode } => {
                 self.project = project;
                 self.runner = runner;
+                self.run_mode = mode;
                 self.total = stories.len() as u32;
                 // On resume the orchestrator emits Init with every story
                 // but doesn't replay StoryComplete for prior-run finishes —
@@ -803,20 +905,16 @@ impl App {
                             .find(|r| r.id == s.id)
                             .map(|r| r.completed)
                             .unwrap_or(false);
-                        StoryState {
-                            id: s.id,
-                            title: s.title,
-                            depends_on: s.depends_on,
-                            status: if already_done {
+                        StoryState::new(
+                            s.id,
+                            s.title,
+                            s.depends_on,
+                            if already_done {
                                 StoryStatus::Complete
                             } else {
                                 StoryStatus::Pending
                             },
-                            duration_secs: None,
-                            error: None,
-                            files_created: 0,
-                            files_modified: 0,
-                        }
+                        )
                     })
                     .collect();
                 self.start_time = Instant::now();
@@ -856,9 +954,9 @@ impl App {
                 self.log_scroll_offsets.entry(id).or_insert(usize::MAX);
             }
 
-            BaroEvent::Activity { id, kind, text, tool, op, ok } => {
+            BaroEvent::Activity { id, kind, text, tool, path: _, op, ok } => {
                 if let Some(active) = self.active_stories.get_mut(&id) {
-                    active.activity.push(ActivityEntry { kind, text, tool, op, ok });
+                    active.activity.push(ActivityEntry { kind, text, tool, op, ok, system: false });
                     if active.activity.len() > MAX_LOG_LINES {
                         active.activity.remove(0);
                     }
@@ -881,16 +979,16 @@ impl App {
                     // Resume: the story finished in a prior run and isn't in
                     // app.stories — push a synthetic entry so duration_secs
                     // feeds the completion screen's sequential-time sum.
-                    self.stories.push(StoryState {
-                        id: id.clone(),
-                        title: id.clone(),
-                        depends_on: Vec::new(),
-                        status: StoryStatus::Complete,
-                        duration_secs: Some(duration_secs),
-                        error: None,
-                        files_created,
-                        files_modified,
-                    });
+                    let mut s = StoryState::new(
+                        id.clone(),
+                        id.clone(),
+                        Vec::new(),
+                        StoryStatus::Complete,
+                    );
+                    s.duration_secs = Some(duration_secs);
+                    s.files_created = files_created;
+                    s.files_modified = files_modified;
+                    self.stories.push(s);
                 }
                 self.active_stories.remove(&id);
                 let count = self.active_stories.len();
@@ -919,6 +1017,7 @@ impl App {
             BaroEvent::StoryRetry { id, attempt } => {
                 if let Some(story) = self.stories.iter_mut().find(|s| s.id == id) {
                     story.status = StoryStatus::Retrying(attempt);
+                    story.retry_count = story.retry_count.max(attempt);
                 }
             }
 
@@ -1038,6 +1137,118 @@ impl App {
                 }
             }
 
+            BaroEvent::Replan { source, reason, added, removed, rewired } => {
+                for a in added {
+                    if let Some(existing) = self.stories.iter_mut().find(|s| s.id == a.id) {
+                        existing.replan = Some(ReplanMark::Added);
+                        existing.depends_on = a.depends_on;
+                    } else {
+                        let mut s = StoryState::new(
+                            a.id,
+                            a.title,
+                            a.depends_on,
+                            StoryStatus::Pending,
+                        );
+                        s.replan = Some(ReplanMark::Added);
+                        self.stories.push(s);
+                    }
+                }
+                for id in removed {
+                    if let Some(story) = self.stories.iter_mut().find(|s| s.id == id) {
+                        story.replan = Some(ReplanMark::Removed(reason.clone()));
+                        if story.status == StoryStatus::Pending
+                            || story.status == StoryStatus::Running
+                        {
+                            story.status = StoryStatus::Skipped;
+                        }
+                    }
+                    self.active_stories.remove(&id);
+                }
+                for r in rewired {
+                    if let Some(story) = self.stories.iter_mut().find(|s| s.id == r.id) {
+                        story.depends_on = r.depends_on;
+                    }
+                }
+                self.total = self.stories.len() as u32;
+                self.push_run_activity(ActivityEntry::system(
+                    "replan",
+                    format!("replan ({}): {}", source, reason),
+                ));
+            }
+
+            BaroEvent::Intervention { id, source, action, reason } => {
+                if let Some(story) = self.stories.iter_mut().find(|s| s.id == id) {
+                    story.intervened = Some(action.clone());
+                }
+                self.push_story_activity(
+                    &id,
+                    ActivityEntry::system(
+                        "warn",
+                        format!("intervention ({}): {} — {}", source, action, reason),
+                    ),
+                );
+            }
+
+            BaroEvent::StoryMerged { id, mode } => {
+                if let Some(story) = self.stories.iter_mut().find(|s| s.id == id) {
+                    story.merge = Some(true);
+                }
+                self.push_run_activity(ActivityEntry::system(
+                    "merge",
+                    format!("{} merged ({})", id, mode),
+                ));
+            }
+
+            BaroEvent::MergeFailed { id, error } => {
+                if let Some(story) = self.stories.iter_mut().find(|s| s.id == id) {
+                    story.merge = Some(false);
+                }
+                self.push_run_activity(ActivityEntry::system(
+                    "error",
+                    format!("{} merge failed: {}", id, error),
+                ));
+            }
+
+            BaroEvent::LevelStarted { ordinal, story_ids: _ } => {
+                self.level_states.insert(ordinal, LevelRunState::Running);
+            }
+
+            BaroEvent::LevelCompleted { ordinal, passed: _, failed } => {
+                self.level_states
+                    .insert(ordinal, LevelRunState::Done { failed: !failed.is_empty() });
+            }
+
+            BaroEvent::RecoveryStarted { attempt, story_ids } => {
+                self.push_run_activity(ActivityEntry::system(
+                    "recovery",
+                    format!("recovery attempt {} — {}", attempt, story_ids.join(", ")),
+                ));
+                self.recoveries.push((attempt, story_ids));
+            }
+
+            BaroEvent::Routed { id, backend, model } => {
+                if let Some(story) = self.stories.iter_mut().find(|s| s.id == id) {
+                    story.route = Some(format!("{}:{}", backend, model));
+                }
+            }
+
+            BaroEvent::Critique { id, verdict, reasoning, violated } => {
+                let pass = verdict == "pass";
+                if let Some(story) = self.stories.iter_mut().find(|s| s.id == id) {
+                    story.critic_pass = Some(pass);
+                }
+                let text = if pass {
+                    "critic: pass".to_string()
+                } else if violated.is_empty() {
+                    format!("critic: fail — {}", reasoning)
+                } else {
+                    format!("critic: fail — {} (violated: {})", reasoning, violated.join(", "))
+                };
+                let mut entry = ActivityEntry::system("verdict", text);
+                entry.ok = Some(pass);
+                self.push_story_activity(&id, entry);
+            }
+
             BaroEvent::OrchestratorExited { code, reason } => {
                 // If a normal `Done` event already arrived, this is just
                 // a redundant terminator — keep the previous final state.
@@ -1079,6 +1290,11 @@ impl App {
         }
     }
 
+    #[cfg(test)]
+    fn story(&self, id: &str) -> &StoryState {
+        self.stories.iter().find(|s| s.id == id).unwrap()
+    }
+
     pub fn model_for_phase(&self, phase: &str) -> Option<String> {
         // Global `--model` always wins.
         if let Some(ref model) = self.override_model {
@@ -1117,5 +1333,85 @@ impl App {
             };
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn feed(app: &mut App, json: &str) {
+        app.handle_event(serde_json::from_str(json).expect(json));
+    }
+
+    fn app_with_run() -> App {
+        let mut app = App::new();
+        feed(
+            &mut app,
+            r#"{"type":"init","project":"p","mode":"focused",
+                "stories":[{"id":"S1","title":"One"},{"id":"S2","title":"Two","depends_on":["S1"]}]}"#,
+        );
+        feed(&mut app, r#"{"type":"story_start","id":"S1","title":"One"}"#);
+        app
+    }
+
+    #[test]
+    fn v2_events_update_story_signals() {
+        let mut app = app_with_run();
+        assert_eq!(app.run_mode.as_deref(), Some("focused"));
+
+        feed(&mut app, r#"{"type":"routed","id":"S1","backend":"codex","model":"gpt-5.3"}"#);
+        assert_eq!(app.story("S1").route.as_deref(), Some("codex:gpt-5.3"));
+
+        feed(&mut app, r#"{"type":"critique","id":"S1","verdict":"fail","reasoning":"no tests","violated":["AC1"]}"#);
+        assert_eq!(app.story("S1").critic_pass, Some(false));
+        // Story-scoped system entry lands in the active story's feed.
+        let feed_s1 = &app.active_stories.get("S1").unwrap().activity;
+        assert!(feed_s1.last().unwrap().system);
+        assert!(feed_s1.last().unwrap().text.contains("AC1"));
+
+        feed(&mut app, r#"{"type":"story_retry","id":"S1","attempt":2}"#);
+        assert_eq!(app.story("S1").retry_count, 2);
+
+        feed(&mut app, r#"{"type":"intervention","id":"S1","source":"sentry","action":"aborted","reason":"stall"}"#);
+        assert_eq!(app.story("S1").intervened.as_deref(), Some("aborted"));
+
+        feed(&mut app, r#"{"type":"story_merged","id":"S1","mode":"worktree"}"#);
+        assert_eq!(app.story("S1").merge, Some(true));
+        feed(&mut app, r#"{"type":"merge_failed","id":"S2","error":"conflict"}"#);
+        assert_eq!(app.story("S2").merge, Some(false));
+    }
+
+    #[test]
+    fn replan_adds_removes_and_rewires() {
+        let mut app = app_with_run();
+        feed(
+            &mut app,
+            r#"{"type":"replan","source":"sentry","reason":"scope shift",
+                "added":[{"id":"S3","title":"Three","depends_on":["S1"]}],
+                "removed":["S2"],"rewired":[{"id":"S1","depends_on":[]}]}"#,
+        );
+        assert_eq!(app.story("S3").replan, Some(ReplanMark::Added));
+        assert_eq!(app.story("S3").depends_on, vec!["S1"]);
+        assert_eq!(
+            app.story("S2").replan,
+            Some(ReplanMark::Removed("scope shift".into()))
+        );
+        assert_eq!(app.story("S2").status, StoryStatus::Skipped);
+        assert_eq!(app.total, 3);
+        // Run-level system entry is fanned out to active feeds.
+        let feed_s1 = &app.active_stories.get("S1").unwrap().activity;
+        assert!(feed_s1.last().unwrap().text.contains("scope shift"));
+    }
+
+    #[test]
+    fn level_and_recovery_state() {
+        let mut app = app_with_run();
+        feed(&mut app, r#"{"type":"level_started","ordinal":0,"story_ids":["S1"]}"#);
+        assert_eq!(app.level_states.get(&0), Some(&LevelRunState::Running));
+        feed(&mut app, r#"{"type":"level_completed","ordinal":0,"passed":[],"failed":["S1"]}"#);
+        assert_eq!(app.level_states.get(&0), Some(&LevelRunState::Done { failed: true }));
+        feed(&mut app, r#"{"type":"recovery_started","attempt":1,"story_ids":["S1"]}"#);
+        assert_eq!(app.recoveries, vec![(1, vec!["S1".to_string()])]);
     }
 }

--- a/crates/baro-tui/src/events.rs
+++ b/crates/baro-tui/src/events.rs
@@ -33,6 +33,24 @@ pub struct DiffFile {
     pub removed: u32,
 }
 
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct ReplanStory {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct ReplanRewire {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(tag = "type")]
 pub enum BaroEvent {
@@ -44,6 +62,9 @@ pub enum BaroEvent {
         /// backwards-compat with orchestrators that don't emit it.
         #[serde(default)]
         runner: Option<String>,
+        /// Resolved execution mode (focused/sequential/parallel).
+        #[serde(default)]
+        mode: Option<String>,
     },
 
     #[serde(rename = "dag")]
@@ -71,6 +92,10 @@ pub enum BaroEvent {
         text: String,
         #[serde(default)]
         tool: Option<String>,
+        // Contract field (file_change); not rendered yet.
+        #[allow(dead_code)]
+        #[serde(default)]
+        path: Option<String>,
         #[serde(default)]
         op: Option<String>,
         #[serde(default)]
@@ -175,6 +200,103 @@ pub enum BaroEvent {
         diff: Option<String>,
     },
 
+    // --- v2 structured semantic events (docs/tui-protocol-v2.md). All
+    // fields default so the TUI tolerates partial/growing payloads.
+    #[serde(rename = "replan")]
+    Replan {
+        #[serde(default)]
+        source: String,
+        #[serde(default)]
+        reason: String,
+        #[serde(default)]
+        added: Vec<ReplanStory>,
+        #[serde(default)]
+        removed: Vec<String>,
+        #[serde(default)]
+        rewired: Vec<ReplanRewire>,
+    },
+
+    #[serde(rename = "intervention")]
+    Intervention {
+        #[serde(default)]
+        id: String,
+        #[serde(default)]
+        source: String,
+        #[serde(default)]
+        action: String,
+        #[serde(default)]
+        reason: String,
+    },
+
+    #[serde(rename = "story_merged")]
+    StoryMerged {
+        #[serde(default)]
+        id: String,
+        #[serde(default)]
+        mode: String,
+    },
+
+    #[serde(rename = "merge_failed")]
+    MergeFailed {
+        #[serde(default)]
+        id: String,
+        #[serde(default)]
+        error: String,
+    },
+
+    #[serde(rename = "level_started")]
+    LevelStarted {
+        #[serde(default)]
+        ordinal: usize,
+        // Contract field; per-story state comes from story events.
+        #[allow(dead_code)]
+        #[serde(default)]
+        story_ids: Vec<String>,
+    },
+
+    #[serde(rename = "level_completed")]
+    LevelCompleted {
+        #[serde(default)]
+        ordinal: usize,
+        // Contract field; per-story state comes from story events.
+        #[allow(dead_code)]
+        #[serde(default)]
+        passed: Vec<String>,
+        #[serde(default)]
+        failed: Vec<String>,
+    },
+
+    #[serde(rename = "recovery_started")]
+    RecoveryStarted {
+        #[serde(default)]
+        attempt: u32,
+        #[serde(default)]
+        story_ids: Vec<String>,
+    },
+
+    #[serde(rename = "routed")]
+    Routed {
+        #[serde(default)]
+        id: String,
+        #[serde(default)]
+        backend: String,
+        #[serde(default)]
+        model: String,
+    },
+
+    #[serde(rename = "critique")]
+    Critique {
+        #[serde(default)]
+        id: String,
+        /// "pass" | "fail"
+        #[serde(default)]
+        verdict: String,
+        #[serde(default)]
+        reasoning: String,
+        #[serde(default)]
+        violated: Vec<String>,
+    },
+
     /// Synthetic event the orchestrator client emits exactly once when
     /// the orchestrator subprocess terminates — whether cleanly with a
     /// preceding `Done` event or abruptly. Lets the TUI escape any
@@ -185,4 +307,115 @@ pub enum BaroEvent {
         code: Option<i32>,
         reason: Option<String>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> BaroEvent {
+        serde_json::from_str(json).expect(json)
+    }
+
+    #[test]
+    fn parses_replan() {
+        let e = parse(
+            r#"{"type":"replan","source":"sentry","reason":"scope shift",
+                "added":[{"id":"S9","title":"New story","depends_on":["S1"]}],
+                "removed":["S3"],"rewired":[{"id":"S4","depends_on":["S9"]}]}"#,
+        );
+        match e {
+            BaroEvent::Replan { added, removed, rewired, .. } => {
+                assert_eq!(added[0].id, "S9");
+                assert_eq!(added[0].depends_on, vec!["S1"]);
+                assert_eq!(removed, vec!["S3"]);
+                assert_eq!(rewired[0].depends_on, vec!["S9"]);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_intervention_and_merge_events() {
+        match parse(r#"{"type":"intervention","id":"S1","source":"sentry","action":"aborted","reason":"stall"}"#) {
+            BaroEvent::Intervention { id, action, .. } => {
+                assert_eq!(id, "S1");
+                assert_eq!(action, "aborted");
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+        match parse(r#"{"type":"story_merged","id":"S1","mode":"worktree"}"#) {
+            BaroEvent::StoryMerged { id, mode } => {
+                assert_eq!((id.as_str(), mode.as_str()), ("S1", "worktree"));
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+        match parse(r#"{"type":"merge_failed","id":"S2","error":"conflict"}"#) {
+            BaroEvent::MergeFailed { id, error } => {
+                assert_eq!((id.as_str(), error.as_str()), ("S2", "conflict"));
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_level_and_recovery_events() {
+        match parse(r#"{"type":"level_started","ordinal":2,"story_ids":["S3","S4"]}"#) {
+            BaroEvent::LevelStarted { ordinal, story_ids } => {
+                assert_eq!(ordinal, 2);
+                assert_eq!(story_ids, vec!["S3", "S4"]);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+        match parse(r#"{"type":"level_completed","ordinal":2,"passed":["S3"],"failed":["S4"]}"#) {
+            BaroEvent::LevelCompleted { passed, failed, .. } => {
+                assert_eq!(passed, vec!["S3"]);
+                assert_eq!(failed, vec!["S4"]);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+        match parse(r#"{"type":"recovery_started","attempt":1,"story_ids":["S4"]}"#) {
+            BaroEvent::RecoveryStarted { attempt, story_ids } => {
+                assert_eq!(attempt, 1);
+                assert_eq!(story_ids, vec!["S4"]);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_routed_and_critique() {
+        match parse(r#"{"type":"routed","id":"S1","backend":"codex","model":"gpt-5.3-codex"}"#) {
+            BaroEvent::Routed { id, backend, model } => {
+                assert_eq!((id.as_str(), backend.as_str(), model.as_str()), ("S1", "codex", "gpt-5.3-codex"));
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+        match parse(r#"{"type":"critique","id":"S1","verdict":"fail","reasoning":"missing tests","violated":["AC2"]}"#) {
+            BaroEvent::Critique { verdict, violated, .. } => {
+                assert_eq!(verdict, "fail");
+                assert_eq!(violated, vec!["AC2"]);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn tolerates_missing_and_unknown_fields() {
+        // Minimal payloads (defaults) and unknown extra fields must both parse.
+        parse(r#"{"type":"replan"}"#);
+        parse(r#"{"type":"critique","id":"S1"}"#);
+        parse(r#"{"type":"routed","id":"S1","backend":"claude","model":"opus","future_field":42}"#);
+        match parse(r#"{"type":"activity","id":"S1","kind":"file_change","text":"src/a.rs","path":"src/a.rs","op":"modify"}"#) {
+            BaroEvent::Activity { path, op, .. } => {
+                assert_eq!(path.as_deref(), Some("src/a.rs"));
+                assert_eq!(op.as_deref(), Some("modify"));
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+        match parse(r#"{"type":"init","project":"p","stories":[],"mode":"focused"}"#) {
+            BaroEvent::Init { mode, .. } => assert_eq!(mode.as_deref(), Some("focused")),
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
 }

--- a/crates/baro-tui/src/screens/execute.rs
+++ b/crates/baro-tui/src/screens/execute.rs
@@ -96,7 +96,7 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
     let elapsed = app.elapsed_secs();
     let counts = count_stories(app);
 
-    let info_line = Line::from(vec![
+    let mut info_spans = vec![
         Span::styled(
             " BARO ",
             Style::default().fg(theme::LOGO_1).add_modifier(Modifier::BOLD),
@@ -106,6 +106,16 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
             &app.project,
             Style::default().fg(theme::TEXT).add_modifier(Modifier::BOLD),
         ),
+    ];
+    if let Some(mode) = &app.run_mode {
+        if !mode.is_empty() {
+            info_spans.push(Span::styled(
+                format!(" {} ", mode),
+                Style::default().fg(theme::TEXT_DIM),
+            ));
+        }
+    }
+    info_spans.extend([
         Span::styled(" \u{2502} ", Style::default().fg(theme::BORDER)),
         Span::styled(
             format!("{}/{}", counts.passed, counts.total),
@@ -117,6 +127,7 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(theme::MUTED),
         ),
     ]);
+    let info_line = Line::from(info_spans);
 
     let info = Paragraph::new(info_line).block(
         Block::default()
@@ -220,8 +231,7 @@ fn render_progress(f: &mut Frame, app: &App, area: Rect) {
 
 // --- Shared: Status Bar ---
 // Full-width run status, mirroring the web run-view bar:
-//   ● status · elapsed · agents · tokens · files · repo
-// (cost + runner id are not tracked in App yet — see report.)
+//   ● status · elapsed · agents · tokens · files [· cost] · repo [· runner] [· branch] [· PR]
 
 fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
     let counts = count_stories(app);
@@ -301,6 +311,20 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(theme::MUTED),
             ));
         }
+    }
+    if !app.branch_name.is_empty() {
+        spans.push(sep());
+        spans.push(Span::styled(
+            format!("\u{2387} {}", app.branch_name),
+            Style::default().fg(theme::TEXT_DIM),
+        ));
+    }
+    if let Some(pr_url) = &app.pr_url {
+        spans.push(sep());
+        spans.push(Span::styled(
+            pr_url.clone(),
+            Style::default().fg(theme::ACCENT_DIM),
+        ));
     }
 
     f.render_widget(Paragraph::new(Line::from(spans)), area);

--- a/crates/baro-tui/src/screens/execute_dag.rs
+++ b/crates/baro-tui/src/screens/execute_dag.rs
@@ -6,7 +6,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::App;
+use crate::app::{App, LevelRunState, ReplanMark};
 use crate::screens::execute::status_icon_color;
 use crate::theme;
 
@@ -50,6 +50,20 @@ pub fn render_dag_full(f: &mut Frame, app: &App, area: Rect) {
                 } else {
                     Span::raw("")
                 },
+                // Level lifecycle from level_started/level_completed; silent
+                // until the orchestrator says something.
+                match app.level_states.get(&i) {
+                    Some(LevelRunState::Running) => {
+                        Span::styled("  \u{25CF} running", Style::default().fg(theme::ACCENT))
+                    }
+                    Some(LevelRunState::Done { failed: false }) => {
+                        Span::styled("  ✓ done", Style::default().fg(theme::SUCCESS))
+                    }
+                    Some(LevelRunState::Done { failed: true }) => {
+                        Span::styled("  ✗ failed", Style::default().fg(theme::ERROR))
+                    }
+                    None => Span::raw(""),
+                },
             ]));
             lines.push(Line::from(vec![
                 Span::styled("  \u{2514}", Style::default().fg(theme::ACCENT_DIM)),
@@ -80,23 +94,43 @@ pub fn render_dag_full(f: &mut Frame, app: &App, area: Rect) {
                         "  \u{2502}   \u{251c}\u{2500}\u{2500} "
                     };
 
+                    let removed_reason = match &story.replan {
+                        Some(ReplanMark::Removed(reason)) => Some(reason.clone()),
+                        _ => None,
+                    };
+                    let name_style = if removed_reason.is_some() {
+                        Style::default().fg(theme::MUTED).add_modifier(Modifier::CROSSED_OUT)
+                    } else {
+                        Style::default().fg(color)
+                    };
+
                     let mut spans = vec![
                         Span::styled(connector, Style::default().fg(theme::BORDER)),
+                    ];
+                    if matches!(story.replan, Some(ReplanMark::Added)) {
+                        spans.push(Span::styled("+", Style::default().fg(theme::REPLAN)));
+                    }
+                    spans.extend([
                         Span::styled(
                             format!("{} ", icon),
                             Style::default().fg(color),
                         ),
                         Span::styled(
                             story.id.to_string(),
-                            Style::default()
-                                .fg(color)
-                                .add_modifier(Modifier::BOLD),
+                            name_style.add_modifier(Modifier::BOLD),
                         ),
                         Span::styled(
                             format!(" {}", story.title),
-                            Style::default().fg(color),
+                            name_style,
                         ),
-                    ];
+                    ]);
+
+                    if let Some(reason) = &removed_reason {
+                        spans.push(Span::styled(
+                            format!("  ✂ {}", reason),
+                            Style::default().fg(theme::REPLAN),
+                        ));
+                    }
 
                     if !duration.is_empty() {
                         spans.push(Span::styled(
@@ -141,6 +175,71 @@ pub fn render_dag_full(f: &mut Frame, app: &App, area: Rect) {
                 )));
             }
 
+            lines.push(Line::from(""));
+        }
+
+        // Recovery levels re-run failed stories after the planned DAG; layout
+        // mirrors a level box (3-line header + stories + blank) so the
+        // scroll math in dag_line_count stays exact.
+        for (attempt, ids) in &app.recoveries {
+            let label = format!(" Recovery attempt {} ", attempt);
+            lines.push(Line::from(vec![
+                Span::styled("  \u{250c}", Style::default().fg(theme::WARNING_DIM)),
+                Span::styled(
+                    "\u{2500}".repeat(label.len()),
+                    Style::default().fg(theme::WARNING_DIM),
+                ),
+                Span::styled("\u{2510}", Style::default().fg(theme::WARNING_DIM)),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("  \u{2502}", Style::default().fg(theme::WARNING_DIM)),
+                Span::styled(
+                    label.clone(),
+                    Style::default().fg(theme::WARNING).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled("\u{2502}", Style::default().fg(theme::WARNING_DIM)),
+                Span::styled(
+                    format!(
+                        "  {} {}",
+                        ids.len(),
+                        if ids.len() == 1 { "story" } else { "stories" }
+                    ),
+                    Style::default().fg(theme::MUTED),
+                ),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("  \u{2514}", Style::default().fg(theme::WARNING_DIM)),
+                Span::styled(
+                    "\u{2500}".repeat(label.len()),
+                    Style::default().fg(theme::WARNING_DIM),
+                ),
+                Span::styled("\u{2518}", Style::default().fg(theme::WARNING_DIM)),
+            ]));
+            for (j, story_id) in ids.iter().enumerate() {
+                let connector = if j == ids.len() - 1 {
+                    "  \u{2502}   \u{2514}\u{2500}\u{2500} "
+                } else {
+                    "  \u{2502}   \u{251c}\u{2500}\u{2500} "
+                };
+                let (icon, color, title) = app
+                    .stories
+                    .iter()
+                    .find(|s| s.id == *story_id)
+                    .map(|s| {
+                        let (i, c) = status_icon_color(&s.status);
+                        (i, c, s.title.clone())
+                    })
+                    .unwrap_or(("○", theme::MUTED, String::new()));
+                lines.push(Line::from(vec![
+                    Span::styled(connector, Style::default().fg(theme::BORDER)),
+                    Span::styled(format!("{} ", icon), Style::default().fg(color)),
+                    Span::styled(
+                        story_id.clone(),
+                        Style::default().fg(color).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(format!(" {}", title), Style::default().fg(color)),
+                ]));
+            }
             lines.push(Line::from(""));
         }
     }

--- a/crates/baro-tui/src/screens/execute_dashboard.rs
+++ b/crates/baro-tui/src/screens/execute_dashboard.rs
@@ -9,7 +9,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{ActivityEntry, App, StoryStatus};
+use crate::app::{ActivityEntry, App, ReplanMark, StoryStatus};
 use crate::theme;
 
 pub fn render_dashboard(f: &mut Frame, app: &mut App, area: Rect) {
@@ -125,11 +125,6 @@ fn story_list_item(
         .map(|d| format!(" ({}:{:02})", d / 60, d % 60))
         .unwrap_or_default();
 
-    let retry_info = match &story.status {
-        StoryStatus::Retrying(n) => format!(" retry #{}", n),
-        _ => String::new(),
-    };
-
     let push_indicator = if story.status == StoryStatus::Complete {
         if let Some((_, success, _)) = push_results.iter().find(|(id, _, _)| id == &story.id) {
             if *success {
@@ -146,28 +141,73 @@ fn story_list_item(
 
     // Truncate title with an ellipsis if it would exceed a reasonable
     // budget for the 35%-width Stories column. The fixed prefix
-    // ("   {icon} {id}: ") is ~7-8 chars, suffixes (duration + retry +
+    // ("   {icon} {id}: ") is ~7-8 chars, suffixes (duration + pills +
     // push indicator) can add ~15 more, so 32 chars for the title keeps
     // the line below ~55 chars total — fits a 35% column on terminals
     // ≥ 160 cols and degrades gracefully (List truncates, scrollbar
     // works) on narrower ones.
     let title = truncate_for_panel(&story.title, 32);
 
+    // Removed-by-replan stories read as struck plan surgery, not failure.
+    let title_style = if matches!(story.replan, Some(ReplanMark::Removed(_))) {
+        Style::default().fg(theme::MUTED).add_modifier(Modifier::CROSSED_OUT)
+    } else {
+        style
+    };
+
     let mut spans = vec![
         Span::raw("   "),
-        Span::styled(
-            format!(
-                "{} {}: {}{}{}",
-                icon, story.id, title, duration, retry_info
-            ),
-            style,
-        ),
+        Span::styled(format!("{} {}: ", icon, story.id), style),
+        Span::styled(title, title_style),
+        Span::styled(duration, style),
     ];
     if let Some(indicator) = push_indicator {
         spans.push(indicator);
     }
+    spans.extend(story_pills(story));
+    if let Some(route) = &story.route {
+        spans.push(Span::styled(
+            format!("  {}", route),
+            Style::default().fg(theme::MUTED),
+        ));
+    }
 
     ListItem::new(Line::from(spans))
+}
+
+/// Compact signal pills after the title — only rendered when the signal
+/// actually fired, so quiet stories stay quiet.
+fn story_pills(story: &crate::app::StoryState) -> Vec<Span<'static>> {
+    let mut pills: Vec<Span> = Vec::new();
+    let mut pill = |text: String, color: ratatui::style::Color| {
+        pills.push(Span::styled(format!(" {}", text), Style::default().fg(color)));
+    };
+
+    let retries = match story.status {
+        StoryStatus::Retrying(n) => n.max(story.retry_count),
+        _ => story.retry_count,
+    };
+    if retries > 0 {
+        pill(format!("↻{}", retries), theme::WARNING);
+    }
+    match story.critic_pass {
+        Some(true) => pill("✓critic".into(), theme::SUCCESS),
+        Some(false) => pill("✗critic".into(), theme::ERROR),
+        None => {}
+    }
+    if let Some(action) = &story.intervened {
+        let color = if action.contains("abort") { theme::ERROR } else { theme::WARNING };
+        pill("⚠stall".into(), color);
+    }
+    match story.merge {
+        Some(true) => pill("✓merged".into(), theme::SUCCESS),
+        Some(false) => pill("✗merge".into(), theme::ERROR),
+        None => {}
+    }
+    if story.replan.is_some() {
+        pill("✂replan".into(), theme::REPLAN);
+    }
+    pills
 }
 
 /// Truncate a string to `max` *characters* (not bytes), appending an
@@ -270,7 +310,7 @@ fn render_logs(f: &mut Frame, app: &App, area: Rect) {
             if i == app.selected_log_index {
                 Span::styled(
                     label,
-                    Style::default().fg(theme::WARNING).add_modifier(Modifier::BOLD),
+                    Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD),
                 )
             } else {
                 Span::styled(label, Style::default().fg(theme::MUTED))
@@ -283,7 +323,7 @@ fn render_logs(f: &mut Frame, app: &App, area: Rect) {
         .style(Style::default().fg(theme::MUTED))
         .highlight_style(
             Style::default()
-                .fg(theme::WARNING)
+                .fg(theme::ACCENT)
                 .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
         )
         .divider(Span::styled("\u{2502}", Style::default().fg(theme::BORDER)));
@@ -296,24 +336,39 @@ fn render_logs(f: &mut Frame, app: &App, area: Rect) {
         .unwrap_or_default();
 
     if let Some(story) = app.active_stories.get(&selected_id) {
-        let total_logs = story.activity.len();
+        // Structured activity is the preferred feed; fall back to raw
+        // story_log lines for backends that emit no activity events.
+        let use_activity = !story.activity.is_empty();
+        let total_logs = if use_activity { story.activity.len() } else { story.logs.len() };
         let inner_height = log_chunks[1].height.saturating_sub(2) as usize;
         let tail = total_logs.saturating_sub(inner_height);
         let stored = app.log_scroll_offsets.get(&selected_id).copied().unwrap_or(usize::MAX);
         let skip = if stored == usize::MAX { tail } else { stored.min(tail) };
         let inner_w = log_chunks[1].width.saturating_sub(3) as usize;
-        let visible_logs: Vec<Line> = story.activity[skip..]
-            .iter()
-            .map(|e| activity_line(e, inner_w))
-            .collect();
+        let visible_logs: Vec<Line> = if use_activity {
+            story.activity[skip..]
+                .iter()
+                .map(|e| activity_line(e, inner_w))
+                .collect()
+        } else {
+            story.logs[skip..]
+                .iter()
+                .map(|l| {
+                    Line::from(Span::styled(
+                        format!(" {}", truncate_for_panel(l, inner_w.saturating_sub(1).max(8))),
+                        Style::default().fg(theme::TEXT_DIM),
+                    ))
+                })
+                .collect()
+        };
 
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(theme::WARNING))
+            .border_style(Style::default().fg(theme::BORDER_ACTIVE))
             .title(Span::styled(
                 format!(" {} ", story.id),
                 Style::default()
-                    .fg(theme::WARNING)
+                    .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             ));
 
@@ -325,7 +380,7 @@ fn render_logs(f: &mut Frame, app: &App, area: Rect) {
             let mut scrollbar_state =
                 ScrollbarState::new(total_logs.saturating_sub(inner_height)).position(skip);
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-                .style(Style::default().fg(theme::WARNING_DIM));
+                .style(Style::default().fg(theme::ACCENT_DIM));
             f.render_stateful_widget(scrollbar, log_chunks[1], &mut scrollbar_state);
         }
     }
@@ -333,8 +388,27 @@ fn render_logs(f: &mut Frame, app: &App, area: Rect) {
 
 /// One Activity entry → a color-coded line. Icon carries the type signal;
 /// file changes + test verdicts color the whole line (diff-like). The panel
-/// is already scoped to one story, so no per-line agent prefix.
+/// is already scoped to one story, so no per-line agent prefix. System
+/// entries (replan/intervention/recovery/merge) get a ▸ accent prefix so run
+/// machinery stands apart from agent output.
 fn activity_line(e: &ActivityEntry, width: usize) -> Line<'static> {
+    if e.system {
+        let text_color = match e.kind.as_str() {
+            "replan" => theme::REPLAN,
+            "warn" | "conflict" => theme::WARNING,
+            "error" => theme::ERROR,
+            "merge" => theme::SUCCESS,
+            "verdict" => {
+                if e.ok == Some(true) { theme::SUCCESS } else { theme::ERROR }
+            }
+            _ => theme::ACCENT,
+        };
+        let budget = width.saturating_sub(2).max(8);
+        return Line::from(vec![
+            Span::styled("▸ ", Style::default().fg(theme::ACCENT)),
+            Span::styled(truncate_for_panel(&e.text, budget), Style::default().fg(text_color)),
+        ]);
+    }
     let (icon, icon_color, text_color) = match e.kind.as_str() {
         "tool_call" => match e.tool.as_deref() {
             Some("bash") => ("$ ", theme::ACCENT, theme::TEXT),

--- a/crates/baro-tui/src/theme.rs
+++ b/crates/baro-tui/src/theme.rs
@@ -15,6 +15,10 @@ pub const WARNING_DIM: Color = Color::Rgb(122, 110, 70);
 pub const ERROR: Color = Color::Rgb(255, 122, 122); // #ff7a7a
 pub const ERROR_DIM: Color = Color::Rgb(120, 70, 70);
 
+// Replan marker — muted magenta, deliberately outside the amber family so
+// DAG surgery reads as "the plan changed", not success/failure.
+pub const REPLAN: Color = Color::Rgb(201, 138, 214); // #c98ad6
+
 pub const TEXT: Color = Color::Rgb(230, 230, 235); // #e6e6eb foreground
 pub const TEXT_DIM: Color = Color::Rgb(139, 139, 143); // #8b8b8f muted-foreground
 pub const MUTED: Color = Color::Rgb(90, 90, 96); // #5a5a60

--- a/docs/semantic-events.md
+++ b/docs/semantic-events.md
@@ -47,6 +47,13 @@ carry no compat constraint beyond "don't rename once shipped"):
 - `story_merged` / `story_merge_failed` — emitted by the GitCoordinator when a
   passed story's work lands on the run branch (worktree merge-back or
   shared-tree reconcile) or the merge-back fails and the worktree is preserved.
+- `recovery_started` — emitted by the Conductor when `tryStartRecoveryLevel`
+  actually starts a recovery level (`attempt` is a 1-based run-level counter).
+  Visibility only: the recovery flow itself stays hook-driven.
+- `story_routed` — emitted by StoryFactory right after `resolveStoryRoute`;
+  the machine-readable twin of the `[story-factory] S1 → backend:model`
+  stderr line (which stays). See docs/tui-protocol-v2.md for the structured
+  BaroEvents these feed.
 
 ## Why type discriminators, not `instanceof`
 

--- a/docs/tui-protocol-v2.md
+++ b/docs/tui-protocol-v2.md
@@ -1,0 +1,45 @@
+# TUI protocol v2 — first-class semantic events
+
+The BaroEvent stream (orchestrator stdout → Rust TUI / cloud control plane)
+historically compressed most bus activity into `story_log` lines. v2 adds
+STRUCTURED events so consumers can render run semantics first-class instead of
+parsing log strings. All additions are backward compatible: old consumers
+ignore unknown `type`s; every new event keeps emitting its old `story_log`
+line alongside for one release.
+
+## New BaroEvent variants (tui-protocol.ts)
+
+| type | fields | source semantic event | consumer rendering |
+|---|---|---|---|
+| `replan` | `source, reason, added: [{id,title,depends_on}], removed: [id], rewired: [{id, depends_on}]` | `Replan` | DAG updates; "replanned" badge on affected stories; activity entry |
+| `intervention` | `id, source, action, reason` | `StoryIntervention` | "stalled → aborted" pill on the agent row; activity warn |
+| `story_merged` | `id, mode: "worktree"\|"shared-tree"` | `StoryMerged` | ✓ merged pill on the agent row |
+| `merge_failed` | `id, error` | `StoryMergeFailed` | ✗ merge-failed pill (worktree preserved) |
+| `level_started` | `ordinal, story_ids` | `LevelStarted` | DAG level highlight |
+| `level_completed` | `ordinal, passed: [id], failed: [id]` | `LevelCompleted` | DAG level state |
+| `recovery_started` | `attempt, story_ids` | `RecoveryStarted` (new) | "recovery attempt N" banner + DAG |
+| `routed` | `id, backend, model` | `StoryRouted` (new) | model lane on the agent row |
+| `critique` | `id, verdict: "pass"\|"fail", reasoning, violated: [string]` | `Critique` | critic pill (✓/✗) on the agent row; activity entry |
+
+## New semantic events (semantic-events.ts)
+
+- `RecoveryStarted { attempt: number, storyIds: string[] }` — wire type
+  `recovery_started`. Emitted by Conductor when `tryStartRecoveryLevel`
+  actually starts a recovery level (visibility; the recovery FLOW stays
+  hook-driven for now — see docs/semantic-events.md deferred list).
+- `StoryRouted { storyId: string, backend: string, model: string }` — wire
+  type `story_routed`. Emitted by StoryFactory right after `resolveStoryRoute`
+  (replaces the stderr-only `[story-factory] S1 → backend:model` as the
+  machine-readable source of truth; the stderr line stays).
+
+## Forwarder mapping rules
+
+One forwarder concern per file (existing pattern in
+`participants/forwarders/`). The forwarders own ALL translation — no `emit()`
+calls for these events anywhere else. `story_log` mirror lines stay for one
+release so older TUIs/dashboards keep working; structured events are the
+source of truth for new consumers.
+
+Existing `activity` events are unchanged; the TUI should now render them
+(kind-colored, story-grouped) instead of relying on the raw `story_log`
+firehose.

--- a/packages/baro-orchestrator/src/participants/conductor.ts
+++ b/packages/baro-orchestrator/src/participants/conductor.ts
@@ -56,6 +56,7 @@ import {
     LevelCompleted,
     LevelComputeRequest,
     LevelStarted,
+    RecoveryStarted,
     Replan,
     RunCompleted,
     RunStartRequest,
@@ -168,6 +169,8 @@ export class Conductor extends BaseObserver {
      */
     private readonly recoveryAttempts: Map<string, number> = new Map()
     private readonly maxRecoveryAttemptsPerStory = 1
+    /** Recovery levels started in this run (1-based `attempt` for RecoveryStarted). */
+    private recoveryLevelsStarted = 0
     private totalAttempts = 0
     private appliedReplans = 0
 
@@ -775,6 +778,13 @@ export class Conductor extends BaseObserver {
             perStoryAttempts: new Map(),
         }
 
+        this.recoveryLevelsStarted += 1
+        this.emit(
+            RecoveryStarted.create({
+                attempt: this.recoveryLevelsStarted,
+                storyIds: this.currentLevel.storyIds,
+            }),
+        )
         this.emit(
             LevelStarted.create({
                 ordinal,

--- a/packages/baro-orchestrator/src/participants/forwarders/coordination.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/coordination.ts
@@ -10,7 +10,11 @@ import {
 } from "../../semantic-events.js"
 import { emit } from "../../tui-protocol.js"
 
-/** Mirrors coordination, critique and intervention notices as `story_log` BaroEvents. */
+/**
+ * Forwards coordination, critique and intervention notices. Critique and
+ * intervention get structured BaroEvents (protocol v2) plus their legacy
+ * `story_log` mirrors for one release.
+ */
 export class CoordinationForwarder extends BaseObserver {
     override async onExternalEvent(
         _source: Participant,
@@ -31,6 +35,13 @@ export class CoordinationForwarder extends BaseObserver {
     }
 
     private handleIntervention(item: StoryInterventionData): void {
+        emit({
+            type: "intervention",
+            id: item.storyId,
+            source: item.source,
+            action: item.action,
+            reason: item.reason,
+        })
         emit({
             type: "story_log",
             id: item.storyId,
@@ -53,6 +64,13 @@ export class CoordinationForwarder extends BaseObserver {
     }
 
     private handleCritique(item: CritiqueData): void {
+        emit({
+            type: "critique",
+            id: item.agentId,
+            verdict: item.verdict,
+            reasoning: item.reasoning,
+            violated: [...item.violatedCriteria],
+        })
         emit({
             type: "story_log",
             id: item.agentId,

--- a/packages/baro-orchestrator/src/participants/forwarders/dag.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/dag.ts
@@ -1,0 +1,85 @@
+import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
+
+import {
+    LevelCompleted,
+    LevelStarted,
+    RecoveryStarted,
+    Replan,
+    type LevelCompletedData,
+    type LevelStartedData,
+    type RecoveryStartedData,
+    type ReplanData,
+} from "../../semantic-events.js"
+import { emit } from "../../tui-protocol.js"
+
+/**
+ * Forwards DAG/coordination-shape events as structured protocol-v2
+ * BaroEvents: replan, level_started, level_completed, recovery_started.
+ * (Their `activity`/`progress` mirrors live in ProgressForwarder.)
+ */
+export class DagForwarder extends BaseObserver {
+    override async onExternalEvent(
+        _source: Participant,
+        event: SemanticEvent<unknown>,
+    ): Promise<void> {
+        if (Replan.is(event)) {
+            this.handleReplan(event.data)
+            return
+        }
+        if (LevelStarted.is(event)) {
+            this.handleLevelStarted(event.data)
+            return
+        }
+        if (LevelCompleted.is(event)) {
+            this.handleLevelCompleted(event.data)
+            return
+        }
+        if (RecoveryStarted.is(event)) {
+            this.handleRecoveryStarted(event.data)
+            return
+        }
+    }
+
+    private handleReplan(item: ReplanData): void {
+        emit({
+            type: "replan",
+            source: item.source,
+            reason: item.reason,
+            added: item.addedStories.map((s) => ({
+                id: s.id,
+                title: s.title,
+                depends_on: [...s.dependsOn],
+            })),
+            removed: [...item.removedStoryIds],
+            rewired: Object.entries(item.modifiedDeps).map(([id, deps]) => ({
+                id,
+                depends_on: [...deps],
+            })),
+        })
+    }
+
+    private handleLevelStarted(item: LevelStartedData): void {
+        emit({
+            type: "level_started",
+            ordinal: item.ordinal,
+            story_ids: [...item.storyIds],
+        })
+    }
+
+    private handleLevelCompleted(item: LevelCompletedData): void {
+        emit({
+            type: "level_completed",
+            ordinal: item.ordinal,
+            passed: [...item.passed],
+            failed: [...item.failed],
+        })
+    }
+
+    private handleRecoveryStarted(item: RecoveryStartedData): void {
+        emit({
+            type: "recovery_started",
+            attempt: item.attempt,
+            story_ids: [...item.storyIds],
+        })
+    }
+}

--- a/packages/baro-orchestrator/src/participants/forwarders/index.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/index.ts
@@ -2,6 +2,7 @@ import { AgenticEnvironment } from "@mozaik-ai/core"
 
 import { AgentStreamForwarder } from "./agent-stream.js"
 import { CoordinationForwarder } from "./coordination.js"
+import { DagForwarder } from "./dag.js"
 import { FinalizationForwarder } from "./finalization.js"
 import { ProgressForwarder } from "./progress.js"
 import { StoryLifecycleForwarder } from "./story-lifecycle.js"
@@ -18,6 +19,7 @@ export function joinBaroEventForwarders(env: AgenticEnvironment): void {
         new TokenUsageForwarder(),
         new ProgressForwarder(),
         new CoordinationForwarder(),
+        new DagForwarder(),
         new FinalizationForwarder(),
     ]
     for (const f of forwarders) f.join(env)

--- a/packages/baro-orchestrator/src/participants/forwarders/story-lifecycle.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/story-lifecycle.ts
@@ -8,8 +8,11 @@ import {
 import {
     AgentState,
     type AgentStateData,
+    StoryMergeFailed,
+    StoryMerged,
     StoryResult,
     type StoryResultData,
+    StoryRouted,
     StorySpawnRequest,
 } from "../../semantic-events.js"
 import { emit } from "../../tui-protocol.js"
@@ -23,8 +26,10 @@ const EDIT_TOOLS = new Set(["Edit", "MultiEdit", "NotebookEdit", "edit_file"])
 /**
  * Mirrors story lifecycle transitions as BaroEvents consumed by the Rust TUI.
  *
- * Subscribes to: AgentState, StoryResult, and per-agent function calls.
- * Emits: story_start, story_complete, story_error, story_retry.
+ * Subscribes to: AgentState, StoryResult, StoryRouted, StoryMerged,
+ * StoryMergeFailed, and per-agent function calls.
+ * Emits: story_start, story_complete, story_error, story_retry, routed,
+ * story_merged, merge_failed.
  */
 export class StoryLifecycleForwarder extends BaseObserver {
     private startedStories = new Set<string>()
@@ -51,6 +56,31 @@ export class StoryLifecycleForwarder extends BaseObserver {
         }
         if (StoryResult.is(event)) {
             this.handleStoryResult(event.data)
+            return
+        }
+        if (StoryRouted.is(event)) {
+            emit({
+                type: "routed",
+                id: event.data.storyId,
+                backend: event.data.backend,
+                model: event.data.model,
+            })
+            return
+        }
+        if (StoryMerged.is(event)) {
+            emit({
+                type: "story_merged",
+                id: event.data.storyId,
+                mode: event.data.mode,
+            })
+            return
+        }
+        if (StoryMergeFailed.is(event)) {
+            emit({
+                type: "merge_failed",
+                id: event.data.storyId,
+                error: event.data.error,
+            })
             return
         }
     }

--- a/packages/baro-orchestrator/src/participants/story-factory.ts
+++ b/packages/baro-orchestrator/src/participants/story-factory.ts
@@ -20,6 +20,7 @@ import { AgenticEnvironment } from "@mozaik-ai/core"
 import {
     StoryIntervention,
     StoryResult,
+    StoryRouted,
     StorySpawnRequest,
     StorySpawned,
     type StorySpawnRequestData,
@@ -202,6 +203,14 @@ export class StoryFactory extends BaseObserver {
             `[story-factory] ${req.storyId} → ${formatRoute(route)}` +
                 (req.model ? ` (model="${req.model}")` : "") +
                 "\n",
+        )
+        this.envRef.deliverSemanticEvent(
+            this,
+            StoryRouted.create({
+                storyId: req.storyId,
+                backend: route.backend,
+                model: route.model ?? "default",
+            }),
         )
 
         // Per-story worktree isolation (#50); falls back to the shared cwd.

--- a/packages/baro-orchestrator/src/semantic-events.ts
+++ b/packages/baro-orchestrator/src/semantic-events.ts
@@ -245,6 +245,18 @@ export const LevelCompleted =
     defineSemanticEvent<LevelCompletedData>("level_completed")
 
 /**
+ * Conductor actually started a recovery level (visibility only; the
+ * recovery flow itself stays hook-driven). `attempt` counts recovery
+ * levels started in this run, 1-based.
+ */
+export interface RecoveryStartedData {
+    attempt: number
+    storyIds: readonly string[]
+}
+export const RecoveryStarted =
+    defineSemanticEvent<RecoveryStartedData>("recovery_started")
+
+/**
  * Unlike the old toJSON() (which logged only `promptLen`), the wire format
  * carries the full prompt — StoryFactory needs it, and audit-log
  * round-tripping is worth the size for replay/debug.
@@ -263,6 +275,17 @@ export interface StorySpawnedData {
     storyId: string
 }
 export const StorySpawned = defineSemanticEvent<StorySpawnedData>("story_spawned")
+
+/**
+ * Which backend + model a story was routed to (machine-readable twin of
+ * StoryFactory's `[story-factory] S1 → backend:model` stderr line).
+ */
+export interface StoryRoutedData {
+    storyId: string
+    backend: string
+    model: string
+}
+export const StoryRouted = defineSemanticEvent<StoryRoutedData>("story_routed")
 
 export interface FinalizeStartedData {
     branch: string

--- a/packages/baro-orchestrator/src/tui-protocol.ts
+++ b/packages/baro-orchestrator/src/tui-protocol.ts
@@ -108,6 +108,30 @@ export type BaroEvent =
           op?: string // file_change: create | modify
           ok?: boolean // test / verdict pass-fail
       }
+    // Protocol v2 structured events (docs/tui-protocol-v2.md). Each keeps
+    // its legacy story_log mirror for one release.
+    | {
+          type: "replan"
+          source: string
+          reason: string
+          added: StoryInfo[]
+          removed: string[]
+          rewired: { id: string; depends_on: string[] }[]
+      }
+    | { type: "intervention"; id: string; source: string; action: string; reason: string }
+    | { type: "story_merged"; id: string; mode: "worktree" | "shared-tree" }
+    | { type: "merge_failed"; id: string; error: string }
+    | { type: "level_started"; ordinal: number; story_ids: string[] }
+    | { type: "level_completed"; ordinal: number; passed: string[]; failed: string[] }
+    | { type: "recovery_started"; attempt: number; story_ids: string[] }
+    | { type: "routed"; id: string; backend: string; model: string }
+    | {
+          type: "critique"
+          id: string
+          verdict: "pass" | "fail"
+          reasoning: string
+          violated: string[]
+      }
 
 /** Caller must not include trailing newlines in any field. */
 export function emit(event: BaroEvent): void {

--- a/packages/baro-orchestrator/test/dag.test.ts
+++ b/packages/baro-orchestrator/test/dag.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+
+import { buildDag } from "../src/dag.js"
+
+describe("buildDag", () => {
+    it("groups stories into topological levels", () => {
+        const levels = buildDag([
+            { id: "setup" },
+            { id: "api", dependsOn: ["setup"] },
+            { id: "ui", dependsOn: ["setup"] },
+            { id: "release", dependsOn: ["api", "ui"] },
+        ])
+
+        assert.deepEqual(levels, [
+            { storyIds: ["setup"] },
+            { storyIds: ["api", "ui"] },
+            { storyIds: ["release"] },
+        ])
+    })
+
+    it("sorts stories at the same level by ascending priority", () => {
+        const levels = buildDag([
+            { id: "medium", priority: 20 },
+            { id: "default" },
+            { id: "low", priority: 100 },
+            { id: "high", priority: -10 },
+        ])
+
+        assert.deepEqual(levels, [
+            { storyIds: ["high", "default", "medium", "low"] },
+        ])
+    })
+
+    it("excludes completed stories with onlyIncomplete and treats their dependencies as satisfied", () => {
+        const levels = buildDag(
+            [
+                { id: "completed-parent", passes: true },
+                { id: "active-child", dependsOn: ["completed-parent"] },
+                { id: "blocked-child", dependsOn: ["active-child"] },
+                { id: "completed-child", dependsOn: ["active-child"], passes: true },
+            ],
+            { onlyIncomplete: true },
+        )
+
+        assert.deepEqual(levels, [
+            { storyIds: ["active-child"] },
+            { storyIds: ["blocked-child"] },
+        ])
+    })
+
+    it("ignores dependencies on unknown stories", () => {
+        const levels = buildDag([
+            { id: "ready", dependsOn: ["missing"] },
+            { id: "dependent", dependsOn: ["ready"] },
+        ])
+
+        assert.deepEqual(levels, [
+            { storyIds: ["ready"] },
+            { storyIds: ["dependent"] },
+        ])
+    })
+
+    it("throws when active stories contain a dependency cycle", () => {
+        assert.throws(
+            () =>
+                buildDag([
+                    { id: "a", dependsOn: ["c"] },
+                    { id: "b", dependsOn: ["a"] },
+                    { id: "c", dependsOn: ["b"] },
+                    { id: "ready" },
+                ]),
+            /Dependency cycle detected: a, b, c/,
+        )
+    })
+})

--- a/packages/baro-orchestrator/test/git.test.ts
+++ b/packages/baro-orchestrator/test/git.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { createOrCheckoutBranch } from "../src/git.js"
+
+function git(cwd: string, ...args: string[]): string {
+    return execFileSync("git", args, { cwd, encoding: "utf8" }).trim()
+}
+
+function initRepo(): string {
+    const repo = mkdtempSync(join(tmpdir(), "baro-git-test-"))
+    git(repo, "init", "-b", "main")
+    git(repo, "config", "user.email", "t@t.t")
+    git(repo, "config", "user.name", "t")
+    writeFileSync(join(repo, "a.txt"), "line1\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-m", "init")
+    return repo
+}
+
+let repo: string
+let remote: string | null
+let logs: string[]
+
+beforeEach(() => {
+    repo = initRepo()
+    remote = null
+    logs = []
+})
+
+afterEach(() => {
+    try { rmSync(repo, { recursive: true, force: true }) } catch { /* */ }
+    if (remote) {
+        try { rmSync(remote, { recursive: true, force: true }) } catch { /* */ }
+    }
+})
+
+describe("createOrCheckoutBranch - branch name handling", () => {
+    it("strips repeated baro prefixes before checkout and push logging", async () => {
+        remote = mkdtempSync(join(tmpdir(), "baro-git-remote-"))
+        git(remote, "init", "--bare")
+        git(repo, "remote", "add", "origin", remote)
+
+        await createOrCheckoutBranch(repo, "baro/baro/baro/S4", (line) => {
+            logs.push(line)
+        })
+
+        assert.equal(git(repo, "branch", "--show-current"), "baro/S4")
+        assert.equal(git(repo, "branch", "--list", "baro/baro/*"), "")
+        assert.ok(
+            logs.some((line) => line === "[git] pushed -u origin baro/S4"),
+            "push log uses the canonical branch name",
+        )
+        assert.ok(
+            logs.every((line) => !line.includes("baro/baro/")),
+            "logs never include the repeated prefix",
+        )
+    })
+
+    it("checks out an existing canonical branch from a repeated-prefix input", async () => {
+        git(repo, "branch", "baro/S4")
+
+        await createOrCheckoutBranch(repo, "baro/baro/S4")
+
+        assert.equal(git(repo, "branch", "--show-current"), "baro/S4")
+        assert.equal(git(repo, "branch", "--list", "baro/baro/S4"), "")
+    })
+})

--- a/packages/baro-orchestrator/test/participants/conductor.test.ts
+++ b/packages/baro-orchestrator/test/participants/conductor.test.ts
@@ -8,6 +8,7 @@ import type { PrdFile } from "../../src/prd.js"
 import {
     LevelCompleted,
     LevelStarted,
+    RecoveryStarted,
     RunCompleted,
     RunStartRequest,
     RunStarted,
@@ -143,6 +144,10 @@ describe("Conductor", () => {
             const levelEvents = env.events.filter(LevelStarted.is)
             assert.equal(levelEvents.length, 2)
             assert.deepEqual(levelEvents.map((event) => event.data.ordinal), [1, 2])
+
+            const recoveries = env.events.filter(RecoveryStarted.is)
+            assert.equal(recoveries.length, 1)
+            assert.deepEqual(recoveries[0].data, { attempt: 1, storyIds: ["S1"] })
 
             const savedPrd = JSON.parse(readFileSync(prdPath, "utf8")) as PrdFile
             assert.equal(savedPrd.userStories[0]?.passes, false)

--- a/packages/baro-orchestrator/test/participants/forwarders/coordination.test.ts
+++ b/packages/baro-orchestrator/test/participants/forwarders/coordination.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
-import { Coordination, Critique } from "../../../src/semantic-events.js"
+import {
+    Coordination,
+    Critique,
+    StoryIntervention,
+} from "../../../src/semantic-events.js"
 import type { BaroEvent } from "../../../src/tui-protocol.js"
 import { CoordinationForwarder } from "../../../src/participants/forwarders/coordination.js"
 import { captureStdout, source } from "../helpers.js"
@@ -41,11 +45,48 @@ describe("CoordinationForwarder", () => {
                 line: "[sentry/wait] blocked by S8",
             },
             {
+                type: "critique",
+                id: "S9",
+                verdict: "fail",
+                reasoning: "missing test coverage",
+                violated: ["tests"],
+            },
+            // story_log mirror stays for one release alongside `critique`.
+            {
                 type: "story_log",
                 id: "S9",
                 line: "[critic/fail] missing test coverage",
             },
         ])
+    })
+
+    it("emits structured intervention plus its story_log mirror", async () => {
+        const forwarder = new CoordinationForwarder()
+        const lines = await captureStdout(async () => {
+            await forwarder.onExternalEvent(
+                source("supervisor"),
+                StoryIntervention.create({
+                    storyId: "S7",
+                    source: "supervisor",
+                    action: "abort",
+                    reason: "stalled for 10m",
+                }),
+            )
+        })
+
+        const events = lines.map((line) => JSON.parse(line) as BaroEvent)
+        assert.deepEqual(events[0], {
+            type: "intervention",
+            id: "S7",
+            source: "supervisor",
+            action: "abort",
+            reason: "stalled for 10m",
+        })
+        // story_log + activity mirrors stay for one release.
+        assert.deepEqual(
+            events.slice(1).map((e) => e.type),
+            ["story_log", "activity"],
+        )
     })
 
     it("emits exact story_log shape for merge coordination", async () => {

--- a/packages/baro-orchestrator/test/participants/forwarders/dag.test.ts
+++ b/packages/baro-orchestrator/test/participants/forwarders/dag.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+    LevelCompleted,
+    LevelStarted,
+    RecoveryStarted,
+    Replan,
+} from "../../../src/semantic-events.js"
+import type { BaroEvent } from "../../../src/tui-protocol.js"
+import { DagForwarder } from "../../../src/participants/forwarders/dag.js"
+import { captureStdout, source } from "../helpers.js"
+
+function parseEvents(lines: string[]): BaroEvent[] {
+    return lines.map((line) => JSON.parse(line) as BaroEvent)
+}
+
+describe("DagForwarder", () => {
+    it("emits a structured replan BaroEvent with added/removed/rewired", async () => {
+        const forwarder = new DagForwarder()
+        const events = parseEvents(await captureStdout(async () => {
+            await forwarder.onExternalEvent(
+                source("surgeon"),
+                Replan.create({
+                    source: "surgeon",
+                    reason: "S2 too large",
+                    addedStories: [
+                        {
+                            id: "S2a",
+                            priority: 2,
+                            title: "First half of S2",
+                            description: "Split from S2.",
+                            dependsOn: ["S1"],
+                        },
+                    ],
+                    removedStoryIds: ["S2"],
+                    modifiedDeps: { S3: ["S2a"] },
+                }),
+            )
+        }))
+
+        assert.deepEqual(events, [
+            {
+                type: "replan",
+                source: "surgeon",
+                reason: "S2 too large",
+                added: [{ id: "S2a", title: "First half of S2", depends_on: ["S1"] }],
+                removed: ["S2"],
+                rewired: [{ id: "S3", depends_on: ["S2a"] }],
+            },
+        ])
+    })
+
+    it("emits level_started, level_completed, and recovery_started", async () => {
+        const forwarder = new DagForwarder()
+        const events = parseEvents(await captureStdout(async () => {
+            await forwarder.onExternalEvent(
+                source("conductor"),
+                LevelStarted.create({
+                    ordinal: 1,
+                    totalLevelsHint: 3,
+                    storyIds: ["S1", "S2"],
+                }),
+            )
+            await forwarder.onExternalEvent(
+                source("conductor"),
+                LevelCompleted.create({
+                    ordinal: 1,
+                    passed: ["S1"],
+                    failed: ["S2"],
+                }),
+            )
+            await forwarder.onExternalEvent(
+                source("conductor"),
+                RecoveryStarted.create({ attempt: 1, storyIds: ["S2"] }),
+            )
+        }))
+
+        assert.deepEqual(events, [
+            { type: "level_started", ordinal: 1, story_ids: ["S1", "S2"] },
+            { type: "level_completed", ordinal: 1, passed: ["S1"], failed: ["S2"] },
+            { type: "recovery_started", attempt: 1, story_ids: ["S2"] },
+        ])
+    })
+})

--- a/packages/baro-orchestrator/test/participants/forwarders/story-lifecycle.test.ts
+++ b/packages/baro-orchestrator/test/participants/forwarders/story-lifecycle.test.ts
@@ -3,7 +3,13 @@ import assert from "node:assert/strict"
 
 import { FunctionCallItem } from "@mozaik-ai/core"
 
-import { AgentState, StoryResult } from "../../../src/semantic-events.js"
+import {
+    AgentState,
+    StoryMergeFailed,
+    StoryMerged,
+    StoryResult,
+    StoryRouted,
+} from "../../../src/semantic-events.js"
 import type { BaroEvent } from "../../../src/tui-protocol.js"
 import { StoryLifecycleForwarder } from "../../../src/participants/forwarders/story-lifecycle.js"
 import { captureStdout, source } from "../helpers.js"
@@ -96,6 +102,35 @@ describe("StoryLifecycleForwarder", () => {
                 attempt: 3,
                 max_retries: 3,
             },
+        ])
+    })
+
+    it("emits structured routed, story_merged, and merge_failed BaroEvents", async () => {
+        const forwarder = new StoryLifecycleForwarder()
+
+        const events = parseEvents(await captureStdout(async () => {
+            await forwarder.onExternalEvent(
+                source("story-factory"),
+                StoryRouted.create({
+                    storyId: "S3",
+                    backend: "openai",
+                    model: "gpt-5.5",
+                }),
+            )
+            await forwarder.onExternalEvent(
+                source("git-coordinator"),
+                StoryMerged.create({ storyId: "S3", mode: "worktree" }),
+            )
+            await forwarder.onExternalEvent(
+                source("git-coordinator"),
+                StoryMergeFailed.create({ storyId: "S4", error: "conflict in a.ts" }),
+            )
+        }))
+
+        assert.deepEqual(events, [
+            { type: "routed", id: "S3", backend: "openai", model: "gpt-5.5" },
+            { type: "story_merged", id: "S3", mode: "worktree" },
+            { type: "merge_failed", id: "S4", error: "conflict in a.ts" },
         ])
     })
 })

--- a/packages/baro-orchestrator/test/participants/story-factory.test.ts
+++ b/packages/baro-orchestrator/test/participants/story-factory.test.ts
@@ -14,6 +14,7 @@ import type { StoryRoute } from "../../src/routing.js"
 import {
     StoryIntervention,
     StoryResult,
+    StoryRouted,
     StorySpawnRequest,
     StorySpawned,
     type StorySpawnRequestData,
@@ -85,6 +86,14 @@ describe("StoryFactory", () => {
             const spawned = env.events.find(StorySpawned.is)
             assert.ok(spawned)
             assert.deepEqual(spawned.data, { storyId: "S1" })
+
+            const routed = env.events.find(StoryRouted.is)
+            assert.ok(routed)
+            assert.deepEqual(routed.data, {
+                storyId: "S1",
+                backend: "claude",
+                model: "sonnet",
+            })
 
             await factory.onExternalEvent(
                 source("S1"),

--- a/packages/baro-orchestrator/test/prd.test.ts
+++ b/packages/baro-orchestrator/test/prd.test.ts
@@ -1,0 +1,179 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+    BARO_COAUTHOR_TRAILER,
+    buildDefaultStoryPrompt,
+    markStoryPassed,
+    normalizePrd,
+    type PrdFile,
+    type PrdStory,
+} from "../src/prd.js"
+
+function story(overrides: Partial<PrdStory> = {}): PrdStory {
+    return {
+        id: "S1",
+        priority: 1,
+        title: "Test PRD helpers",
+        description: "Add focused tests for PRD helper behavior.",
+        dependsOn: [],
+        retries: 2,
+        acceptance: [],
+        tests: [],
+        passes: false,
+        completedAt: null,
+        durationSecs: null,
+        model: undefined,
+        ...overrides,
+    }
+}
+
+describe("normalizePrd", () => {
+    it("applies defaults and filters story string arrays", () => {
+        const prd = normalizePrd(
+            {
+                userStories: [
+                    {
+                        id: "S1",
+                        priority: 7,
+                        title: "Story one",
+                        description: "Has mixed array values.",
+                        dependsOn: ["S0", 1, "S00"],
+                        retries: 3.9,
+                        acceptance: ["works", false, "ships"],
+                        tests: ["npm test", null, "cargo test"],
+                        passes: "yes",
+                        completedAt: 42,
+                        durationSecs: "fast",
+                        model: 5,
+                    },
+                    {},
+                ],
+            } as unknown as Partial<PrdFile>,
+            "prd.json",
+        )
+
+        assert.equal(prd.project, "")
+        assert.equal(prd.branchName, "")
+        assert.equal(prd.description, "")
+        assert.deepEqual(prd.userStories[0], {
+            id: "S1",
+            priority: 7,
+            title: "Story one",
+            description: "Has mixed array values.",
+            dependsOn: ["S0", "S00"],
+            retries: 3,
+            acceptance: ["works", "ships"],
+            tests: ["npm test", "cargo test"],
+            passes: false,
+            completedAt: null,
+            durationSecs: null,
+            model: undefined,
+        })
+        assert.deepEqual(prd.userStories[1], {
+            id: "S2",
+            priority: 0,
+            title: "",
+            description: "",
+            dependsOn: [],
+            retries: 2,
+            acceptance: [],
+            tests: [],
+            passes: false,
+            completedAt: null,
+            durationSecs: null,
+            model: undefined,
+        })
+    })
+
+    it("canonicalizes doubled baro/baro branch prefixes", () => {
+        const prd = normalizePrd(
+            {
+                branchName: "baro/baro/baro/feature-prd-tests",
+                userStories: [],
+            },
+            "prd.json",
+        )
+
+        assert.equal(prd.branchName, "baro/feature-prd-tests")
+    })
+
+    it("preserves decision and execution metadata", () => {
+        const executionMode = {
+            mode: "parallel" as const,
+            reason: "independent stories",
+            confidence: 0.9,
+            maxStories: 4,
+            parallelism: 2,
+            source: "llm",
+        }
+        const prd = normalizePrd(
+            {
+                decisionDocument: "Use the existing PRD schema.",
+                executionMode,
+                userStories: [],
+            },
+            "prd.json",
+        )
+
+        assert.equal(prd.decisionDocument, "Use the existing PRD schema.")
+        assert.deepEqual(prd.executionMode, executionMode)
+    })
+})
+
+describe("markStoryPassed", () => {
+    it("returns an immutable PRD update for the matching story", () => {
+        const prd = normalizePrd(
+            {
+                project: "baro",
+                branchName: "baro/prd-tests",
+                description: "Test PRD helpers.",
+                userStories: [
+                    story({ id: "S1", title: "First" }),
+                    story({ id: "S2", title: "Second" }),
+                ],
+            },
+            "prd.json",
+        )
+        const before = Date.now()
+
+        const updated = markStoryPassed(prd, "S2", 12.5)
+        const after = Date.now()
+
+        assert.notEqual(updated, prd)
+        assert.notEqual(updated.userStories, prd.userStories)
+        assert.deepEqual(updated.userStories[0], prd.userStories[0])
+        assert.deepEqual(prd.userStories[1], story({ id: "S2", title: "Second" }))
+        assert.equal(updated.userStories[1].passes, true)
+        assert.equal(updated.userStories[1].durationSecs, 12.5)
+        assert.equal(typeof updated.userStories[1].completedAt, "string")
+        const completedAt = Date.parse(updated.userStories[1].completedAt!)
+        assert.ok(completedAt >= before)
+        assert.ok(completedAt <= after)
+    })
+})
+
+describe("buildDefaultStoryPrompt", () => {
+    it("includes acceptance criteria, test commands, and coauthor trailer", () => {
+        const prompt = buildDefaultStoryPrompt(
+            story({
+                id: "S7",
+                title: "Prompt coverage",
+                description: "Verify the default prompt content.",
+                acceptance: ["Normalize PRD defaults", "Keep metadata"],
+                tests: ["npm test -- prd.test.ts", "npm run build"],
+            }),
+        )
+
+        assert.ok(prompt.includes("You are working on story S7: Prompt coverage"))
+        assert.ok(
+            prompt.includes(
+                "ACCEPTANCE CRITERIA:\n1. Normalize PRD defaults\n2. Keep metadata",
+            ),
+        )
+        assert.ok(
+            prompt.includes("TEST COMMANDS:\n- npm test -- prd.test.ts\n- npm run build"),
+        )
+        assert.ok(prompt.includes(BARO_COAUTHOR_TRAILER))
+    })
+})

--- a/packages/baro-orchestrator/test/routing.test.ts
+++ b/packages/baro-orchestrator/test/routing.test.ts
@@ -53,6 +53,13 @@ describe("resolveStoryRoute — bare tier names (back-compat)", () => {
         })
     })
 
+    it("trims route whitespace before parsing", () => {
+        assert.deepEqual(resolveStoryRoute("  openai: MiniMax-M3  ", claudeFallback), {
+            backend: "openai",
+            model: "MiniMax-M3",
+        })
+    })
+
     it("treats an unknown prefix as part of the model name, not a backend", () => {
         assert.deepEqual(resolveStoryRoute("deepseek:chat", openaiFallback), {
             backend: "openai",
@@ -151,6 +158,33 @@ describe("resolveStoryRoute — tier map (the operator's seniority table)", () =
             { backend: "openai", model: "gpt-5.5" },
         )
     })
+
+    it("uses default and star entries for un-tiered stories", () => {
+        assert.deepEqual(
+            resolveStoryRoute(undefined, {
+                ...openaiFallback,
+                tierMap: { default: "codex" },
+            }),
+            { backend: "codex" },
+        )
+        assert.deepEqual(
+            resolveStoryRoute("", {
+                ...openaiFallback,
+                tierMap: { "*": "openai:gpt-4o-mini" },
+            }),
+            { backend: "openai", model: "gpt-4o-mini" },
+        )
+    })
+
+    it("allows a mapped tier to select a backend default only", () => {
+        assert.deepEqual(
+            resolveStoryRoute("haiku", {
+                ...claudeFallback,
+                tierMap: { haiku: "codex" },
+            }),
+            { backend: "codex" },
+        )
+    })
 })
 
 describe("resolveStoryRoute — --story-model override", () => {
@@ -219,6 +253,21 @@ describe("resolveStoryRoute — per-story OpenAI endpoint (@)", () => {
     it("resolves a named endpoint to baseUrl + apiKey", () => {
         assert.deepEqual(
             resolveStoryRoute("openai:MiniMax-M3@minimax", {
+                fallbackBackend: "claude",
+                endpoints,
+            }),
+            {
+                backend: "openai",
+                model: "MiniMax-M3",
+                baseUrl: "https://api.minimax.io/v1",
+                apiKey: "mm-key",
+            },
+        )
+    })
+
+    it("matches endpoint names case-insensitively and trims model/ref whitespace", () => {
+        assert.deepEqual(
+            resolveStoryRoute("openai: MiniMax-M3 @ MINIMAX ", {
                 fallbackBackend: "claude",
                 endpoints,
             }),
@@ -318,6 +367,8 @@ describe("parseEndpoints", () => {
 
     it("throws on a malformed spec", () => {
         assert.throws(() => parseEndpoints(["minimax"]), /expected name=url/)
+        assert.throws(() => parseEndpoints(["=https://api.minimax.io/v1"]), /expected name=url/)
+        assert.throws(() => parseEndpoints(["minimax="]), /expected name=url/)
     })
 })
 
@@ -341,6 +392,15 @@ describe("helpers", () => {
         assert.equal(formatRoute({ backend: "codex" }), "codex")
         assert.equal(
             formatRoute({ backend: "openai", model: "MiniMax-M3", baseUrl: "https://api.minimax.io/v1" }),
+            "openai:MiniMax-M3@https://api.minimax.io/v1",
+        )
+        assert.equal(
+            formatRoute({
+                backend: "openai",
+                model: "MiniMax-M3",
+                baseUrl: "https://api.minimax.io/v1",
+                apiKey: "secret",
+            }),
             "openai:MiniMax-M3@https://api.minimax.io/v1",
         )
     })


### PR DESCRIPTION
> Opened by [baro](https://baro.rs) — Mozaik-orchestrated parallel coding agents.

## Goal

Add focused unit tests for orchestrator helper modules using the existing node:test style.

## Plan

```
Level 1 ─── S1, S2, S3, S4
```

## Stories

| # | Story | Status | Duration | Commit |
|---|-------|--------|----------|--------|
| S1 | Test DAG helpers | ✓ | 3:01 | `ce148c6` |
| S2 | Test PRD helpers | ✓ | 4:32 | `2c2b6a4` |
| S3 | Extend routing helper tests | ✓ | 4:12 | `e629fe6` |
| S4 | Test git branch-name handling | ✓ | 3:52 | `3a02dfd` |

## Diff stats

- **Files created**: 3
- **Files modified**: 1
- **Total commits**: 8

## Run summary

- **Wall time**: 4:45
- **Sequential time**: 15:37
- **Parallel speedup**: 3.29×
- **Stories passed**: 4/4
- **Stories failed**: 0
- **Total story attempts**: 4

---

🤖 Plan. Parallelize. Review. Ship. — opened by baro

Co-Authored-By: baro <285254893+baro-rs@users.noreply.github.com>