### PR TITLE
fix(orchestrator): codex one-shot rejects on abnormal exit instead of returning partial output

### DIFF
--- a/packages/baro-orchestrator/src/codex-one-shot.ts
+++ b/packages/baro-orchestrator/src/codex-one-shot.ts
@@ -141,11 +141,6 @@ export async function runCodexOneShot(
             clearTimeout(timer)
             const elapsedMs = Date.now() - startedAt
 
-            if (agentMessage.trim()) {
-                resolve(agentMessage)
-                return
-            }
-
             const ctx = [
                 `elapsed=${elapsedMs}ms`,
                 `exit=${code}`,
@@ -162,6 +157,25 @@ export async function runCodexOneShot(
             ]
                 .filter((x): x is string => x !== null)
                 .join(" ")
+
+            // Abnormal termination must fail even if SOME text accumulated:
+            // callers feed the string into a markdown/JSON extractor that
+            // accepts truncated-but-closed fragments, so partial text on
+            // timeout/crash would silently yield an incomplete doc or PRD.
+            if (timedOut || signal != null || (code != null && code !== 0)) {
+                reject(
+                    new Error(
+                        `runCodexOneShot: codex terminated abnormally before completing (${ctx})`,
+                    ),
+                )
+                return
+            }
+
+            if (agentMessage.trim()) {
+                resolve(agentMessage)
+                return
+            }
+
             reject(
                 new Error(
                     `runCodexOneShot: codex produced no agent_message (${ctx})`,

--- a/packages/baro-orchestrator/test/codex-one-shot.test.ts
+++ b/packages/baro-orchestrator/test/codex-one-shot.test.ts
@@ -1,0 +1,64 @@
+import { chmodSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+
+import { runCodexOneShot } from "../src/codex-one-shot.js"
+import { withTempDir } from "./participants/helpers.js"
+
+/** Fake codex: emits agent_message lines, then optionally hangs, then exits. */
+function writeFakeCodex(
+    dir: string,
+    opts: { texts: string[]; exitCode?: number; hangMs?: number },
+): string {
+    const bin = join(dir, "fake-codex.mjs")
+    writeFileSync(
+        bin,
+        `#!/usr/bin/env node
+const texts = ${JSON.stringify(opts.texts)};
+for (const text of texts) {
+    console.log(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text } }));
+}
+${opts.hangMs ? `await new Promise((r) => setTimeout(r, ${opts.hangMs}));` : ""}
+process.exit(${opts.exitCode ?? 0});
+`,
+    )
+    chmodSync(bin, 0o755)
+    return bin
+}
+
+describe("runCodexOneShot exit contract", () => {
+    it("resolves the agent message on a clean exit", async () => {
+        await withTempDir("baro-codex-exit-", async (dir) => {
+            const bin = writeFakeCodex(dir, { texts: ["design doc"] })
+
+            const result = await runCodexOneShot({ prompt: "goal", cwd: dir, codexBin: bin })
+            assert.equal(result, "design doc")
+        })
+    })
+
+    it("rejects on a non-zero exit instead of returning the partial output", async () => {
+        // Codex streams part of the answer, then crashes. The partial text
+        // must not come back as success — a truncated PRD parses as a
+        // smaller-but-valid plan downstream.
+        await withTempDir("baro-codex-exit-", async (dir) => {
+            const bin = writeFakeCodex(dir, { texts: ["stories 1-9 of 12…"], exitCode: 3 })
+
+            await assert.rejects(
+                runCodexOneShot({ prompt: "goal", cwd: dir, codexBin: bin }),
+                /terminated abnormally.*exit=3/,
+            )
+        })
+    })
+
+    it("rejects on timeout instead of returning the partial output", async () => {
+        await withTempDir("baro-codex-exit-", async (dir) => {
+            const bin = writeFakeCodex(dir, { texts: ["partial…"], hangMs: 30_000 })
+
+            await assert.rejects(
+                runCodexOneShot({ prompt: "goal", cwd: dir, codexBin: bin, timeoutMs: 200 }),
+                /terminated abnormally.*timedOut=true/,
+            )
+        })
+    })
+})


### PR DESCRIPTION
### Before
- `runCodexOneShot` resolved whatever `agent_message` text had accumulated the moment the process exited — **before** checking the timeout flag, signal, or exit code. A codex that hit the 10-minute wall-clock cap or crashed mid-answer returned its partial output as success.
- Downstream that failure is silent: the Architect/Planner feed the string into a lenient markdown/JSON extractor that accepts truncated-but-closed fragments, so a PRD that died at story 9 of 12 becomes a "valid" 9-story plan. The fleet builds it; the only symptom is a PR missing features.
- This exact bug was already found and fixed on the **opencode** and **pi** one-shots (guard + explanatory comment). Codex — same structure, same downstream hazard — was skipped.

### After
- The exit handler checks abnormal termination first: `timedOut || signal != null || code !== 0` → reject with the diagnostic context the code already builds (elapsed, exit code, signal, event/item types seen). Only a clean exit can resolve text.
- All three one-shot runners now share the same guard and the same comment — codex carries the current (post comment-pass) wording from its siblings.

### Notes
- Overlaps with #70, which also adds a `test/codex-one-shot.test.ts` (concatenation / arg-passing / empty-output cases — the abnormal-exit path isn't covered there, so the two don't conflict semantically, only the file path collides). These tests use the same conventions (`withTempDir`, node-script fake codex bin), so whichever PR lands second can fold the other's cases in by copy-paste — happy to rebase onto #70 if it merges first.
- Branch is rebased on current `main`, single commit.

### Test
- `test/codex-one-shot.test.ts` — 3 cases on the exit contract: clean exit resolves; **exit 3 after partial output rejects**; **timeout after partial output rejects**. The two reject cases fail against the current code — they're the repro.
- `npm test` in `packages/baro-orchestrator`: **248/248 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)