### PR TITLE
Checkpoint: CLI UX wiring — detach, watch/logs, scrub, budget, bare-launch resume (3 stories)

### DIFF
--- a/crates/baro-tui/src/cli/detach.rs
+++ b/crates/baro-tui/src/cli/detach.rs
@@ -1,0 +1,211 @@
+//! Re-executes baro as a background child whose stream lands in the run
+//! registry's log file. The decisions (log paths, caffeinate argv) come from
+//! `launch::plan_detach`; this module owns only the parts that need a process:
+//! rebuilding the child's argv, finding a binary on PATH, and the spawn itself.
+
+// The main.rs call site lands separately; until then the binary target sees
+// this module as unreachable.
+#![allow(dead_code)]
+
+use std::{
+    io,
+    process::{Command, Stdio},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use crate::cli::{launch, run_registry};
+
+/// The parent's argv minus `--detach` and `--goal-file`, forced headless. The
+/// child has no TTY, and `resolve_goal` has already read the goal file into
+/// `cli.goal`, so the file need not exist (or be readable) for the child.
+pub fn detached_child_args(raw_args: &[String], resolved_goal: Option<&str>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(raw_args.len());
+    let mut skip_next_value = false;
+    for arg in raw_args.iter().skip(1) {
+        if skip_next_value {
+            skip_next_value = false;
+            continue;
+        }
+        if arg == "--detach" {
+            continue;
+        }
+        if arg == "--goal-file" {
+            skip_next_value = true;
+            continue;
+        }
+        if arg.starts_with("--goal-file=") {
+            continue;
+        }
+        out.push(arg.clone());
+    }
+
+    if !out.iter().any(|a| a == "--headless" || a.starts_with("--headless=")) {
+        out.push("--headless".to_string());
+    }
+
+    // A surviving positional goal is byte-identical to the resolved goal
+    // (clap rejects passing both a positional and --goal-file), so its absence
+    // from the filtered argv is exactly the case that needs the goal appended.
+    if let Some(goal) = resolved_goal {
+        if !out.iter().any(|a| a == goal) {
+            out.push(goal.to_string());
+        }
+    }
+    out
+}
+
+pub fn binary_on_path(name: &str, path_var: Option<&str>) -> bool {
+    let Some(path_var) = path_var else {
+        return false;
+    };
+    path_var
+        .split(':')
+        .filter(|entry| !entry.is_empty())
+        .any(|entry| std::path::Path::new(entry).join(name).exists())
+}
+
+/// Spawns the background run and returns its pid, which is also its run id.
+/// The caller is the parent and exits immediately afterwards.
+pub fn run_detached(cli: &crate::cli::cli::Cli, raw_args: &[String]) -> io::Result<u32> {
+    let logs_dir = run_registry::logs_dir()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no writable ~/.baro/logs"))?;
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?
+        .as_nanos();
+    let parent_pid = std::process::id();
+
+    // The stream must be redirected before spawn, and the run id is the child
+    // pid, so the log opens under a pending name and is renamed once known.
+    let pending = launch::plan_detach(
+        &logs_dir,
+        parent_pid,
+        nanos,
+        None,
+        cfg!(target_os = "macos"),
+        false,
+    );
+    let out = std::fs::File::create(&pending.pending_log)?;
+    let err = out.try_clone()?;
+
+    let mut command = Command::new(std::env::current_exe()?);
+    command
+        .args(detached_child_args(raw_args, cli.goal.as_deref()))
+        .current_dir(&cli.cwd)
+        .stdin(Stdio::null())
+        .stdout(out)
+        .stderr(err);
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // Its own group, so a signal to the launching shell's group stops
+        // neither the run nor anything it spawns.
+        command.process_group(0);
+    }
+    let child = command.spawn()?;
+    let child_pid = child.id();
+
+    let plan = launch::plan_detach(
+        &logs_dir,
+        parent_pid,
+        nanos,
+        Some(child_pid),
+        cfg!(target_os = "macos"),
+        binary_on_path("caffeinate", std::env::var("PATH").ok().as_deref()),
+    );
+    let log_path = match std::fs::rename(&plan.pending_log, &plan.final_log) {
+        Ok(()) => plan.final_log.clone(),
+        // The child is already writing; a failed rename costs the conventional
+        // name, not the run.
+        Err(_) => plan.pending_log.clone(),
+    };
+    let _ = run_registry::register_detached(
+        cli.goal.as_deref().unwrap_or(""),
+        &cli.cwd,
+        child_pid,
+        &log_path,
+    );
+
+    if let Some(argv) = plan.caffeinate.as_ref() {
+        let _ = Command::new(&argv[0])
+            .args(&argv[1..])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn();
+    }
+    Ok(child_pid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|p| p.to_string()).collect()
+    }
+
+    #[test]
+    fn the_child_argv_drops_detach_and_goal_file_and_forces_headless() {
+        let separate = detached_child_args(
+            &argv(&["baro", "--detach", "--resume", "--goal-file", "./goal.md", "--shell-budget", "45"]),
+            Some("ship it"),
+        );
+        assert_eq!(separate, argv(&["--resume", "--shell-budget", "45", "--headless", "ship it"]));
+
+        let inline = detached_child_args(
+            &argv(&["baro", "--detach", "--continue", "--goal-file=./goal.md"]),
+            Some("ship it"),
+        );
+        assert_eq!(inline, argv(&["--continue", "--headless", "ship it"]));
+    }
+
+    #[test]
+    fn an_already_headless_argv_is_not_given_a_second_headless_flag() {
+        let already = detached_child_args(
+            &argv(&["baro", "--detach", "--resume", "--headless", "--shell-budget", "45"]),
+            None,
+        );
+        assert_eq!(already, argv(&["--resume", "--headless", "--shell-budget", "45"]));
+        assert_eq!(already.iter().filter(|a| *a == "--headless").count(), 1);
+
+        let with_goal =
+            detached_child_args(&argv(&["baro", "--detach", "--headless", "ship it"]), Some("ship it"));
+        assert_eq!(with_goal, argv(&["--headless", "ship it"]));
+    }
+
+    #[test]
+    fn the_resolved_goal_is_appended_only_when_no_positional_survives() {
+        let positional = detached_child_args(&argv(&["baro", "ship it", "--detach"]), Some("ship it"));
+        assert_eq!(positional, argv(&["ship it", "--headless"]));
+
+        // From --goal-file the goal is file text no surviving token can equal.
+        let from_file = detached_child_args(
+            &argv(&["baro", "--detach", "--goal-file", "./goal.md"]),
+            Some("read from the file"),
+        );
+        assert_eq!(from_file, argv(&["--headless", "read from the file"]));
+
+        // A flag value is not a positional, so the goal still has to be added.
+        let value_only = detached_child_args(
+            &argv(&["baro", "--detach", "--shell-budget", "45"]),
+            Some("ship it"),
+        );
+        assert_eq!(value_only, argv(&["--shell-budget", "45", "--headless", "ship it"]));
+
+        assert_eq!(detached_child_args(&argv(&["baro", "--detach"]), None), argv(&["--headless"]));
+    }
+
+    #[test]
+    fn a_binary_is_found_only_on_a_path_entry_that_holds_it() {
+        let held = env!("CARGO_MANIFEST_DIR");
+
+        assert!(binary_on_path("Cargo.toml", Some(&format!("/nonexistent:{held}"))));
+        // Empty entries are skipped rather than read as the current directory.
+        assert!(binary_on_path("Cargo.toml", Some(&format!("::{held}:"))));
+        assert!(!binary_on_path("Cargo.toml", Some("/nonexistent:/also-nonexistent")));
+        assert!(!binary_on_path("definitely-not-a-file", Some(held)));
+        assert!(!binary_on_path("Cargo.toml", None));
+        assert!(!binary_on_path("Cargo.toml", Some("")));
+    }
+}

--- a/crates/baro-tui/src/cli/launch.rs
+++ b/crates/baro-tui/src/cli/launch.rs
@@ -59,6 +59,20 @@ pub fn goal_fingerprint(goal: &str) -> String {
     format!("fnv1a64:{hash:016x}")
 }
 
+/// An inherited BARO_RUN_ID belongs to whoever launched this process; leaving
+/// it in place would make this run report under another run's identity.
+pub fn scrub_inherited_run_id() {
+    std::env::remove_var("BARO_RUN_ID");
+}
+
+/// The value BASH_DEFAULT_TIMEOUT_MS should take, or `None` to leave the
+/// environment alone. `operator_value` is taken only so the precedence the
+/// flag's help promises is a function of both inputs.
+pub fn shell_budget_env(flag_secs: Option<u64>, operator_value: Option<&str>) -> Option<String> {
+    let _ = operator_value;
+    flag_secs.map(|secs| secs.saturating_mul(1000).to_string())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LaunchMode {
     Fresh,
@@ -113,6 +127,10 @@ pub fn decide_launch(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Rust tests share one process, so every env-mutating test in this module
+    /// must hold this before touching the environment.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn logs_dir() -> PathBuf {
         PathBuf::from("/home/op/.baro/logs")
@@ -221,5 +239,28 @@ mod tests {
 
         assert_eq!(decision.mode, LaunchMode::Fresh);
         assert_eq!(decision.message, None);
+    }
+
+    #[test]
+    fn an_inherited_run_id_is_gone_but_a_freshly_set_one_survives() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        std::env::set_var("BARO_RUN_ID", "inherited");
+        scrub_inherited_run_id();
+        assert!(std::env::var("BARO_RUN_ID").is_err());
+
+        // The scrub must not stop the run from minting and exporting its own id.
+        std::env::set_var("BARO_RUN_ID", "run-local");
+        assert_eq!(std::env::var("BARO_RUN_ID").as_deref(), Ok("run-local"));
+
+        std::env::remove_var("BARO_RUN_ID");
+    }
+
+    #[test]
+    fn the_shell_budget_flag_wins_over_an_operator_set_timeout() {
+        assert_eq!(shell_budget_env(Some(45), None).as_deref(), Some("45000"));
+        assert_eq!(shell_budget_env(Some(45), Some("900000")).as_deref(), Some("45000"));
+        assert_eq!(shell_budget_env(None, Some("900000")), None);
+        assert_eq!(shell_budget_env(None, None), None);
     }
 }

--- a/crates/baro-tui/src/cli/mod.rs
+++ b/crates/baro-tui/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod cli;
 pub mod launch;
+pub mod detach;
 pub mod run_registry;
 pub mod session;

--- a/crates/baro-tui/src/cli/run_registry.rs
+++ b/crates/baro-tui/src/cli/run_registry.rs
@@ -151,7 +151,6 @@ fn detached_record(goal: &str, cwd: &str, child_pid: u32, log_path: &Path) -> Ru
 /// Registers a detached child as a live run. The returned handle deliberately
 /// does not unregister on drop; the caller is the parent, which exits at once.
 // Wired from main.rs's detach path (a sibling story); unreferenced until then.
-#[allow(dead_code)]
 pub fn register_detached(
     goal: &str,
     cwd: &str,
@@ -363,7 +362,6 @@ fn record_still_listed(id: String) -> impl Fn() -> bool {
 }
 
 // Dispatched from main.rs's raw-argv arm (a sibling story); unreferenced here.
-#[allow(dead_code)]
 pub fn run_logs(args: &[String]) -> i32 {
     let Some(id) = command_target(args) else {
         eprintln!("usage: baro logs <ID> [--follow]   (list them with: baro runs)");
@@ -408,7 +406,6 @@ fn stream_log(path: &Path, follow: &dyn Fn() -> bool, out: &mut dyn Write) -> io
 }
 
 // Dispatched from main.rs's raw-argv arm (a sibling story); unreferenced here.
-#[allow(dead_code)]
 pub fn run_watch(args: &[String]) -> i32 {
     let Some(id) = command_target(args) else {
         eprintln!("usage: baro watch <ID>   (list them with: baro runs)");

--- a/crates/baro-tui/src/executor.rs
+++ b/crates/baro-tui/src/executor.rs
@@ -72,7 +72,7 @@ pub struct PrdFile {
     pub goal_fingerprint: Option<String>,
 }
 
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
 pub struct PrdStory {
     pub id: String,
     pub priority: i32,
@@ -184,10 +184,7 @@ pub fn prd_from_review(
         user_stories: stories.iter().map(prd_story_from_review).collect(),
         decision_document,
         execution_mode,
-        runtime_graph: None,
-        conversation_session_id: None,
-        goal_envelope: None,
-        goal_fingerprint: None,
+        ..Default::default()
     }
 }
 
@@ -252,15 +249,10 @@ pub fn prd_from_resume_review(
 
     let prd = PrdFile {
         project: project.to_string(),
-        branch_name: original.branch_name.clone(),
         description: description.to_string(),
         user_stories: merged,
-        decision_document: original.decision_document.clone(),
         execution_mode: execution_mode.or_else(|| original.execution_mode.clone()),
-        runtime_graph: original.runtime_graph.clone(),
-        conversation_session_id: original.conversation_session_id.clone(),
-        goal_envelope: original.goal_envelope.clone(),
-        goal_fingerprint: original.goal_fingerprint.clone(),
+        ..original.clone()
     };
     validate_resume_prd(&prd)?;
     Ok(prd)
@@ -360,8 +352,7 @@ fn prd_story_from_review(story: &ReviewStory) -> PrdStory {
         completed_at: None,
         duration_secs: None,
         model: story.model.clone(),
-        merge_status: None,
-        merge_commit_sha: None,
+        ..Default::default()
     }
 }
 
@@ -383,7 +374,7 @@ pub fn write_prd(prd: &PrdFile, cwd: &Path) -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{prd_from_resume_review, prd_from_review, write_prd, PrdFile};
+    use super::{prd_from_resume_review, prd_from_review, write_prd, PrdFile, PrdStory};
     use crate::app::ReviewStory;
     use std::fs;
 
@@ -710,5 +701,119 @@ mod tests {
         assert!(!out.contains("goalFingerprint"));
         assert!(!out.contains("mergeStatus"));
         assert!(!out.contains("mergeCommitSha"));
+    }
+
+    #[test]
+    fn a_goal_fingerprint_survives_a_full_prd_round_trip() {
+        let with_fingerprint = PrdFile {
+            project: "p".to_string(),
+            branch_name: "baro/p".to_string(),
+            goal_fingerprint: Some("fnv1a64:0123456789abcdef".to_string()),
+            ..Default::default()
+        };
+        let out = serde_json::to_string(&with_fingerprint).unwrap();
+        assert!(out.contains(r#""goalFingerprint":"fnv1a64:0123456789abcdef""#));
+        let parsed: PrdFile = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed.goal_fingerprint, with_fingerprint.goal_fingerprint);
+
+        let without_fingerprint = PrdFile {
+            project: "p".to_string(),
+            branch_name: "baro/p".to_string(),
+            ..Default::default()
+        };
+        let out = serde_json::to_string(&without_fingerprint).unwrap();
+        assert!(!out.contains("goalFingerprint"));
+    }
+
+    #[test]
+    fn merge_status_and_commit_sha_survive_a_completed_story_round_trip() {
+        let completed = PrdStory {
+            id: "S1".to_string(),
+            priority: 1,
+            title: "Done".to_string(),
+            description: "done".to_string(),
+            retries: 2,
+            passes: true,
+            merge_status: Some("merged".to_string()),
+            merge_commit_sha: Some("deadbeef".to_string()),
+            ..Default::default()
+        };
+        let prd = PrdFile {
+            project: "p".to_string(),
+            branch_name: "baro/p".to_string(),
+            user_stories: vec![completed.clone()],
+            ..Default::default()
+        };
+        let out = serde_json::to_string(&prd).unwrap();
+        assert!(out.contains(r#""mergeStatus":"merged""#));
+        assert!(out.contains(r#""mergeCommitSha":"deadbeef""#));
+        let parsed: PrdFile = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed.user_stories[0].merge_status, completed.merge_status);
+        assert_eq!(
+            parsed.user_stories[0].merge_commit_sha,
+            completed.merge_commit_sha
+        );
+
+        let pending = PrdStory {
+            id: "S2".to_string(),
+            priority: 2,
+            title: "Pending".to_string(),
+            description: "pending".to_string(),
+            retries: 2,
+            passes: false,
+            ..Default::default()
+        };
+        let prd_without = PrdFile {
+            project: "p".to_string(),
+            branch_name: "baro/p".to_string(),
+            user_stories: vec![pending],
+            ..Default::default()
+        };
+        let out = serde_json::to_string(&prd_without).unwrap();
+        assert!(!out.contains("mergeStatus"));
+        assert!(!out.contains("mergeCommitSha"));
+    }
+
+    #[test]
+    fn rewriting_the_branch_name_keeps_the_satellite_fields() {
+        let story = PrdStory {
+            id: "S1".to_string(),
+            priority: 1,
+            title: "Done".to_string(),
+            description: "done".to_string(),
+            retries: 2,
+            passes: true,
+            merge_status: Some("merged".to_string()),
+            merge_commit_sha: Some("deadbeef".to_string()),
+            ..Default::default()
+        };
+        let original = PrdFile {
+            project: "p".to_string(),
+            branch_name: "baro/original".to_string(),
+            goal_fingerprint: Some("fnv1a64:0123456789abcdef".to_string()),
+            user_stories: vec![story],
+            ..Default::default()
+        };
+
+        // Mirrors the main.rs branch-rewrite pattern: mutate branch_name on
+        // the moved value rather than rebuilding a full field literal.
+        let mut rewritten = original;
+        rewritten.branch_name = "baro/rewritten".to_string();
+
+        let out = serde_json::to_string(&rewritten).unwrap();
+        let parsed: PrdFile = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed.branch_name, "baro/rewritten");
+        assert_eq!(
+            parsed.goal_fingerprint.as_deref(),
+            Some("fnv1a64:0123456789abcdef")
+        );
+        assert_eq!(
+            parsed.user_stories[0].merge_status.as_deref(),
+            Some("merged")
+        );
+        assert_eq!(
+            parsed.user_stories[0].merge_commit_sha.as_deref(),
+            Some("deadbeef")
+        );
     }
 }

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -353,6 +353,9 @@ struct ModeContractView {
 
 #[tokio::main]
 async fn main() -> std::process::ExitCode {
+    // Before anything reads it: an inherited value belongs to whoever launched
+    // this process, and would make this run report under their identity.
+    cli::launch::scrub_inherited_run_id();
     match run_main().await {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(error) => {
@@ -385,13 +388,65 @@ async fn run_main() -> Result<(), Box<dyn std::error::Error>> {
         cli::run_registry::run_stop(&raw_args[2..])?;
         return Ok(());
     }
+    // `baro watch <id>` / `baro logs <id> [--follow]` — read a run from another
+    // terminal. Before clap so they neither take the session lock nor register
+    // themselves as a run; the slice is parsed inside run_registry.
+    if raw_args.get(1).map(|s| s.as_str()) == Some("watch") {
+        let code = cli::run_registry::run_watch(&raw_args[2..]);
+        std::process::exit(code);
+    }
+    if raw_args.get(1).map(|s| s.as_str()) == Some("logs") {
+        let code = cli::run_registry::run_logs(&raw_args[2..]);
+        std::process::exit(code);
+    }
 
     // Update notice: the network check runs in the JS layer (no HTTP dep
     // here); this reads its cache. Printed AFTER the TUI restores the
     // terminal (below) — the alternate screen purges it.
     let update_notice = notify_update();
 
-    let (cli, _lock) = cli::cli::parse()?;
+    let (mut cli, _lock) = cli::cli::parse()?;
+
+    // Detach re-execs this argv headless in a child and hands the run over to
+    // it, so the parent must leave before it registers or touches the terminal.
+    if cli.detach {
+        match cli::detach::run_detached(&cli, &raw_args) {
+            Ok(pid) => {
+                println!("run-{pid}");
+                std::process::exit(0);
+            }
+            Err(err) => {
+                eprintln!("baro: could not detach: {err}");
+                std::process::exit(2);
+            }
+        }
+    }
+
+    // Whether a bare `baro` continues the run prd.json describes or starts a
+    // new one. Decided here because the notice must reach a plain terminal —
+    // below, the alternate screen would swallow it.
+    let inferred = {
+        let prd = std::fs::read_to_string(std::path::Path::new(&cli.cwd).join("prd.json"))
+            .ok()
+            .and_then(|raw| serde_json::from_str::<executor::PrdFile>(&raw).ok());
+        let has_incomplete = prd
+            .as_ref()
+            .is_some_and(|p| p.user_stories.iter().any(|s| !s.passes));
+        cli::launch::decide_launch(
+            cli.resume,
+            cli.continue_run,
+            cli.goal.as_deref(),
+            prd.as_ref().and_then(|p| p.goal_fingerprint.as_deref()),
+            has_incomplete,
+        )
+    };
+    if let Some(message) = inferred.message.as_deref() {
+        eprintln!("baro: {message}");
+    }
+    if inferred.mode == cli::launch::LaunchMode::Resume {
+        cli.resume = true;
+    }
+
     // Held for the process's life; its Drop unregisters the run.
     let _run_record = cli::run_registry::register(
         cli.goal.as_deref().unwrap_or(""),
@@ -424,6 +479,14 @@ async fn run_main() -> Result<(), Box<dyn std::error::Error>> {
     }
     if let Some(value) = &cli.dialogue_model {
         std::env::set_var("BARO_DIALOGUE_MODEL", value);
+    }
+    // The orchestrator child inherits this env, so the flag reaches it without
+    // build_command knowing about it. Absent flag = leave an operator's value.
+    if let Some(ms) = cli::launch::shell_budget_env(
+        cli.shell_budget,
+        std::env::var("BASH_DEFAULT_TIMEOUT_MS").ok().as_deref(),
+    ) {
+        std::env::set_var("BASH_DEFAULT_TIMEOUT_MS", ms);
     }
 
     // --doctor short-circuits before any TUI setup — it must work even
@@ -740,6 +803,10 @@ async fn run_app(
     cli: cli::cli::Cli,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let headless = cli.headless;
+    // Captured before `cli.goal` is moved into the conversation and before the
+    // planner handoff replaces `app.goal_input`: this is the only stable copy
+    // of the goal that launched the run.
+    let launch_goal = cli.goal.clone();
     let critic_backend_explicitly_set = cli.critic_llm.is_some();
     let mut app = App::new();
     let cwd = std::fs::canonicalize(&cli.cwd)?;
@@ -1168,6 +1235,11 @@ async fn run_app(
                     )
                     .map_err(|error| format!("cannot verify resume branch: {error}"))?;
                     app.is_resume = true;
+                    // The orchestrator learns to resume only from `--resume` on
+                    // its own argv or from this variable, which it inherits;
+                    // without it the persisted plan is re-run from the top
+                    // instead of skipping what already landed.
+                    std::env::set_var("BARO_RESUME", "1");
                     app.project = prd.project.clone();
                     app.branch_name = continuation_branch.clone();
                     app.continuation_branch = Some(continuation_branch);
@@ -1185,7 +1257,14 @@ async fn run_app(
                         // `--resume --headless` sat on a review screen it had
                         // no way to answer.
                         println!(r#"{{"type":"plan_ready","stories":{}}}"#, stories.len());
-                        confirm_and_execute(&mut app, stories, &cwd, tx.clone(), headless);
+                        confirm_and_execute(
+                            &mut app,
+                            stories,
+                            &cwd,
+                            tx.clone(),
+                            headless,
+                            launch_goal.as_deref(),
+                        );
                     } else {
                         app.show_review(stories);
                     }
@@ -1698,8 +1777,15 @@ async fn run_app(
                 }
             }
             Some(AppEvent::ProgressivePlanningPrepared(spec)) => {
-                if let Err(error) =
-                    begin_progressive_execution(&mut app, spec, &cwd, tx.clone(), headless).await
+                if let Err(error) = begin_progressive_execution(
+                    &mut app,
+                    spec,
+                    &cwd,
+                    tx.clone(),
+                    headless,
+                    launch_goal.as_deref(),
+                )
+                .await
                 {
                     if headless {
                         return Err(format!("progressive planning could not start: {error}").into());
@@ -1725,7 +1811,14 @@ async fn run_app(
                         // Emit a planning event for the runner/dashboard, then
                         // auto-confirm and execute (no review screen).
                         println!(r#"{{"type":"plan_ready","stories":{}}}"#, stories.len());
-                        confirm_and_execute(&mut app, stories, &cwd, tx.clone(), headless);
+                        confirm_and_execute(
+                            &mut app,
+                            stories,
+                            &cwd,
+                            tx.clone(),
+                            headless,
+                            launch_goal.as_deref(),
+                        );
                     } else if app.conversation.goal_envelope().is_some() {
                         // Conversation-owned: confirm inline in the session.
                         app.pending_plan = Some(stories);
@@ -2203,7 +2296,14 @@ async fn run_app(
                                 );
                                 spawn_planner_stage_b(&app, &cwd, tx.clone(), mode_json);
                             } else if let Some(stories) = app.pending_plan.take() {
-                                confirm_and_execute(&mut app, stories, &cwd, tx.clone(), headless);
+                                confirm_and_execute(
+                                    &mut app,
+                                    stories,
+                                    &cwd,
+                                    tx.clone(),
+                                    headless,
+                                    launch_goal.as_deref(),
+                                );
                             } else if app.conversation_input.trim().starts_with('/') {
                                 let command = app.input_take();
                                 if run_slash_command(&mut app, &cwd, tx.clone(), command.trim()) {
@@ -2461,6 +2561,7 @@ async fn run_app(
                                         let exec_cwd = cwd.clone();
                                         let branch_tx = tx.clone();
                                         let err_tx = tx.clone();
+                                        let exec_goal = launch_goal.clone();
                                         if let Err(error) =
                                             begin_conversation_execution(&mut app, &cwd)
                                         {
@@ -2499,7 +2600,7 @@ async fn run_app(
                                                     return;
                                                 }
                                             };
-                                            let prd = match executor::prd_from_resume_review(
+                                            let mut prd = match executor::prd_from_resume_review(
                                                 &original_prd,
                                                 &project,
                                                 &description,
@@ -2516,6 +2617,7 @@ async fn run_app(
                                                     return;
                                                 }
                                             };
+                                            stamp_goal_fingerprint(&mut prd, exec_goal.as_deref());
                                             if let Err(error) = executor::write_prd(&prd, &exec_cwd)
                                             {
                                                 let _ = err_tx
@@ -2539,6 +2641,7 @@ async fn run_app(
                                             app.execution_mode.clone(),
                                         );
                                         attach_conversation_metadata(&mut prd, &app);
+                                        stamp_goal_fingerprint(&mut prd, launch_goal.as_deref());
                                         if let Err(e) = executor::write_prd(&prd, &cwd) {
                                             app.planning_error =
                                                 Some(format!("Failed to write prd.json: {}", e));
@@ -3836,6 +3939,15 @@ fn spawn_context_builder(cwd: &Path, tx: mpsc::Sender<AppEvent>) {
     });
 }
 
+/// Stamps the launching goal so a later bare `baro` recognises this prd.json as
+/// its own. `app.goal_input` cannot serve: the planner handoff overwrites it
+/// with the planning prompt. An already-stamped PRD keeps its fingerprint.
+fn stamp_goal_fingerprint(prd: &mut executor::PrdFile, launch_goal: Option<&str>) {
+    let Some(goal) = launch_goal else { return };
+    prd.goal_fingerprint
+        .get_or_insert_with(|| cli::launch::goal_fingerprint(goal));
+}
+
 /// Plan confirmation: write the PRD, create the run branch, and spawn the
 /// orchestrator. Shared by headless (which needs the raw event echo on stdout)
 /// and the conversation session, where echoing would paint over the TUI.
@@ -3845,6 +3957,7 @@ fn confirm_and_execute(
     cwd: &Path,
     tx: mpsc::Sender<AppEvent>,
     headless: bool,
+    launch_goal: Option<&str>,
 ) {
     app.review_stories = stories;
     let mut prd = executor::prd_from_review(
@@ -3856,6 +3969,7 @@ fn confirm_and_execute(
         app.execution_mode.clone(),
     );
     attach_conversation_metadata(&mut prd, app);
+    stamp_goal_fingerprint(&mut prd, launch_goal);
     if let Err(e) = executor::write_prd(&prd, cwd) {
         let _ = tx.try_send(AppEvent::BranchError(format!(
             "Failed to write prd.json: {}",
@@ -3971,6 +4085,7 @@ async fn begin_progressive_execution(
     cwd: &Path,
     tx: mpsc::Sender<AppEvent>,
     headless: bool,
+    launch_goal: Option<&str>,
 ) -> Result<(), String> {
     if app.is_followup || app.is_resume {
         return Err(
@@ -4012,6 +4127,7 @@ async fn begin_progressive_execution(
     )
     .map_err(|error| error.to_string())?;
     attach_conversation_metadata(&mut bootstrap, app);
+    stamp_goal_fingerprint(&mut bootstrap, launch_goal);
 
     let actual_branch = git::create_fresh_branch(cwd, &bootstrap.branch_name)
         .await


### PR DESCRIPTION
Completes the CLI UX work from PR #91 — the wiring that turns landed structure into behavior. Run 69's three stories all merged; the machine lost power exactly as the run gate started, so the gate and this PR are hand-carried by the operator's session.

- **S1**: detach spawn module (cli/detach.rs — re-exec argv headless, registry log redirect, caffeinate sibling on macOS) + BARO_RUN_ID scrub + shell-budget helpers.
- **S2**: PrdFile/PrdStory satellite-site audit — construction/clone/serialize sites preserve goalFingerprint/mergeStatus/mergeCommitSha.
- **S3**: main.rs wiring — top-of-main scrub, pre-clap watch/logs dispatch, detach execution, bare-launch decide_launch with plain-terminal notice, shell-budget precedence, BARO_RESUME seam to the TS orchestrator.

Gate equivalent run by hand on the merged tree: cargo 236/236, TS suite 1989/1990 with the one failure (provider-ownership-manifest, load-sensitive) passing 7/7 in isolation per the flake rule, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)