### PR TITLE
fix(codex): accept `message` alias as terminal assistant text in one-shot

### DIFF
--- a/packages/baro-orchestrator/src/harness/codex/one-shot.ts
+++ b/packages/baro-orchestrator/src/harness/codex/one-shot.ts
@@ -489,11 +489,14 @@ export async function runCodexOneShot(
                     additionalEnvironment,
                 )
                 if (
-                    item.type === "agent_message" &&
+                    (item.type === "agent_message" ||
+                        item.type === "message") &&
                     typeof item.text === "string"
                 ) {
                     // Codex can emit completed assistant/status messages before
                     // the terminal response. Keep only the terminal message.
+                    // "message" is the mapper's alias for assistant text
+                    // (stream-mapper.ts) — both paths must accept it.
                     agentMessage = item.text
                 } else if (innerType === "command_execution") {
                     const cmd =

--- a/packages/baro-orchestrator/test/harness/codex/one-shot.test.ts
+++ b/packages/baro-orchestrator/test/harness/codex/one-shot.test.ts
@@ -111,6 +111,33 @@ describe("runCodexOneShot exit contract", () => {
         })
     })
 
+    it("resolves a terminal item typed `message` (mapper alias) on a clean exit", async () => {
+        // The stream mapper treats item.type "message" as an alias for
+        // "agent_message" (stream-mapper.ts). The one-shot must agree, or a
+        // successful run whose terminal item is typed "message" is rejected as
+        // "produced no agent_message".
+        await withTempDir("baro-codex-message-alias-", async (dir) => {
+            const bin = join(dir, "message-alias-codex.mjs")
+            writeFileSync(
+                bin,
+                `#!/usr/bin/env node
+console.log(JSON.stringify({
+    type: "item.completed",
+    item: { type: "message", text: "structured message alias" },
+}));
+`,
+            )
+            chmodSync(bin, 0o755)
+
+            const result = await runCodexOneShot({
+                prompt: "goal",
+                cwd: dir,
+                codexBin: bin,
+            })
+            assert.equal(result, "structured message alias")
+        })
+    })
+
     it("returns the terminal agent message instead of corrupting it with progress text", async () => {
         await withTempDir("baro-codex-terminal-message-", async (dir) => {
             const terminal = '{"schemaVersion":1,"kind":"ready"}'


### PR DESCRIPTION
## What

`runCodexOneShot` rejected a **successful** Codex run whenever the terminal `item.completed` event carried `item.type === "message"` instead of `"agent_message"`. The stream mapper for the same CLI wire format already treats both as assistant text ([`stream-mapper.ts:108`](https://github.com/jigjoy-ai/baro/blob/main/packages/baro-orchestrator/src/harness/codex/stream-mapper.ts#L108)); the one-shot only accepted `agent_message`, so the two parsers disagreed and a completed run became a hard failure:

```
runCodexOneShot: codex produced no agent_message (elapsed=709ms exit=0 events=1 items=1 event_types=[item.completed] item_types=[message])
```

One-shot backs planning / architect / conversation calls, so this surfaced as a spurious PRD / story / conversation failure on a run that actually succeeded.

Fixes #79.

## Fix

Accept both `agent_message` and `message` in the one-shot terminal-item check, mirroring the mapper — a one-line predicate change in `one-shot.ts`.

## Reproduce → verify

Added a regression test (`test/harness/codex/one-shot.test.ts`) that emits a terminal item typed `message` on a clean exit and asserts the text is returned.

- **Before the fix:** the test fails with `codex produced no agent_message` (exit=0, `item_types=[message]`) — confirming the bug.
- **After the fix:** the full codex suite passes.

```
tests 42  pass 42  fail 0   # one-shot.test.ts + stream-mapper.test.ts
```

`tsc --noEmit` clean.

## Scope

Two files, +31/−1: the predicate fix and its regression test. No behavior change for `agent_message` runs.
