### PR TITLE
fix(verification): a skipped gate is not reported to the agent as FAIL

### DIFF
--- a/packages/baro-orchestrator/src/verification/continuous-gate-runner.ts
+++ b/packages/baro-orchestrator/src/verification/continuous-gate-runner.ts
@@ -186,11 +186,17 @@ export class ContinuousGateRunner extends BaseObserver {
         if (result.commands.some((command) => wasKilled(command))) {
             throw new Error("a gate command was killed before it reported")
         }
-        return result.commands.map((command) => ({
-            label: command.command,
-            passed: command.status === "passed",
-            detail: command.status === "passed" ? "" : command.tail ?? "",
-        }))
+        // A skipped command (tool not installed, containment cut short, a
+        // requirement we could not run) never touched the patch, so it is not
+        // the agent's failure — same reason as the killed guard above. Drop it
+        // rather than reporting a two-state FAIL the agent would chase.
+        return result.commands
+            .filter((command) => command.status !== "skipped")
+            .map((command) => ({
+                label: command.command,
+                passed: command.status === "passed",
+                detail: command.status === "passed" ? "" : command.tail ?? "",
+            }))
     }
 
     private deliver(agentId: string, outcome: GateOutcome): void {

--- a/packages/baro-orchestrator/test/verification/continuous-gate-runner.test.ts
+++ b/packages/baro-orchestrator/test/verification/continuous-gate-runner.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict"
+import { tmpdir } from "node:os"
 import { describe, it } from "node:test"
 
 import { ContinuousGateRunner } from "../../src/verification/continuous-gate-runner.js"
 import type { GateCommandOutcome } from "../../src/verification/continuous-gate.js"
+import type { VerifyPlan } from "../../src/verification/verify.js"
 
 const GREEN: GateCommandOutcome[] = [{ label: "go build ./...", passed: true, detail: "" }]
 const RED: GateCommandOutcome[] = [
@@ -34,6 +36,34 @@ function harness(gates: () => Promise<readonly GateCommandOutcome[]>) {
             { name: "Write", callId: "c", arguments: "{}" } as never,
         )
     return { runner, delivered, write, runCount: () => runs }
+}
+
+/**
+ * Drives the real verifyBuild path (no `runGates` hook), so the three-state
+ * command result actually flows through the runner's own projection — the
+ * `runGates` harness above hands the runner pre-projected two-state outcomes
+ * and cannot exercise it.
+ */
+function harnessWithPlan(plan: VerifyPlan) {
+    const delivered: Array<{ recipientId: string; text: string }> = []
+    const environment = {
+        deliverSemanticEvent(_source: unknown, event: { data: unknown }) {
+            delivered.push(event.data as { recipientId: string; text: string })
+        },
+    }
+    const runner = new ContinuousGateRunner({
+        runId: "run-1",
+        resolveTarget: () => ({ cwd: tmpdir() }),
+        settleMs: 5,
+        plan,
+    })
+    ;(runner as unknown as { getEnvironments(): unknown[] }).getEnvironments = () => [environment]
+    const write = (agentId: string) =>
+        runner.onExternalFunctionCall(
+            { agentId } as never,
+            { name: "Write", callId: "c", arguments: "{}" } as never,
+        )
+    return { runner, delivered, write }
 }
 
 const settle = (ms = 40) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -159,6 +189,35 @@ describe("the gate runs when it is worth running, not constantly", () => {
         await settle(300)
         assert.equal(peak, 1, "the machine runs one build at a time")
         assert.equal(h.runCount(), 4, "each story still gets checked")
+        h.runner.stop()
+    })
+
+    it("does not report a gate we could not run as a failing gate", async () => {
+        // A repo whose gate tool is absent on the host (cargo not installed,
+        // ENOENT, containment cut short) makes verifyBuild return status
+        // "skipped" — which says nothing about the agent's patch. Reporting it
+        // as FAIL once told an agent its build was broken when only our own
+        // gate never ran. The passing command must still be reported; the
+        // skipped one must not turn the report red.
+        const plan: VerifyPlan = {
+            commands: [
+                { label: "node noop", tool: process.execPath, args: ["-e", ""] },
+                {
+                    label: "cargo build",
+                    tool: "cargo",
+                    args: ["build"],
+                    incompleteReason: "cargo is not installed",
+                },
+            ],
+        }
+        const h = harnessWithPlan(plan)
+        h.write("S1")
+        await settle(200)
+        assert.equal(h.delivered.length, 1)
+        const text = h.delivered[0]!.text
+        assert.match(text, /PASS {2}node noop/u)
+        assert.doesNotMatch(text, /FAIL/u)
+        assert.doesNotMatch(text, /cargo build/u)
         h.runner.stop()
     })
 


### PR DESCRIPTION
## What

`ContinuousGateRunner` reported a **skipped** verification gate to the still-working story agent as `FAIL`. `verifyBuild` is three-state (`passed`/`failed`/`skipped`), but `execute()` collapsed it with `passed: command.status === "passed"`, so a command that never ran — tool not installed (ENOENT), containment cut short, or an incomplete requirement — became a reported failure with the skip reason as its detail.

The agent, mid-work, was told:

```
[baro] Your worktree was checked after your last change:
  PASS  node noop
  FAIL  cargo build

--- cargo build ---
cargo is not installed
```

`cargo build` never ran (`cargo` isn't on the host) — yet the agent is told its build failed and burns turns chasing it. This is the exact false-fail the killed-command guard directly above (`continuous-gate-runner.ts:183-188`) exists to prevent; `skipped` slipped past it.

Fixes #81.

## Fix

Drop `skipped` commands from the reported set — a gate that never ran says nothing about the agent's patch, the same rationale as the adjacent killed guard. When a whole gate skips, the runner now delivers nothing: `summarizeGate` + `shouldDeliverGate` already stay silent on an empty command set, matching the module's "couldn't-verify is not a failure" contract.

Six source lines; no change to `passed`/`failed` reporting.

## Reproduce -> verify

The existing runner tests drive the `runGates` escape hatch, which hands the runner **pre-projected two-state** outcomes and never exercises the three-state->two-state mapping — which is why this was never caught. The new test drives the real `verifyBuild` path with a plan of one passing command + one skipped:

- **Before the fix:** fails — the delivered report contains `FAIL  cargo build` / `cargo is not installed`.
- **After the fix:** the passing command is reported `PASS`, the skipped one is absent, no `FAIL`.

```
verification/ suite: 71 pass, 0 fail
tsc --noEmit: clean
```

## Scope

Two files, +70/-5 — the projection fix and its regression test. No behavior change for gates that actually pass or fail.
