### PR TITLE
feat(baro-dsh): baro as a DeepSeek Harness subagent provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7337,6 +7337,7 @@
         "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
         "@deepseek-ai/dsh-subagent": "0.1.2-rc.1",
         "@deepseek-ai/dsh-subprocess": "0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1",
         "@deepseek-ai/schemastery": "^3.18.2",
         "@types/node": "^22.0.0",
         "@types/react": "~18.3.1",
@@ -7350,6 +7351,7 @@
         "@deepseek-ai/dsh-jobs": "0.1.2-rc.1",
         "@deepseek-ai/dsh-subagent": "0.1.2-rc.1",
         "@deepseek-ai/dsh-subprocess": "0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1",
         "@deepseek-ai/schemastery": "^3.18.2"
       }
     },

--- a/packages/baro-dsh/README.md
+++ b/packages/baro-dsh/README.md
@@ -1,11 +1,15 @@
 # baro-dsh
 
 baro as a subagent provider for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness).
-A dsh agent delegates a goal, baro plans and executes it in the session's
-working directory as a headless run, and the delegation comes back with the
-certified outcome: whether the run succeeded, how it was classified when it
-did not, and the pull request if one was made. While it runs it is a `baro-N`
-job in dsh's jobs list, readable by anyone in the frame.
+A dsh agent calls the `baro` tool with a goal; baro plans it into stories,
+executes them in parallel with coding agents in the session's working
+directory, reviews each story independently and verifies the merged result.
+The delegation returns the certified outcome: whether the run succeeded, how it
+was classified when it did not, the story count, commits, and the pull request
+if one was made. While it runs, the sidebar shows a **baro runs** panel with the
+phase (intake → architect → planning → executing → finalizing), story progress,
+the agent's latest activity and the milestone log; dsh's own jobs list carries
+it as a `baro-N` job.
 
 ## Install
 
@@ -13,15 +17,15 @@ job in dsh's jobs list, readable by anyone in the frame.
 dsh plugin --profile web add baro-dsh
 ```
 
-The `baro` CLI must be on `PATH` (`npm i -g baro-ai`) and logged into its own
-model lane; dsh scrubs the parent environment, so any credential baro needs
-goes into the plugin's `env` config, never inherited.
+The `baro` CLI must be on `PATH` (`npm i -g baro-ai`) and signed into its own
+model lane. dsh scrubs the parent environment before spawning, so any credential
+baro needs goes into the plugin's `env` config, never inherited.
 
 ## Configuration
 
 | key | default | meaning |
 |---|---|---|
-| `providerName` | `baro` | name under `ctx.subagents` |
+| `providerName` | `baro` | name under `ctx.subagents`; the tool is named the same |
 | `command` | `baro` | executable, name on PATH or absolute path |
 | `args` | `[]` | extra `baro` flags (e.g. `--llm codex`) |
 | `localOnly` | `true` | `--local-only`: no baro-owned pushes or pull requests |
@@ -29,12 +33,43 @@ goes into the plugin's `env` config, never inherited.
 | `env` | `{}` | child environment (credentials go here) |
 | `disposeGraceMs` | `5000` | SIGTERM→SIGKILL grace on dispose |
 
+## What the model sees
+
+dsh's delegation tool has a fixed description, so the plugin adds a system
+prompt section: `baro` is for goals that span several files or need more than
+one coherent change; a single small edit or an investigation stays with the
+agent or the ordinary subagent. A run takes 10–30 minutes.
+
+## Outcome mapping
+
+| baro `done` | dsh `stopReason` |
+|---|---|
+| `success: true` | `completed` |
+| every story merged, verification passed, no abort code, goal contract left open | `completed` (the open contract is in the text) |
+| `abort_code: token_ceiling` | `max-tokens` |
+| cancelled or disposed | `aborted` |
+| anything else | `error` |
+
+The full protocol stream of a run is in `~/.baro/runs/<repo>-<timestamp>.jsonl`.
+
 ## Layout
 
-- `src/domain` — baro's TUI protocol v3 and the run fold; no dsh imports.
-- `src/application` — the one use case, `DelegateRun`, over two ports:
-  a process to run and an observer to watch.
-- `src/adapters/dsh` — dsh's subagent provider, subprocess and jobs seams.
+- `src/domain` — baro's TUI protocol v3 and the run fold (phase, activity,
+  milestones, outcome); no dsh imports.
+- `src/application` — the one use case, `DelegateRun`, over two ports: a
+  process to run and observers to watch, composed and isolated from each other.
+- `src/adapters/dsh` — the subagent provider, the subprocess runner, the jobs
+  observer and the settings observer that feeds the panel.
+- `src/client` — the browser half: reads run state from the `baro-dsh` settings
+  namespace, follows `settings/document-updated`, renders the sidebar panel.
 - `src/index.ts` — the plugin: composition only.
+
+## Why a settings namespace
+
+An out-of-tree plugin cannot add a remote or a forwarded event to dsh's API
+assembly (it is fixed at dsh build time). The settings service is writable from
+the host, readable from every client, and its update event is forwarded, so
+run state travels that way. Writes are throttled to one per second per run and
+finished runs are pruned after five.
 
 Pinned to dsh `0.1.2-rc.1`; the provider seam is a developer preview upstream.

--- a/packages/baro-dsh/package.json
+++ b/packages/baro-dsh/package.json
@@ -1,7 +1,27 @@
 {
   "name": "baro-dsh",
   "version": "0.1.0",
-  "description": "baro as a subagent provider for DeepSeek Harness: delegate a goal, watch it as a background job, get a certified verdict back",
+  "description": "baro as a DeepSeek Harness subagent provider: delegate a multi-story goal, get parallel execution, independent review and a verified outcome back \u2014 with a live run panel in the sidebar",
+  "keywords": [
+    "dsh-plugin",
+    "deepseek-harness",
+    "dsh",
+    "baro",
+    "subagent",
+    "agents",
+    "orchestration",
+    "verification"
+  ],
+  "homepage": "https://github.com/jigjoy-ai/baro/tree/main/packages/baro-dsh#readme",
+  "bugs": {
+    "url": "https://github.com/jigjoy-ai/baro/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jigjoy-ai/baro",
+    "directory": "packages/baro-dsh"
+  },
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,6 +39,9 @@
     "dist/",
     "cordis.patch.yml"
   ],
+  "engines": {
+    "node": ">=20"
+  },
   "dsh": {
     "bundle": {
       "patch": "./cordis.patch.yml"
@@ -39,7 +62,8 @@
     "build:host": "tsc -p tsconfig.json",
     "build:client": "tsup",
     "test": "node --test --import tsx test/*.test.ts",
-    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.client.json"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.client.json",
+    "prepublishOnly": "npm run typecheck && npm test && npm run build"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.2",
@@ -75,17 +99,5 @@
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",
     "typescript": "^5.3.3"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jigjoy-ai/baro",
-    "directory": "packages/baro-dsh"
-  },
-  "keywords": [
-    "dsh-plugin",
-    "deepseek-harness",
-    "baro",
-    "subagent"
-  ],
-  "license": "MIT"
+  }
 }

--- a/packages/baro-dsh/package.json
+++ b/packages/baro-dsh/package.json
@@ -46,6 +46,7 @@
     "@deepseek-ai/dsh-jobs": "0.1.2-rc.1",
     "@deepseek-ai/dsh-subagent": "0.1.2-rc.1",
     "@deepseek-ai/dsh-subprocess": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1",
     "@deepseek-ai/schemastery": "^3.18.2"
   },
   "devDependencies": {
@@ -66,6 +67,7 @@
     "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
     "@deepseek-ai/dsh-subagent": "0.1.2-rc.1",
     "@deepseek-ai/dsh-subprocess": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1",
     "@deepseek-ai/schemastery": "^3.18.2",
     "@types/node": "^22.0.0",
     "@types/react": "~18.3.1",

--- a/packages/baro-dsh/src/adapters/dsh/subprocess-runner.ts
+++ b/packages/baro-dsh/src/adapters/dsh/subprocess-runner.ts
@@ -29,10 +29,12 @@ export class SubprocessRunner implements RunProcessPort {
       ...(this.baro.localOnly ? ['--local-only'] : []),
       ...this.baro.args,
     ]
+    // stdin must be closed, not merely silent: headless baro answers its own
+    // intake questions only once stdin hits EOF, and blocks on an open pipe.
     const child = this.spawn({
       argv,
       cwd: request.cwd,
-      stdio: { stdin: 'pipe', stdout: 'pipe', stderr: 'inherit' },
+      stdio: { stdin: 'ignore', stdout: 'pipe', stderr: 'inherit' },
       graceMs: this.baro.disposeGraceMs,
       signal: request.signal,
       env: { ...this.baro.env, BARO_RUN_ID: request.runId },

--- a/packages/baro-dsh/src/index.ts
+++ b/packages/baro-dsh/src/index.ts
@@ -17,8 +17,15 @@ export type { RunRecord, RunsDocument } from './adapters/dsh/settings-observer.j
    registers the provider. Everything else in this package is dsh-free. */
 
 export const name = 'baro-dsh'
-// cordis has no optional injection; all four are in dsh-base.
-export const inject = ['subagents', 'subprocess', 'jobs', 'settings']
+// cordis has no optional injection; all five are in dsh-base.
+export const inject = ['subagents', 'subprocess', 'jobs', 'settings', 'systemPrompt']
+
+/* dsh's delegation tool carries a fixed description, so the one place to tell
+   the model what baro is for is a prompt section. It is a run, not a helper:
+   minutes of planning and verification that only pay off past one small edit. */
+export const DELEGATION_GUIDANCE = `\
+The "baro" tool delegates a goal to baro, an autonomous run that plans the goal into stories, executes them in parallel with coding agents, reviews each story independently, and verifies the merged result. A run takes 10–30 minutes and returns a certified outcome, not a chat reply.
+Use "baro" for goals that span several files or need more than one coherent change, where a plan, parallel execution and independent verification are worth the wait. For a single small edit, a question, or an investigation, do the work yourself or use the ordinary subagent. Give baro the full goal in one prompt; it does not see this conversation.`
 
 /** Namespace the browser panel reads; must match `src/client`. */
 export const RUNS_SETTINGS_NS = 'baro-dsh'
@@ -85,4 +92,11 @@ export function apply(ctx: Context, config: Config): void {
     resolved.cwd,
   )
   ctx.effect(() => ctx.subagents.registerProvider(provider))
+  ctx.effect(() =>
+    ctx.systemPrompt.section({
+      name: 'baro:delegation',
+      order: 400,
+      text: DELEGATION_GUIDANCE.replaceAll('"baro"', `"${resolved.providerName ?? 'baro'}"`),
+    }),
+  )
 }

--- a/packages/baro-dsh/test/subprocess-runner.test.ts
+++ b/packages/baro-dsh/test/subprocess-runner.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { PassThrough } from 'node:stream'
+import type { SubprocessHandle, SubprocessSpawnSpec } from '@deepseek-ai/dsh-subprocess'
+import { SubprocessRunner } from '../src/adapters/dsh/subprocess-runner.ts'
+
+function recordingSpawn(): { spawn: (spec: SubprocessSpawnSpec) => SubprocessHandle; specs: SubprocessSpawnSpec[] } {
+  const specs: SubprocessSpawnSpec[] = []
+  const spawn = (spec: SubprocessSpawnSpec): SubprocessHandle => {
+    specs.push(spec)
+    return {
+      stdin: undefined,
+      stdout: new PassThrough(),
+      stderr: undefined,
+      done: new Promise(() => {}),
+      terminate: () => {},
+      waitForExit: async () => undefined,
+    } as unknown as SubprocessHandle
+  }
+  return { spawn, specs }
+}
+
+describe('SubprocessRunner', () => {
+  const baro = { command: 'baro', args: ['--llm', 'claude'], localOnly: true, env: { HOME: '/h' }, disposeGraceMs: 5 }
+
+  it('spawns headless baro with the goal, cwd and run id', () => {
+    const { spawn, specs } = recordingSpawn()
+    new SubprocessRunner(spawn, baro).start({ goal: 'add a helper', cwd: '/repo', label: 'helper', runId: 'run-1', signal: new AbortController().signal })
+    assert.equal(specs.length, 1)
+    assert.deepEqual(specs[0].argv, ['baro', 'add a helper', '--headless', '--cwd', '/repo', '--local-only', '--llm', 'claude'])
+    assert.equal(specs[0].cwd, '/repo')
+    assert.equal(specs[0].env?.BARO_RUN_ID, 'run-1')
+  })
+
+  // A run stalled 20 minutes on an intake question nobody could answer: headless
+  // baro decides such questions itself only after stdin reaches EOF.
+  it('closes stdin so headless baro resolves intake questions on its own', () => {
+    const { spawn, specs } = recordingSpawn()
+    new SubprocessRunner(spawn, baro).start({ goal: 'g', cwd: '/repo', label: 'g', runId: 'run-2', signal: new AbortController().signal })
+    assert.equal(specs[0].stdio.stdin, 'ignore')
+    assert.equal(specs[0].stdio.stdout, 'pipe')
+  })
+})


### PR DESCRIPTION
## What

New package `packages/baro-dsh`: a DeepSeek Harness plugin that makes baro a subagent provider. From dsh, an agent delegates a goal with the `baro` tool; baro plans it into stories, runs coding agents in parallel, reviews each story independently and hands back a verified outcome. A sidebar panel shows the run live: phase stepper, stories, last activity, milestones, elapsed time.

## Layout (DDD)

- `domain/` — protocol v3 parsing, run tracker, outcome classification (`classifyDone`, `deliveredDespiteContract`)
- `application/` — `DelegateRun` use case over two ports: `RunProcessPort` and `RunObserverPort`
- `adapters/dsh/` — subprocess runner, jobs observer, settings observer (panel channel), subagent provider
- `client/` — the sidebar panel bundle (CJS, `__ModuleLoader__` wrapper, dsw theme tokens)
- `cordis.patch.yml` — rows `baro` and `tool-baro` (`@deepseek-ai/dsh-tool-subagent`, one-shot, provider-managed depth)

## Verified

- 19 tests, typecheck clean (host + client)
- Five real delegations from dsh web on `~/Desktop/baro-dsh-playground`; the last one (camelCase + padCenter) ended `success: true`, verification passed, 13/13 goal invariants, panel `completed`, agent reported the exact commits
- Those runs surfaced three baro fixes (PR #122, released as 0.108.0) and one plugin fix: the child's stdin is now closed so headless baro answers its own intake questions instead of waiting forever

## Not in this PR

Custom remote (out-of-tree plugins cannot add api-remotes; the panel reads a settings namespace instead), tee of the run stream to a file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1bpAF6qY7wdqxL77pKxKE