### PR TITLE
fix(orchestrator): green test runs no longer shown as failed ("fail 0")

### DIFF
--- a/packages/baro-orchestrator/src/participants/forwarders/agent-stream.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/agent-stream.ts
@@ -7,6 +7,7 @@ import {
 } from "@mozaik-ai/core"
 
 import { emit } from "../../tui-protocol.js"
+import { testVerdict } from "./test-verdict.js"
 
 /**
  * Turns the agent bus stream into the TUI's structured Activity feed:
@@ -121,15 +122,4 @@ function firstLine(s: string): string {
 
 function truncate(s: string, max: number): string {
     return s.length <= max ? s : s.slice(0, max - 1) + "…"
-}
-
-/** true = passed, false = failed, null = not a recognizable test result. */
-function testVerdict(out: string): boolean | null {
-    const s = out.toLowerCase()
-    const failed = /\b\d+\s+fail(ed|ing|ures?)?\b/.test(s) || /(^|\s)fail\b/.test(s)
-    const passed =
-        /\b(all\s+)?\d+\s+(tests?\s+)?(pass(ed|ing)?|ok)\b/.test(s) || /\btests?\s+pass(ed)?\b/.test(s)
-    if (failed) return false
-    if (passed) return true
-    return null
 }

--- a/packages/baro-orchestrator/src/participants/forwarders/test-verdict.ts
+++ b/packages/baro-orchestrator/src/participants/forwarders/test-verdict.ts
@@ -1,0 +1,49 @@
+/**
+ * Classify tool output as a test-run verdict: `true` = passed, `false` =
+ * failed, `null` = not a test result (caller renders a plain line, no ✓/✗).
+ *
+ * Display-only heuristic over arbitrary shell output, so it never guesses:
+ * a wrong ✗ on a green run is worse than no verdict at all.
+ *
+ * Counts are extracted, not keyword-matched, because green runs often state
+ * their zero failures — "fail 0" (node:test), "0 failed" (cargo), "0
+ * failures" (RSpec) — and the number appears on either side of the keyword.
+ *
+ * Rules, in order:
+ *   1. a failure count > 0             → failed
+ *   2. bare "FAIL" and no counts       → failed  (go test, jest file headers;
+ *                                                 beats pass lines in mixed output)
+ *   3. a pass count > 0                → passed
+ *   4. "tests pass(ed)" / "N tests ok" → passed
+ *   5. all stated failure counts are 0 → passed  ("12 examples, 0 failures")
+ *   6. otherwise                       → null
+ */
+export function testVerdict(out: string): boolean | null {
+    const s = out.toLowerCase()
+    const failCounts = extractCounts(
+        s,
+        /\b(\d+)\s+fail(?:ed|ing|ures?)?\b/g,
+        /\bfail(?:ed|ing|ures?)?:?\s+(\d+)\b/g,
+    )
+    const passCounts = extractCounts(
+        s,
+        /\b(\d+)\s+(?:tests?\s+)?pass(?:ed|ing)?\b/g,
+        /\bpass(?:ed|ing)?:?\s+(\d+)\b/g,
+    )
+
+    if (failCounts.some((n) => n > 0)) return false
+    if (failCounts.length === 0 && /(^|\s)fail\b/.test(s)) return false
+    if (passCounts.some((n) => n > 0)) return true
+    if (/\b\d+\s+tests?\s+ok\b/.test(s) || /\btests?\s+pass(?:ed)?\b/.test(s)) return true
+    if (failCounts.length > 0) return true
+    return null
+}
+
+/** All numbers captured by the given patterns' first capture group. */
+function extractCounts(s: string, ...patterns: RegExp[]): number[] {
+    const counts: number[] = []
+    for (const p of patterns) {
+        for (const m of s.matchAll(p)) counts.push(Number(m[1]))
+    }
+    return counts
+}

--- a/packages/baro-orchestrator/test/participants/forwarders/agent-stream.test.ts
+++ b/packages/baro-orchestrator/test/participants/forwarders/agent-stream.test.ts
@@ -110,4 +110,22 @@ describe("AgentStreamForwarder", () => {
             },
         ])
     })
+
+    // Wiring check: the forwarder must use the counts-based testVerdict —
+    // a green node:test summary ("fail 0") is a passed test entry, not a ✗.
+    it("reads zero-failure summaries as passed", async () => {
+        const forwarder = new AgentStreamForwarder()
+        const agent = source("S3")
+
+        const events = parseEvents(await captureStdout(async () => {
+            await forwarder.onExternalFunctionCallOutput(
+                agent,
+                FunctionCallOutputItem.create("call-1", "ℹ tests 144\nℹ pass 144\nℹ fail 0"),
+            )
+        }))
+
+        assert.deepEqual(events, [
+            { type: "activity", id: "S3", kind: "test", ok: true, text: "ℹ tests 144" },
+        ])
+    })
 })

--- a/packages/baro-orchestrator/test/participants/forwarders/test-verdict.test.ts
+++ b/packages/baro-orchestrator/test/participants/forwarders/test-verdict.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+
+import { testVerdict } from "../../../src/participants/forwarders/test-verdict.js"
+
+// Real runner outputs grouped by expected verdict; adding a format is one line.
+
+const GREEN: Array<[string, string]> = [
+    ["node:test summary", "ℹ tests 144\nℹ pass 144\nℹ fail 0"],
+    [
+        "cargo test summary",
+        "test result: ok. 144 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out",
+    ],
+    ["jest-style zero failed", "Tests: 0 failed, 12 passed, 12 total"],
+    ["rspec zero failures", "12 examples, 0 failures"],
+    ["pytest", "===== 12 passed in 0.53s ====="],
+    ["mocha passing", "  12 passing (340ms)"],
+    ["plain english", "All 5 tests passed"],
+    ["tests ok", "12 tests ok"],
+]
+
+const RED: Array<[string, string]> = [
+    ["count-first failed", "2 failed, 3 passed"],
+    ["node:test failures", "ℹ tests 144\nℹ pass 141\nℹ fail 3"],
+    ["cargo failures", "test result: FAILED. 1 failed; 143 passed; 0 ignored"],
+    ["mocha failing", "10 passing (2s)\n2 failing"],
+    ["go test FAIL", "--- FAIL: TestParse (0.00s)\nFAIL\nexit status 1"],
+    ["jest suite FAIL line", "FAIL src/app.test.ts\n● Test suite failed to run"],
+]
+
+const NO_VERDICT: Array<[string, string]> = [
+    ["not a test run", "installed 12 packages in 3s"],
+    ["plain output", "done"],
+    ["go package lines only", "ok  example.com/pkg  0.2s"],
+    ["all skipped", "0 passed"],
+]
+
+describe("testVerdict", () => {
+    for (const [name, out] of GREEN) {
+        it(`green: ${name}`, () => assert.equal(testVerdict(out), true))
+    }
+    for (const [name, out] of RED) {
+        it(`red: ${name}`, () => assert.equal(testVerdict(out), false))
+    }
+    for (const [name, out] of NO_VERDICT) {
+        it(`no verdict: ${name}`, () => assert.equal(testVerdict(out), null))
+    }
+})


### PR DESCRIPTION
### Before
- A story agent runs your tests, **all of them pass** — and the Activity feed still draws a red ✗.
- Cause: `testVerdict()` treated any `fail` keyword or any `\d+ fail…` count — **including zero** — as a failure. Green runs routinely *state* their zero failures: node:test prints `ℹ fail 0`, cargo prints `0 failed`, RSpec prints `0 failures`. On those runners every fully green run rendered as failed.

### After
- Verdicts come from **extracted pass/fail counts**, not keyword hits: a stated zero is not a failure, a bare `FAIL` with no counts still is (go test, jest file headers), and ambiguous output gets **no verdict** (plain feed line) instead of a guess.
- `testVerdict` moved to its own pure module (`test-verdict.ts`) — string in, verdict out — with the rule table documented in the header.

### Notes
- This path is display-only (the feed ✓/✗ glyph); nothing gates on it. The design rule is asymmetric: a wrong ✗ on a green run is worse than no verdict, so unknown formats degrade to a plain line rather than a red guess.
- Small behavior fix that falls out of counts: `0 passed` (everything skipped) used to read as ✓ — now it yields no verdict.
- Branch is rebased on current `main` (post comment-pass), single commit.

### Test
- New `test/participants/forwarders/test-verdict.test.ts`: 18 table-driven cases over real runner outputs — node:test, cargo, jest-style `0 failed`, RSpec, pytest, mocha `2 failing`, go `FAIL` — split green / red / no-verdict.
- One forwarder-level case asserts the end-to-end wiring: `ℹ fail 0` summary → `kind: "test", ok: true`.
- `npm test` in `packages/baro-orchestrator`: **264/264 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)