### PR TITLE
release(0.74.8): fix Windows CLI launch — node shim, not sh.exe

### DIFF
--- a/crates/baro-tui/Cargo.toml
+++ b/crates/baro-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baro-tui"
-version = "0.74.7"
+version = "0.74.8"
 edition = "2021"
 
 [[bin]]

--- a/packages/baro-app/bin/baro
+++ b/packages/baro-app/bin/baro
@@ -1,9 +1,27 @@
-#!/usr/bin/env sh
-# Look for baro binary in ~/.baro/bin/
-NATIVE="$HOME/.baro/bin/baro"
-if [ -x "$NATIVE" ]; then
-    exec "$NATIVE" "$@"
-else
-    echo "baro: binary not installed. Run: npm rebuild baro-ai" >&2
-    exit 1
-fi
+#!/usr/bin/env node
+// Node launcher, not a shell script: npm generates its shims from this bin's
+// shebang, and a #!/bin/sh bin makes the Windows shim invoke sh.exe (absent on
+// Windows). A node shebang yields correct cmd/ps1/sh shims on every platform.
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { homedir } from "node:os"
+import path from "node:path"
+
+const bin = path.join(
+    homedir(),
+    ".baro",
+    "bin",
+    process.platform === "win32" ? "baro.exe" : "baro",
+)
+
+if (!existsSync(bin)) {
+    console.error("baro: binary not installed. Run: npm rebuild baro-ai")
+    process.exit(1)
+}
+
+const result = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" })
+if (result.error) {
+    console.error(`baro: failed to launch binary: ${result.error.message}`)
+    process.exit(1)
+}
+process.exit(result.signal ? 1 : (result.status ?? 0))

--- a/packages/baro-app/bin/baro.cmd
+++ b/packages/baro-app/bin/baro.cmd
@@ -1,8 +1,0 @@
-@echo off
-set "NATIVE=%USERPROFILE%\.baro\bin\baro.exe"
-if exist "%NATIVE%" (
-    "%NATIVE%" %*
-) else (
-    echo baro: binary not installed. Run: npm rebuild baro-ai 1>&2
-    exit /b 1
-)

--- a/packages/baro-app/package.json
+++ b/packages/baro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baro-ai",
-  "version": "0.74.7",
+  "version": "0.74.8",
   "description": "Autonomous parallel coding - plan and execute with AI",
   "type": "module",
   "bin": {

--- a/packages/baro-orchestrator/scripts/runner.ts
+++ b/packages/baro-orchestrator/scripts/runner.ts
@@ -60,7 +60,7 @@ let token = process.env.RUNNER_TOKEN
 const httpBase = url.replace(/^ws/, "http").replace(/\/+$/, "")
 const credsPath = join(homedir(), ".baro", "credentials.json")
 
-const VERSION = "0.74.7"
+const VERSION = "0.74.8"
 const updateCachePath = join(homedir(), ".baro", "update-check.json")
 
 // Latest published baro-ai version, cached ~24h in ~/.baro so we don't hit npm on every


### PR DESCRIPTION
## Problem

On Windows, `npm install -g baro-ai` then `baro` fails with:

```
The term 'sh.exe' is not recognized as a name of a cmdlet...
```

`packages/baro-app/bin/baro` was a `#!/usr/bin/env sh` script. npm generates its Windows shims (`baro.cmd` / `baro.ps1`) from the bin's shebang — a `sh` shebang makes those shims invoke `sh.exe`, which doesn't exist on Windows. The package shipped a hand-written `bin/baro.cmd`, but npm overrides it with its own generated shim, so it was dead code.

## Fix

- Rewrite `bin/baro` as a **Node launcher** (`#!/usr/bin/env node`) that execs the native binary in `~/.baro/bin/`. npm now emits correct **node-based** `cmd`/`ps1`/`sh` shims on every platform.
- Delete the dead `bin/baro.cmd`.
- Bump `0.74.7 → 0.74.8` (Cargo.toml, package.json, runner.ts).

## Verification

- Launcher execs the native binary, passes args, propagates exit codes (0 / 1 / nonzero) — tested locally on macOS.
- Missing-binary fallback prints `baro: binary not installed. Run: npm rebuild baro-ai` and exits 1.
- Ran npm's own `cmd-shim` against the new bin: generated `.ps1`/`.cmd` now call `node`, **not** `sh` — the exact line that failed (`& "sh$exe" ...`) is now `& "$basedir/node$exe" ...`.

Merging + tagging `v0.74.8` triggers the release workflow (binaries + GitHub release + npm publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)