### PR TITLE
release(0.74.11): fix Windows critic/surgeon — execFile → cross-spawn

### DIFF
--- a/crates/baro-tui/Cargo.toml
+++ b/crates/baro-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baro-tui"
-version = "0.74.10"
+version = "0.74.11"
 edition = "2021"
 
 [[bin]]

--- a/packages/baro-app/package.json
+++ b/packages/baro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baro-ai",
-  "version": "0.74.10",
+  "version": "0.74.11",
   "description": "Autonomous parallel coding - plan and execute with AI",
   "type": "module",
   "bin": {

--- a/packages/baro-orchestrator/scripts/runner.ts
+++ b/packages/baro-orchestrator/scripts/runner.ts
@@ -60,7 +60,7 @@ let token = process.env.RUNNER_TOKEN
 const httpBase = url.replace(/^ws/, "http").replace(/\/+$/, "")
 const credsPath = join(homedir(), ".baro", "credentials.json")
 
-const VERSION = "0.74.10"
+const VERSION = "0.74.11"
 const updateCachePath = join(homedir(), ".baro", "update-check.json")
 
 // Latest published baro-ai version, cached ~24h in ~/.baro so we don't hit npm on every

--- a/packages/baro-orchestrator/src/participants/critic.ts
+++ b/packages/baro-orchestrator/src/participants/critic.ts
@@ -21,8 +21,7 @@
  * Library-grade: no imports from prd.ts, story-agent.ts, or conductor.ts.
  */
 
-import { execFile } from "child_process"
-import { promisify } from "util"
+import { execFileCli } from "../exec-file-cli.js"
 
 import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
 
@@ -31,8 +30,6 @@ import {
     AgentTargetedMessage,
     Critique,
 } from "../semantic-events.js"
-
-const execFileAsync = promisify(execFile)
 
 export const VERDICT_SYSTEM_PROMPT = `\
 You are a strict acceptance-criteria evaluator. You will receive:
@@ -168,7 +165,7 @@ export class Critic extends BaseObserver {
         const prompt = buildEvalPrompt(criteria, resultText)
 
         try {
-            const { stdout } = await execFileAsync(
+            const { stdout } = await execFileCli(
                 this.opts.claudeBin,
                 [
                     "--print",

--- a/packages/baro-orchestrator/src/participants/surgeon.ts
+++ b/packages/baro-orchestrator/src/participants/surgeon.ts
@@ -26,8 +26,7 @@
  * the Conductor stays the only PRD-aware piece of code.
  */
 
-import { execFile } from "child_process"
-import { promisify } from "util"
+import { execFileCli } from "../exec-file-cli.js"
 
 import { BaseObserver, Participant, SemanticEvent } from "@mozaik-ai/core"
 
@@ -63,8 +62,6 @@ export class CritiqueLog {
         return this.byStory.get(storyId) ?? []
     }
 }
-
-const execFileAsync = promisify(execFile)
 
 /**
  * Lightweight read-only view of the PRD that Surgeon needs to reason.
@@ -267,7 +264,7 @@ export class Surgeon extends BaseObserver {
             this.critiques.forStory(failure.storyId),
         )
         try {
-            const { stdout } = await execFileAsync(
+            const { stdout } = await execFileCli(
                 this.opts.claudeBin,
                 [
                     "--print",


### PR DESCRIPTION
## Problem

The Claude **Critic** and **Surgeon** launch `claude` via `execFile()` — the same Windows flaw fixed for the planner/architect in 0.74.10. `execFile("claude")` throws ENOENT on Windows even when `claude.cmd` is on PATH. Left unfixed, a Windows run would clear planning (0.74.10) only to fail at the **first story's acceptance check** (Critic runs every story).

## Fix

Swap both Claude `execFile` sites (`critic.ts`, `surgeon.ts`) to the existing `execFileCli` helper.

**Full audit of remaining process launches** (shipped `origin/main`):
- `codex`/`opencode`/`pi` critics → already route through the cross-spawn one-shots ✓
- `openai` critic/surgeon → in-process, no subprocess ✓
- `git` / `gh` → real `.exe` on Windows ✓
- `verify.ts` → already uses `shell: process.platform === "win32"` ✓
- `codebase-tools` `execSync` → runs via a shell (resolves `.cmd`) ✓

This completes Windows coverage for every CLI-launch path.

## Verification (macOS)

- `tsc --noEmit` clean; `tsup` builds.
- **Full 282-test orchestrator suite passes.**
- A **real authenticated `claude --print` call through `execFileCli`** returns `is_error:false` with parsed JSON — the exact path Critic/Surgeon now use.
- cross-spawn is a passthrough to `child_process.spawn` on non-Windows, so macOS behavior is unchanged (confirmed empirically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)