### PR TITLE
release(0.74.12): Windows hardening — junction symlinks + HOME/USERPROFILE

### DIFF
--- a/crates/baro-tui/Cargo.toml
+++ b/crates/baro-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baro-tui"
-version = "0.74.11"
+version = "0.74.12"
 edition = "2021"
 
 [[bin]]

--- a/crates/baro-tui/src/doctor.rs
+++ b/crates/baro-tui/src/doctor.rs
@@ -235,13 +235,15 @@ async fn check_gh_on_path() -> CheckResult {
 /// Audit logs land in ~/.baro/runs — if it's root-owned (sudo install
 /// accident) we want to know now, not mid-run.
 async fn check_audit_dir_writable() -> CheckResult {
-    let home = match std::env::var_os("HOME") {
+    let home = match std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+    {
         Some(h) => PathBuf::from(h),
         None => {
             return CheckResult::fail(
                 "audit dir writable",
-                "$HOME is unset",
-                "baro writes audit logs to $HOME/.baro/runs. Set HOME and re-run.",
+                "$HOME / %USERPROFILE% is unset",
+                "baro writes audit logs to ~/.baro/runs. Set HOME (or USERPROFILE) and re-run.",
             );
         }
     };

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -2287,6 +2287,7 @@ fn spawn_executor(
         .map(|d| d.as_secs())
         .unwrap_or(0);
     let audit_root = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)
         .unwrap_or_else(|| cwd.clone())
         .join(".baro")

--- a/crates/baro-tui/src/subprocess.rs
+++ b/crates/baro-tui/src/subprocess.rs
@@ -231,7 +231,9 @@ fn detail_tail(stdout: &str, stderr: &str) -> String {
 /// Write `~/.baro/runs/<tag>-<unix_secs>.log` containing both streams.
 /// `None` on any failure — we'd rather lose the log than crash the run.
 fn persist_log(tag: &str, stdout: &str, stderr: &str) -> Option<PathBuf> {
-    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)?;
     let dir = home.join(".baro").join("runs");
     if std::fs::create_dir_all(&dir).is_err() {
         return None;

--- a/packages/baro-app/package.json
+++ b/packages/baro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baro-ai",
-  "version": "0.74.11",
+  "version": "0.74.12",
   "description": "Autonomous parallel coding - plan and execute with AI",
   "type": "module",
   "bin": {

--- a/packages/baro-orchestrator/scripts/runner.ts
+++ b/packages/baro-orchestrator/scripts/runner.ts
@@ -60,7 +60,7 @@ let token = process.env.RUNNER_TOKEN
 const httpBase = url.replace(/^ws/, "http").replace(/\/+$/, "")
 const credsPath = join(homedir(), ".baro", "credentials.json")
 
-const VERSION = "0.74.11"
+const VERSION = "0.74.12"
 const updateCachePath = join(homedir(), ".baro", "update-check.json")
 
 // Latest published baro-ai version, cached ~24h in ~/.baro so we don't hit npm on every

--- a/packages/baro-orchestrator/src/orchestrate.ts
+++ b/packages/baro-orchestrator/src/orchestrate.ts
@@ -8,7 +8,7 @@
  */
 
 import { mkdirSync } from "fs"
-import { hostname } from "os"
+import { homedir, hostname } from "os"
 import { dirname, join } from "path"
 
 import { AgenticEnvironment } from "@mozaik-ai/core"
@@ -401,7 +401,7 @@ export async function orchestrate(
 
     // Session-scoped memory path (Vectra index + cache.json), shared
     // cross-process via BARO_MEMORY_PATH.
-    const sessionsDir = join(process.env.HOME || "/tmp", ".baro", "sessions")
+    const sessionsDir = join(homedir(), ".baro", "sessions")
     const memorySessionPath = useMemory
         ? join(sessionsDir, runId, "memory")
         : undefined

--- a/packages/baro-orchestrator/src/participants/memory-librarian.ts
+++ b/packages/baro-orchestrator/src/participants/memory-librarian.ts
@@ -23,9 +23,10 @@ import {
 
 const DEBUG = process.env.BARO_DEBUG?.includes("memory") ?? false
 import { appendFileSync, mkdirSync } from "fs"
+import { homedir } from "os"
 import { join } from "path"
 
-const LOG_DIR = join(process.env.HOME || "/tmp", ".baro", "runs")
+const LOG_DIR = join(homedir(), ".baro", "runs")
 const LOG_FILE = join(LOG_DIR, `memory-${Date.now()}.log`)
 try { mkdirSync(LOG_DIR, { recursive: true }) } catch {}
 

--- a/packages/baro-orchestrator/src/worktree.ts
+++ b/packages/baro-orchestrator/src/worktree.ts
@@ -302,7 +302,10 @@ export class WorktreeManager {
             try {
                 if (!existsSync(shared)) mkdirSync(shared, { recursive: true })
                 mkdirSync(join(worktreePath, rel), { recursive: true })
-                symlinkSync(shared, dest, "dir")
+                // "junction" (not "dir"): a dir symlink needs admin/Developer
+                // Mode on Windows; a junction doesn't. Ignored off Windows, so
+                // this stays a normal symlink on macOS/Linux.
+                symlinkSync(shared, dest, "junction")
             } catch (e) {
                 this.log(`could not symlink ${join(rel, dir)} into worktree (${errMsg(e)})`)
             }


### PR DESCRIPTION
## Context

The friend still reports Windows failures without a specific error. Deeper audit beyond the CLI-spawn chain (0.74.8–0.74.11) surfaced more Windows-only bugs. The **primary run path (planning + story execution) is node/cross-spawn and already worked after 0.74.11**; these fix secondary paths.

## Fixes

- **`worktree.ts`** — share dependency dirs with a **`"junction"`**, not a `"dir"` symlink. A directory symlink needs admin/Developer Mode on Windows (`EPERM` otherwise), so per-story `node_modules` sharing silently failed → dependent builds/tests broke. Junctions need no privilege; the `type` arg is ignored off Windows, so macOS/Linux keep a normal symlink.
- **`orchestrate.ts` + `memory-librarian.ts`** — sessions/audit dirs used `process.env.HOME || "/tmp"`; `HOME` is undefined on Windows → wrote to `C:\tmp`. Use `os.homedir()`.
- **Rust** (`main.rs` audit_root, `subprocess.rs` persist_log, `doctor.rs`) — fall back to `%USERPROFILE%` when `HOME` is unset, matching the existing pattern in `main.rs`/`service.rs`. Audit logs land in `~/.baro/runs` on Windows instead of the project dir / nowhere.

## Not in scope (documented)

The Rust plan-refine (`claude_runner.rs`) and CLAUDE.md-context (`context.rs`) helpers spawn `claude` directly. That's fine with the **recommended native `claude.exe`** install (claude.com/code); only an npm-installed `claude.cmd` would miss it. Secondary paths, lower priority, and the cmd.exe wrapping needed is risky for a large prompt arg — deferred.

## Verification (macOS)

- node `tsc --noEmit` clean; `tsup` builds.
- **Full 282-test suite passes**, incl. the WorktreeManager symlink tests (junction → normal symlink on macOS).
- `cargo check -p baro-tui` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)