### PR TITLE
release(0.74.10): fix Windows claude planner/architect — execFile → cross-spawn

### DIFF
--- a/crates/baro-tui/Cargo.toml
+++ b/crates/baro-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baro-tui"
-version = "0.74.9"
+version = "0.74.10"
 edition = "2021"
 
 [[bin]]

--- a/packages/baro-app/package.json
+++ b/packages/baro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baro-ai",
-  "version": "0.74.9",
+  "version": "0.74.10",
   "description": "Autonomous parallel coding - plan and execute with AI",
   "type": "module",
   "bin": {

--- a/packages/baro-orchestrator/scripts/runner.ts
+++ b/packages/baro-orchestrator/scripts/runner.ts
@@ -60,7 +60,7 @@ let token = process.env.RUNNER_TOKEN
 const httpBase = url.replace(/^ws/, "http").replace(/\/+$/, "")
 const credsPath = join(homedir(), ".baro", "credentials.json")
 
-const VERSION = "0.74.9"
+const VERSION = "0.74.10"
 const updateCachePath = join(homedir(), ".baro", "update-check.json")
 
 // Latest published baro-ai version, cached ~24h in ~/.baro so we don't hit npm on every

--- a/packages/baro-orchestrator/src/exec-file-cli.ts
+++ b/packages/baro-orchestrator/src/exec-file-cli.ts
@@ -1,0 +1,90 @@
+/**
+ * Windows-safe execFile for npm-installed CLIs (claude/codex/… ship as `.cmd`
+ * shims on Windows). Node's execFile/spawn won't resolve PATHEXT without a
+ * shell, so execFile("claude") throws `spawn claude ENOENT` even when
+ * claude.cmd is on PATH. cross-spawn resolves the real target cross-platform
+ * and escapes args correctly (prompts pass as argv, never a shell string), so
+ * we keep shell:false. Buffers stdout/stderr to preserve execFile's promise
+ * shape (`{ stdout }`), with the same timeout + maxBuffer semantics.
+ */
+
+import type { SpawnOptions } from "child_process"
+import spawn from "cross-spawn"
+
+export interface ExecFileCliOptions {
+    cwd?: string
+    env?: NodeJS.ProcessEnv
+    /** SIGTERM the child after this many ms; the promise rejects (killed=true). */
+    timeout?: number
+    /** Reject once buffered stdout exceeds this many bytes. */
+    maxBuffer?: number
+}
+
+export function execFileCli(
+    command: string,
+    args: readonly string[],
+    options: ExecFileCliOptions = {},
+): Promise<{ stdout: string; stderr: string }> {
+    const maxBuffer = options.maxBuffer ?? 1024 * 1024
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args as string[], {
+            cwd: options.cwd,
+            env: options.env,
+            stdio: ["ignore", "pipe", "pipe"],
+        } as SpawnOptions)
+
+        let stdout = ""
+        let stderr = ""
+        let settled = false
+        let timer: ReturnType<typeof setTimeout> | undefined
+
+        const finish = (fn: () => void): void => {
+            if (settled) return
+            settled = true
+            if (timer) clearTimeout(timer)
+            fn()
+        }
+
+        if (options.timeout && options.timeout > 0) {
+            timer = setTimeout(() => {
+                child.kill("SIGTERM")
+                finish(() => {
+                    const err = new Error(
+                        `${command} timed out after ${options.timeout}ms`,
+                    ) as Error & { killed: boolean }
+                    err.killed = true
+                    reject(err)
+                })
+            }, options.timeout)
+        }
+
+        child.stdout?.on("data", (d: Buffer) => {
+            stdout += d.toString()
+            if (stdout.length > maxBuffer) {
+                child.kill("SIGTERM")
+                finish(() =>
+                    reject(new Error(`${command} stdout exceeded maxBuffer`)),
+                )
+            }
+        })
+        child.stderr?.on("data", (d: Buffer) => {
+            stderr += d.toString()
+        })
+        child.on("error", (err) => finish(() => reject(err)))
+        child.on("close", (code) => {
+            finish(() => {
+                if (code === 0) {
+                    resolve({ stdout, stderr })
+                    return
+                }
+                const err = new Error(
+                    `${command} exited with code ${code}\n${stderr}`,
+                ) as Error & { code: number | null; stdout: string; stderr: string }
+                err.code = code
+                err.stdout = stdout
+                err.stderr = stderr
+                reject(err)
+            })
+        })
+    })
+}

--- a/packages/baro-orchestrator/src/planning/architect-claude.ts
+++ b/packages/baro-orchestrator/src/planning/architect-claude.ts
@@ -4,16 +4,13 @@
  * decision documents; Claude's built-in tools do the exploration.
  */
 
-import { execFile } from "child_process"
-import { promisify } from "util"
+import { execFileCli } from "../exec-file-cli.js"
 
 import {
     ARCHITECT_SYSTEM_PROMPT,
     buildArchitectUserMessage,
 } from "./architect-prompts.js"
 import { effortTimeoutMs } from "./planner-claude.js"
-
-const execFileAsync = promisify(execFile)
 
 export interface RunArchitectClaudeOptions {
     goal: string
@@ -31,7 +28,7 @@ export async function runArchitectClaude(
     opts: RunArchitectClaudeOptions,
 ): Promise<string> {
     const userMessage = buildArchitectUserMessage(opts.goal, opts.projectContext)
-    const { stdout } = await execFileAsync(
+    const { stdout } = await execFileCli(
         opts.claudeBin ?? "claude",
         [
             "--print",

--- a/packages/baro-orchestrator/src/planning/planner-claude.ts
+++ b/packages/baro-orchestrator/src/planning/planner-claude.ts
@@ -4,8 +4,7 @@
  * (`PrdOutput`) so the schema has a single source of truth.
  */
 
-import { execFile } from "child_process"
-import { promisify } from "util"
+import { execFileCli } from "../exec-file-cli.js"
 
 import {
     PLANNER_SYSTEM_PROMPT,
@@ -15,8 +14,6 @@ import {
     parseModeContract,
     type ModeContract,
 } from "./planner-prompts.js"
-
-const execFileAsync = promisify(execFile)
 
 export interface RunPlannerClaudeOptions {
     goal: string
@@ -65,7 +62,7 @@ export async function runPlannerClaude(
         modeContract,
     })
 
-    const { stdout } = await execFileAsync(
+    const { stdout } = await execFileCli(
         opts.claudeBin ?? "claude",
         [
             "--print",
@@ -99,7 +96,7 @@ export async function runPlannerClaude(
 
 export async function runClaudeIntake(opts: RunPlannerClaudeOptions) {
     if (opts.quick) return heuristicModeContract(opts)
-    const { stdout } = await execFileAsync(
+    const { stdout } = await execFileCli(
         opts.claudeBin ?? "claude",
         [
             "--print",


### PR DESCRIPTION
## Problem

After 0.74.9, `baro` reaches the main screen on Windows but **planning still fails**:

```
[run-planner] FAILED: spawn claude ENOENT
```

0.74.9 fixed the `spawn()` CLI sites, but the **Claude planner and architect** launch `claude` via **`execFile()`** (`planner-claude.ts`, `architect-claude.ts`) — which has the identical Windows flaw: it won't resolve `PATHEXT` without a shell, so `execFile("claude")` throws `ENOENT` even when `claude.cmd` is on PATH. (Intake's `execFile` failed too but was swallowed by a `.catch` → heuristic fallback, so only the uncaught main planner surfaced.)

`codex`/`opencode`/`pi` planners were unaffected — they already route through the cross-spawn one-shot helpers.

## Fix

New **`execFileCli`** — a cross-spawn-backed `execFile` with the same promise shape (buffered `stdout`, `timeout`, `maxBuffer`). Prompts pass as **argv, never a shell string**, so a prompt with quotes/`&`/`%`/`|` is escaped safely. Swapped the 3 Claude `execFile` sites (planner ×2, architect ×1).

## Verification (macOS)

- `tsc --noEmit` clean.
- `execFileCli` unit-behaviors: buffers stdout; rejects on nonzero exit (`code`); SIGTERM + rejects on timeout (`killed`); ENOENT on missing binary; **tricky args (`a "quoted" & %PATH% | value`) survive intact as argv** — proves no shell interpretation.
- `tsup` bundles cross-spawn into `run-planner.mjs` / `run-architect.mjs`.
- 19 planning tests pass.
- Windows `.cmd` resolution is cross-spawn's documented purpose; not verifiable here without a Windows host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)