### PR TITLE
planner invariant coverage: claude-lane receipt, repair-prompt invariants, notice-before-terminal proof

### DIFF
--- a/packages/baro-orchestrator/src/planning/adapters/planner-bus-session.ts
+++ b/packages/baro-orchestrator/src/planning/adapters/planner-bus-session.ts
@@ -50,6 +50,8 @@ import {
 import { missingObligationIdsFromError } from "../domain/architecture-obligation-contract.js"
 import type { WriteSurfaceOverlapFacts } from "../../events/runtime-graph.js"
 import { formatObligationIdList } from "../domain/obligation-coverage-report.js"
+import { unownedInvariantsWithText } from "../domain/invariant-coverage-report.js"
+import { deriveGoalContract } from "../../goal/goal-contract.js"
 import {
     createPlannerHarnessProgressiveSupport,
     currentPlannerMcpServerCommand,
@@ -395,6 +397,10 @@ export async function runPlannerBusSession(
         )
     }
 
+    // Derived after the publisher, which already validated this same
+    // envelope, so a malformed goal still fails there and not here.
+    const goalContract = deriveGoalContract(opts.goalEnvelope)
+
     const systemPrompt = progressive.systemInstruction
         ? `${PLANNER_SYSTEM_PROMPT}\n\n${progressive.systemInstruction}`
         : PLANNER_SYSTEM_PROMPT
@@ -583,6 +589,10 @@ export async function runPlannerBusSession(
                             reason,
                             error: rejectionError,
                             unownedObligationIds: unowned,
+                            unownedInvariants: unownedInvariantsWithText(
+                                goalContract,
+                                progressive.unownedInvariantIds(),
+                            ),
                             ...(lastWriteSurfaceOverlap
                                 ? { writeSurfaceOverlap: lastWriteSurfaceOverlap }
                                 : {}),

--- a/packages/baro-orchestrator/src/planning/domain/planner-prompts.ts
+++ b/packages/baro-orchestrator/src/planning/domain/planner-prompts.ts
@@ -7,6 +7,8 @@ import {
     renderArchitectureObligationCriterion,
 } from "./architecture-obligation-contract.js"
 import { formatObligationIdList } from "./obligation-coverage-report.js"
+import { renderUnownedInvariantLines } from "./invariant-coverage-report.js"
+import type { GoalInvariant } from "../../goal/goal-contract.js"
 import type { WriteSurfaceOverlapFacts } from "../../events/runtime-graph.js"
 
 /**
@@ -574,6 +576,7 @@ export function buildFinalPrdRepairMessage(input: {
     reason: string
     error?: unknown
     unownedObligationIds: readonly string[]
+    unownedInvariants?: readonly GoalInvariant[]
     writeSurfaceOverlap?: WriteSurfaceOverlapFacts
 }): string {
     // contractDefects synthesizes a defect from whatever it is handed, so an
@@ -595,6 +598,16 @@ export function buildFinalPrdRepairMessage(input: {
             `Unowned architecture obligations (${input.unownedObligationIds.length}):\n` +
                 `${formatObligationIdList(input.unownedObligationIds)}\n` +
                 "Every id above must be claimed by an acceptance criterion of a " +
+                "story in THIS reply — already-published stories are immutable " +
+                "and cannot take them later.",
+        )
+    }
+    const unownedInvariants = input.unownedInvariants ?? []
+    if (unownedInvariants.length > 0) {
+        sections.push(
+            `Unowned goal invariants (${unownedInvariants.length}):\n` +
+                `${renderUnownedInvariantLines(unownedInvariants)}\n` +
+                "Every id above must be claimed via goalInvariantIds of a " +
                 "story in THIS reply — already-published stories are immutable " +
                 "and cannot take them later.",
         )

--- a/packages/baro-orchestrator/test/planning/planner-invariant-coverage-conformance.test.ts
+++ b/packages/baro-orchestrator/test/planning/planner-invariant-coverage-conformance.test.ts
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict"
+import { afterEach, beforeEach, describe, it } from "node:test"
+
+import { createPlannerHarnessProgressiveSupport } from "../../src/planning/adapters/planner-harness-progressive.js"
+import type { PlannerOpenAIPlanFragmentEvent } from "../../src/planning/adapters/planner-openai-progressive.js"
+import type { InvariantCoverageGap } from "../../src/planning/application/plan-events.js"
+import {
+    invariantGapSummary,
+    unownedInvariantsWithText,
+} from "../../src/planning/domain/invariant-coverage-report.js"
+import { buildFinalPrdRepairMessage } from "../../src/planning/domain/planner-prompts.js"
+import {
+    deriveGoalContract,
+    GoalInvariantLedger,
+} from "../../src/goal/goal-contract.js"
+import {
+    VerificationGoalGate,
+    type VerificationGoalGateHost,
+} from "../../src/verification/verification-goal-gate.js"
+import {
+    GoalCompletionCheckRequested,
+    type GoalCompletionAttestedData,
+} from "../../src/semantic-events.js"
+import type { SemanticEvent } from "../../src/runtime/mozaik.js"
+import type { PrdFile } from "../../src/prd.js"
+
+const GOAL_ENVELOPE = {
+    objective: "Preserve the public boundary.",
+    acceptanceCriteria: [
+        "Its behavior remains observable.",
+        "Its receipt names the gap.",
+    ],
+    constraints: ["It stays fail-closed."],
+    nonGoals: [],
+    assumptions: [],
+}
+
+const CONTRACT = deriveGoalContract(GOAL_ENVELOPE)
+assert.ok(CONTRACT)
+const ALL_INVARIANT_IDS = CONTRACT.invariants.map(({ id }) => id)
+
+const BASE_STORY = {
+    priority: 1,
+    description: "Thread the signal through the provider boundary.",
+    dependsOn: [] as string[],
+    retries: 2,
+    tests: ["npm test"],
+    acceptance: ["The exact signal reaches providers."],
+    model: "heavy",
+}
+
+function story(id: string, invariantIds: readonly string[]) {
+    return {
+        ...BASE_STORY,
+        id,
+        title: `Story ${id}`,
+        goalInvariantIds: [...invariantIds],
+    }
+}
+
+/** Configured exactly as planner-bus-session.ts configures the claude lane. */
+async function busLaneSupport(
+    runId: string,
+    hooks: {
+        onInvariantCoverageGap: (gap: InvariantCoverageGap) => void
+        onHostFeedback?: (feedback: Record<string, unknown>) => void
+    },
+) {
+    return await createPlannerHarnessProgressiveSupport({
+        runId,
+        planningId: `planning-${runId}`,
+        trustedGoalEnvelope: GOAL_ENVELOPE,
+        finalizationTailOnly: true,
+        mcpServer: { command: process.execPath, args: [] },
+        onInvariantCoverageGap: hooks.onInvariantCoverageGap,
+        publish: async (event: PlannerOpenAIPlanFragmentEvent) => {
+            const feedback: Record<string, unknown> = {
+                graphVersion: 7,
+                admittedStoryIds: event.stories.map(({ id }) => id),
+                replayed: false,
+            }
+            hooks.onHostFeedback?.(feedback)
+            return feedback
+        },
+    })
+}
+
+const RESERVED_RECEIPT_KEYS = [
+    "invariantNote",
+    "unownedInvariantIds",
+    "obligationNote",
+    "unownedObligationIds",
+]
+
+describe("claude-lane invariant coverage conformance", () => {
+    let written: string[] = []
+    const realWrite = process.stderr.write.bind(process.stderr)
+
+    beforeEach(() => {
+        written = []
+        process.stderr.write = ((chunk: string | Uint8Array) => {
+            written.push(typeof chunk === "string" ? chunk : chunk.toString())
+            return true
+        }) as typeof process.stderr.write
+    })
+
+    afterEach(() => {
+        process.stderr.write = realWrite
+    })
+
+    const announcements = () =>
+        written.filter((line) => line.startsWith("[planner-invariants] "))
+
+    it("bus-session receipt carries unowned invariant ids", async () => {
+        const gaps: InvariantCoverageGap[] = []
+        const feedbacks: Record<string, unknown>[] = []
+        const support = await busLaneSupport("bus-lane-receipt", {
+            onInvariantCoverageGap: (gap) => gaps.push(gap),
+            onHostFeedback: (feedback) => feedbacks.push(feedback),
+        })
+
+        let receipt: Record<string, unknown>
+        try {
+            receipt = JSON.parse(
+                await support.publish({
+                    fragmentId: "foundation",
+                    stories: [story("S1", []), story("S2", [])],
+                }),
+            ) as Record<string, unknown>
+        } finally {
+            await support.close()
+        }
+
+        assert.deepEqual(receipt.unownedInvariantIds, ALL_INVARIANT_IDS)
+        const note = receipt.invariantNote as string
+        assert.ok(note.startsWith("WARNING:"), note)
+        for (const id of ALL_INVARIANT_IDS) assert.ok(note.includes(id), id)
+        assert.deepEqual(support.unownedInvariantIds(), ALL_INVARIANT_IDS)
+
+        assert.equal(feedbacks.length, 1)
+        for (const key of RESERVED_RECEIPT_KEYS) {
+            assert.ok(!(key in (feedbacks[0] as object)), key)
+        }
+        assert.equal(receipt.graphVersion, 7)
+
+        assert.equal(gaps.length, 1)
+        assert.deepEqual(gaps[0], {
+            fragmentId: "foundation",
+            unownedInvariantIds: ALL_INVARIANT_IDS,
+            totalInvariants: ALL_INVARIANT_IDS.length,
+        })
+
+        assert.deepEqual(announcements(), [
+            `[planner-invariants] fragment foundation admitted; unowned ${invariantGapSummary(
+                ALL_INVARIANT_IDS,
+                ALL_INVARIANT_IDS.length,
+            )}\n`,
+        ])
+    })
+
+    it("repair prompt lists invariant ids with canonical statements", () => {
+        const ids = ALL_INVARIANT_IDS.slice(0, 2)
+        const unownedInvariants = unownedInvariantsWithText(CONTRACT, ids)
+        assert.equal(unownedInvariants.length, 2)
+
+        const input = {
+            reason: "final PRD failed goal coverage",
+            unownedObligationIds: ["O-001"],
+        }
+        const message = buildFinalPrdRepairMessage({
+            ...input,
+            unownedInvariants,
+        })
+
+        assert.ok(message.includes("Unowned goal invariants (2):"), message)
+        const lines = message.split("\n")
+        for (const invariant of unownedInvariants) {
+            assert.ok(
+                lines.includes(`- [${invariant.id}] ${invariant.text}`),
+                invariant.id,
+            )
+        }
+        assert.ok(
+            message.includes("Unowned architecture obligations (1):"),
+            message,
+        )
+        assert.ok(message.indexOf("Unowned architecture obligations (1):") <
+            message.indexOf("Unowned goal invariants (2):"))
+        assert.ok(message.indexOf("Unowned goal invariants (2):") <
+            message.indexOf("Expected schema:"))
+
+        // A session whose envelope yields no contract must degrade silently.
+        const withoutContract = unownedInvariantsWithText(
+            deriveGoalContract(undefined),
+            ids,
+        )
+        assert.deepEqual(withoutContract, [])
+        const degraded = buildFinalPrdRepairMessage({
+            ...input,
+            unownedInvariants: withoutContract,
+        })
+        assert.ok(!degraded.includes("Unowned goal invariants"), degraded)
+        assert.equal(degraded, buildFinalPrdRepairMessage(input))
+    })
+
+    it("coverage notice precedes terminal failure", async () => {
+        const observed: string[] = []
+
+        const support = await busLaneSupport("bus-lane-ordering", {
+            onInvariantCoverageGap: (gap) =>
+                observed.push(
+                    `coverage-gap:${gap.unownedInvariantIds.join(",")}`,
+                ),
+        })
+        try {
+            await support.publish({
+                fragmentId: "foundation",
+                stories: [story("S1", [])],
+            })
+        } finally {
+            await support.close()
+        }
+
+        const ledger = new GoalInvariantLedger(CONTRACT)
+        const assessment = ledger.assess([], false)
+        const projection = ledger.snapshot(1)
+        assert.equal(assessment.status, "incomplete")
+        assert.deepEqual(assessment.openInvariantIds, ALL_INVARIANT_IDS)
+
+        const prd = {
+            goalEnvelope: GOAL_ENVELOPE,
+            userStories: [],
+            runtimeGraph: {
+                protocol: { schemaVersion: 1, goal: projection },
+            },
+        } as unknown as PrdFile
+        const emitted: SemanticEvent<unknown>[] = []
+        let phase = "running"
+        const host: VerificationGoalGateHost = {
+            emit: (event) => emitted.push(event),
+            phase: () => phase,
+            enterVerifying: () => {
+                phase = "verifying"
+            },
+            requestPush: (reason) => observed.push(`terminal:${reason}`),
+            prd: () => prd,
+            persistGoalProtocol: () => undefined,
+            waveOrdinal: () => 1,
+        }
+        const gate = new VerificationGoalGate({
+            runId: "ordering-run",
+            verifyBeforePush: false,
+            hasGoalCompletionAuthority: true,
+            host,
+        })
+        gate.requestVerification(null)
+
+        const requested = emitted.find((event) =>
+            GoalCompletionCheckRequested.is(event),
+        )
+        assert.ok(requested)
+        gate.onGoalCompletionAttested({
+            runId: "ordering-run",
+            checkId: requested.data.checkId,
+            contractId: CONTRACT.contractId,
+            goalRevision: projection.revision,
+            verificationId: requested.data.verificationId,
+            status: assessment.status,
+            satisfiedInvariantIds: assessment.satisfiedInvariantIds,
+            openInvariantIds: assessment.openInvariantIds,
+            rejectedInvariantIds: assessment.rejectedInvariantIds,
+            invariants: assessment.invariants,
+            reason: assessment.reason,
+        } as GoalCompletionAttestedData)
+        gate.releasePendings()
+
+        const gapIndex = observed.findIndex((entry) =>
+            entry.startsWith("coverage-gap:"),
+        )
+        const terminalIndex = observed.findIndex((entry) =>
+            entry.startsWith("terminal:"),
+        )
+        assert.ok(gapIndex >= 0, JSON.stringify(observed))
+        assert.ok(terminalIndex >= 0, JSON.stringify(observed))
+        assert.ok(gapIndex < terminalIndex, JSON.stringify(observed))
+        const terminal = observed[terminalIndex] as string
+        assert.match(terminal, /global goal is not satisfied/)
+        assert.match(terminal, /open invariant\(s\)/)
+    })
+})


### PR DESCRIPTION
Completes GitHub issue #112 by shipping the three parts PR #116 left open: the claude lane's coverage notice, the finalization repair prompt's invariant list, and a conformance test proving the notice precedes the terminal failure.

## The claude lane was already conformant — no adapter diff ships

ADR-001 required the claude lane to be *characterized with a test before* any adapter was edited, rather than assuming code was missing. That test (`bus-session receipt carries unowned invariant ids`) **passed on its first run, before any production edit**, so no change was made to `planner-harness-progressive.ts` or `planner-openai-progressive.ts`.

The reason: `planner-harness-progressive.ts` hands its entire config object to `createPlannerProgressivePublisher(config)`, and `PlannerHarnessProgressiveConfig extends PlannerOpenAIProgressiveConfig`. So `trustedGoalEnvelope` and `onInvariantCoverageGap` already reach the single `publish()` in `planner-openai-progressive.ts` that owns the `invariantNote`, the `[planner-invariants]` stderr line and the warn sink. Both lanes were already byte-identical by construction; inventing a refactor to create a diff would have been the wrong outcome.

## Changes

- `src/planning/domain/planner-prompts.ts` — `buildFinalPrdRepairMessage` gains one optional `unownedInvariants?: readonly GoalInvariant[]` field, rendered through `renderUnownedInvariantLines` from `invariant-coverage-report.js`. Omitted or empty, the message is byte-identical to before.
- `src/planning/adapters/planner-bus-session.ts` — the single repair call site passes `unownedInvariants: unownedInvariantsWithText(goalContract, progressive.unownedInvariantIds())`, with the contract derived once per session *after* the publisher (which already validates the same envelope, so a malformed goal keeps failing there).
- `test/planning/planner-invariant-coverage-conformance.test.ts` — new, the only test file added or modified.

No file under `src/verification/`, nor `src/goal/goal-contract.ts`, nor `src/execution/collective-board.ts` is touched: the terminal fail-closed gate is unchanged, and this work adds only notices and prompt content.

## The three tests

1. **`bus-session receipt carries unowned invariant ids`** — drives the lane through `createPlannerHarnessProgressiveSupport` with the exact config shape `planner-bus-session.ts` builds (host `publish` returning only `{graphVersion, admittedStoryIds, replayed}`) and publishes one fragment whose stories set `goalInvariantIds: []`. Asserts `receipt.unownedInvariantIds` deep-equals every contract invariant id, `invariantNote` starts with `WARNING:` and contains those ids, the host feedback carries none of the four reserved keys, `receipt.graphVersion` survives the last-position spread, exactly one warn event reaches the injected sink, and the stderr line is built from the production `invariantGapSummary`.
2. **`repair prompt lists invariant ids with canonical statements`** — pins the section *order* (obligations < `Unowned goal invariants (2):` < `Expected schema:`), each exact `- [<id>] <text>` line, and that a non-derivable contract degrades silently to a message byte-identical to omitting the field.
3. **`coverage notice precedes terminal failure`** — the terminal string comes only from production code, never a literal: `GoalInvariantLedger.assess([], false)` supplies the `N open invariant(s)` half and the real `VerificationGoalGate.onGoalCompletionAttested` composes the rest against a stub host. The proof is that the `coverage-gap:` index is `>= 0` and strictly less than the `terminal:` index. `VerificationGoalGate` turned out to be constructible with a stub host, so the `collective-board.test.ts` fallback was not needed.

## Verification

- New conformance file: 3/3 pass.
- The three #116 tests plus both repair tests, unchanged: 54/54 pass.
- `npm run typecheck -w packages/baro-orchestrator` and `npm run build -w packages/baro-orchestrator`: clean.

## Known limitation

Test 1 pins that host feedback does not shadow the invariant receipt keys *given today's bus-session callback*. ADR-002's key freeze is a review-time discipline, not an enforced one — nothing in the type system stops a future `publish` callback from returning `unownedInvariantIds` and silently overwriting the publisher's, since `...(hostFeedback ?? {})` is spread last. `planner-progressive-invariant-note.test.ts` even documents that shadowing works today ("may still override them"). Making it structurally impossible would mean changing the spread order in `planner-openai-progressive.ts`, which is outside this change set's permitted file list — a candidate follow-up.

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
