### PR TITLE
fix(planning): final tail meets the board while the planner can still answer (#104)

### DIFF
--- a/packages/baro-orchestrator/src/planning/adapters/planner-bus-session.ts
+++ b/packages/baro-orchestrator/src/planning/adapters/planner-bus-session.ts
@@ -553,6 +553,7 @@ export async function runPlannerBusSession(
             let composedFinalPrd: Record<string, unknown>
             let candidate: string | null = null
             let rejectionError: unknown = null
+            let tailRefusedByHost = false
             try {
                 candidate = extractJsonObject(resultText.trim())
             } catch {
@@ -565,6 +566,15 @@ export async function runPlannerBusSession(
                     )
                 }
                 progressive.assertInitialized()
+                // The appended tail meets the board here, while the planner is
+                // still listening — run-55089 learned of its overlapping tail
+                // only from the run's obituary (issue #104).
+                try {
+                    await progressive.publishFinalTail(candidate)
+                } catch (error) {
+                    tailRefusedByHost = true
+                    throw error
+                }
                 composedFinalPrd = progressive.reconcileFinalCandidate(candidate)
             } catch (error) {
                 rejectionError = error
@@ -602,43 +612,57 @@ export async function runPlannerBusSession(
                     continue
                 }
                 planner.closeStdin()
-                // The host already holds every admitted story — the run is
-                // not missing a plan, only the planner's restatement of
-                // "nothing remains" in the terminal shape. Compose that shape
-                // here; reconciliation and obligation coverage still judge
-                // it, so a prefix that does not cover the goal contract
-                // fails exactly as before. Composition covers ONLY the
-                // shapeless-prose case: a candidate that PARSED and was
-                // rejected carries planner intent this host must not
-                // silently overrule.
-                if (candidate !== null || !progressive.hasEarlyPlan()) {
-                    return fail("planner_failed", reason)
-                }
-                // Compose only after the model was actually told how to fix it.
-                if (repairMessagesSent === 0) return fail("planner_failed", reason)
-                try {
-                    composedFinalPrd = progressive.reconcileFinalCandidate(
-                        JSON.stringify({
-                            project: opts.prdMetadata.project,
-                            branchName: opts.prdMetadata.branchName,
-                            description: opts.prdMetadata.description,
-                            userStories: [],
-                        }),
+                if (tailRefusedByHost && candidate !== null) {
+                    // A tail the board kept refusing goes to the board anyway,
+                    // as the completed plan: the coordinator's tolerance
+                    // decides whether it was redundant (discard, run
+                    // completes) or load-bearing (fail with the board's own
+                    // reason). Closing on the planner's last word here would
+                    // fail runs whose admitted stories already deliver.
+                    process.stderr.write(
+                        "[planner-bus] final tail refused after every repair round — " +
+                            "handing the plan to the board's tail tolerance\n",
                     )
-                } catch (composeError) {
-                    return fail(
-                        "planner_failed",
-                        `${reason}; host empty-tail composition also failed: ${
-                            composeError instanceof Error
-                                ? composeError.message
-                                : String(composeError)
-                        }${unownedObligationsClause(resolveUnowned(composeError))}`,
+                    composedFinalPrd = progressive.reconcileFinalCandidate(candidate)
+                } else {
+                    // The host already holds every admitted story — the run is
+                    // not missing a plan, only the planner's restatement of
+                    // "nothing remains" in the terminal shape. Compose that shape
+                    // here; reconciliation and obligation coverage still judge
+                    // it, so a prefix that does not cover the goal contract
+                    // fails exactly as before. Composition covers ONLY the
+                    // shapeless-prose case: a candidate that PARSED and was
+                    // rejected carries planner intent this host must not
+                    // silently overrule.
+                    if (candidate !== null || !progressive.hasEarlyPlan()) {
+                        return fail("planner_failed", reason)
+                    }
+                    // Compose only after the model was actually told how to fix it.
+                    if (repairMessagesSent === 0) return fail("planner_failed", reason)
+                    try {
+                        composedFinalPrd = progressive.reconcileFinalCandidate(
+                            JSON.stringify({
+                                project: opts.prdMetadata.project,
+                                branchName: opts.prdMetadata.branchName,
+                                description: opts.prdMetadata.description,
+                                userStories: [],
+                            }),
+                        )
+                    } catch (composeError) {
+                        return fail(
+                            "planner_failed",
+                            `${reason}; host empty-tail composition also failed: ${
+                                composeError instanceof Error
+                                    ? composeError.message
+                                    : String(composeError)
+                            }${unownedObligationsClause(resolveUnowned(composeError))}`,
+                        )
+                    }
+                    process.stderr.write(
+                        "[planner-bus] terminal restatement never arrived — " +
+                            "host composed the published prefix with an empty tail\n",
                     )
                 }
-                process.stderr.write(
-                    "[planner-bus] terminal restatement never arrived — " +
-                        "host composed the published prefix with an empty tail\n",
-                )
             }
             planner.closeStdin()
             await planner.done

--- a/packages/baro-orchestrator/src/planning/adapters/planner-harness-progressive.ts
+++ b/packages/baro-orchestrator/src/planning/adapters/planner-harness-progressive.ts
@@ -102,6 +102,9 @@ export interface PlannerHarnessProgressiveSupport {
      * A lane that runs inside this process calls it.
      */
     publish(args: unknown): Promise<string>
+    /** Admit the candidate's appended tail through the fragment path first, so
+     *  a host rejection reaches the planner as a repairable error. */
+    publishFinalTail(candidate: string): Promise<void>
     /** Returns the composed final PRD (admitted prefix + tail). */
     reconcileFinalCandidate(candidate: string): Record<string, unknown>
     /** Obligation ids no admitted story owns yet; [] without a contract. */
@@ -123,6 +126,7 @@ const NO_HARNESS_PROGRESSIVE_SUPPORT: PlannerHarnessProgressiveSupport =
         publish: async () => {
             throw new Error("progressive planning is not enabled for this run")
         },
+        publishFinalTail: async () => undefined,
         reconcileFinalCandidate: (candidate: string) =>
             JSON.parse(candidate) as Record<string, unknown>,
         unownedObligationIds: () => [],
@@ -171,6 +175,7 @@ export async function createPlannerHarnessProgressiveSupport(
             const receipt = await publisher.publish(args)
             return typeof receipt === "string" ? receipt : JSON.stringify(receipt)
         },
+        publishFinalTail: (candidate) => publisher.publishFinalTail(candidate),
         reconcileFinalCandidate: (candidate) =>
             publisher.reconcileFinalCandidate(candidate),
         unownedObligationIds: () =>

--- a/packages/baro-orchestrator/src/planning/adapters/planner-openai-progressive.ts
+++ b/packages/baro-orchestrator/src/planning/adapters/planner-openai-progressive.ts
@@ -74,6 +74,13 @@ export interface PlannerOpenAIProgressiveSupport {
 
 export interface PlannerProgressivePublisher {
     publish(args: unknown): Promise<Record<string, unknown>>
+    /**
+     * Send the candidate's appended tail through the same admission path as
+     * a mid-stream fragment, so a host rejection (write-surface overlap) comes
+     * back with its remedy while the planner can still answer. Resolves without
+     * publishing when nothing is appended or the session is already reconciled.
+     */
+    publishFinalTail(candidate: string): Promise<void>
     /** Returns the composed final PRD (admitted prefix + tail). */
     reconcileFinalCandidate(candidate: string): Record<string, unknown>
     /** Obligation ids no admitted story owns yet; [] without a contract. */
@@ -257,7 +264,20 @@ export function createPlannerProgressivePublisher(
         config.trustedDecisionDocument,
         goalContract,
     )
-    return {
+    const publisher: PlannerProgressivePublisher = {
+        async publishFinalTail(candidate: string) {
+            if (session.phase !== "open") return
+            const { tail } = reconcileProgressivePlanStories(
+                session.snapshot().stories,
+                progressiveFinalPrd(candidate),
+                { tailOnly: config.finalizationTailOnly === true },
+            )
+            if (tail.length === 0) return
+            await publisher.publish({
+                fragmentId: `final-tail-${session.nextOrdinal}`,
+                stories: tail.map(snapshotPlannerStory),
+            })
+        },
         async publish(args: unknown) {
             if (!isExactToolArgs(args)) {
                 throw new Error(
@@ -306,7 +326,17 @@ export function createPlannerProgressivePublisher(
                 ordinal: admission.ordinal,
                 stories: fragment.stories.map(snapshotPlannerStory),
             }
-            const hostFeedback = await config.publish(event)
+            let hostFeedback: Awaited<ReturnType<typeof config.publish>>
+            try {
+                hostFeedback = await config.publish(event)
+            } catch (error) {
+                // The host is the authority; a fragment it refused must not
+                // stay admitted here or the corrected retry can never land.
+                if (admission.disposition === "admitted") {
+                    session.retract(admission.fragmentId)
+                }
+                throw error
+            }
             // Published stories are immutable, so an obligation that is not
             // attached here can never be attached — say so on the receipt,
             // in the round where it is still fixable, instead of at close.
@@ -419,6 +449,7 @@ export function createPlannerProgressivePublisher(
             return session.snapshot().stories.length > 0
         },
     }
+    return publisher
 }
 
 function goalContractMappings(stories: readonly PrdStory[]) {

--- a/packages/baro-orchestrator/src/planning/domain/progressive-plan.ts
+++ b/packages/baro-orchestrator/src/planning/domain/progressive-plan.ts
@@ -575,6 +575,29 @@ export class ProgressivePlanSession {
         return this.admissionResult(rememberedFragment, "admitted")
     }
 
+    /**
+     * Forget the most recent admission after the host refused it. Local
+     * admission precedes the host's verdict; without this the planner's
+     * corrected fragment met `duplicate_story` here and `ordinal_gap` there
+     * (issue #104). Only the newest fragment of an open session can go.
+     */
+    retract(fragmentId: string): boolean {
+        if (this.phaseValue !== "open") return false
+        const last = this.fragments.at(-1)
+        if (!last || last.fragment.fragmentId !== fragmentId) return false
+        this.fragments.pop()
+        this.fragmentsById.delete(fragmentId)
+        const retracted = new Set(last.fragment.stories.map((story) => story.id))
+        for (let index = this.admittedStories.length - 1; index >= 0; index -= 1) {
+            if (retracted.has(this.admittedStories[index]!.id)) {
+                this.admittedStories.splice(index, 1)
+            }
+        }
+        for (const id of retracted) this.admittedStoryIds.delete(id)
+        this.nextOrdinalValue -= 1
+        return true
+    }
+
     reconcile(
         finalPrd: PrdFile | unknown,
         options: ProgressiveReconcileOptions = {},

--- a/packages/baro-orchestrator/test/planner-finalization-repair.test.ts
+++ b/packages/baro-orchestrator/test/planner-finalization-repair.test.ts
@@ -6,7 +6,11 @@ import type {
     AgenticEnvironment as Env,
     Participant,
 } from "../src/runtime/mozaik.js"
-import { AgentResult, PlanFragmentAdmitted } from "../src/semantic-events.js"
+import {
+    AgentResult,
+    PlanFragmentAdmitted,
+    PlanFragmentRejected,
+} from "../src/semantic-events.js"
 import { registerLane } from "../src/harness/lane-registry.js"
 import type {
     HostFunction,
@@ -143,6 +147,8 @@ class StubFeed extends BaseObserver {
     readonly fragments: PlanFragmentCommand[] = []
     readonly completions: PlanCompleteCommand[] = []
     readonly failures: PlanFailedCommand[] = []
+    /** How many final-tail fragments the board refuses for overlapping writes. */
+    refuseTailTimes = 0
 
     open(command: PlanningOpenCommand): void {
         this.opened.push(command)
@@ -150,6 +156,27 @@ class StubFeed extends BaseObserver {
 
     fragment(command: PlanFragmentCommand): void {
         this.fragments.push(command)
+        if (command.fragment_id.startsWith("final-tail") && this.refuseTailTimes > 0) {
+            this.refuseTailTimes -= 1
+            const candidateStoryId = command.stories[0]!.id
+            const rejected = PlanFragmentRejected.create({
+                runId: command.run_id,
+                planningId: command.planning_id,
+                fragmentId: command.fragment_id,
+                ordinal: command.ordinal,
+                code: "graph_rejected",
+                reason: `overlapping write surface: story '${candidateStoryId}' writes src/a.js already owned by story 'S1'`,
+                overlap: {
+                    candidateStoryId,
+                    owners: [{ storyId: "S1", ownedFiles: ["src/a.js"], collidingPaths: ["src/a.js"] }],
+                    remainingPaths: [],
+                },
+            })
+            for (const environment of this.getEnvironments()) {
+                environment.deliverSemanticEvent(this, rejected)
+            }
+            return
+        }
         const admitted = PlanFragmentAdmitted.create({
             runId: command.run_id,
             planningId: command.planning_id,
@@ -322,6 +349,7 @@ async function runSession(input: {
     publishFragment?: boolean
     decisionDocument?: string
     backend?: string
+    refuseTailTimes?: number
 }): Promise<SessionRun> {
     const prompts: string[] = []
     const plan: ArmedPlan = {
@@ -332,6 +360,7 @@ async function runSession(input: {
     armed = plan
     const env = new AgenticEnvironment("planner-finalization-repair")
     const feed = new StubFeed()
+    feed.refuseTailTimes = input.refuseTailTimes ?? 0
     feed.join(env)
     try {
         const result = await runPlannerBusSession({
@@ -505,6 +534,61 @@ describe("planner finalization repair prompt", () => {
         assert.equal(
             run.result.reason,
             `planner_failed: ${run.failureReason}`,
+        )
+    })
+
+    // Issue #104 (run-55089): the final tail now meets the board through the
+    // fragment path while the planner is still listening, so a write-surface
+    // refusal arrives as a repair round carrying the overlap remedy.
+    it("retries a host-refused final tail with the overlap remedy on the same ordinal", async () => {
+        const run = await runSession({
+            script: [OWNED_TAIL_PRD, OWNED_TAIL_PRD],
+            decisionDocument: DECISION_DOCUMENT,
+            refuseTailTimes: 1,
+        })
+
+        assert.deepEqual(run.feed.failures, [])
+        assert.equal(run.result.status, "completed")
+        assert.equal(run.repairPrompts.length, 1)
+        const repair = run.repairPrompts[0]!
+        assert.ok(repair.includes("fragment rejected (graph_rejected): overlapping write surface"))
+        assert.ok(repair.includes("Write-surface overlap (1):"))
+        assert.ok(repair.includes("story 'S1' owns: src/a.js"))
+        assert.deepEqual(
+            run.feed.fragments.map((f) => [f.fragment_id, f.ordinal]),
+            [
+                ["foundation", 1],
+                ["final-tail-2", 2],
+                ["final-tail-2", 2],
+            ],
+            "the refused tail is retracted locally, so the retry reuses its ordinal",
+        )
+        assert.equal(run.feed.completions.length, 1)
+        assert.deepEqual(
+            (run.feed.completions[0]!.final_prd as { userStories: Array<{ id: string }> })
+                .userStories.map((story) => story.id),
+            ["S1", "S2"],
+        )
+    })
+
+    it("hands a tail refused in every round to the board's tolerance instead of failing", async () => {
+        const run = await runSession({
+            script: [OWNED_TAIL_PRD, OWNED_TAIL_PRD, OWNED_TAIL_PRD],
+            decisionDocument: DECISION_DOCUMENT,
+            refuseTailTimes: 3,
+        })
+
+        assert.deepEqual(run.feed.failures, [])
+        assert.equal(run.result.status, "completed")
+        assert.equal(run.repairPrompts.length, 2)
+        assert.equal(run.feed.fragments.length, 4, "foundation + three refused tails")
+        // The completed plan still carries the tail: the coordinator decides
+        // whether it is redundant (discard) or load-bearing (fail with reason).
+        assert.equal(run.feed.completions.length, 1)
+        assert.deepEqual(
+            (run.feed.completions[0]!.final_prd as { userStories: Array<{ id: string }> })
+                .userStories.map((story) => story.id),
+            ["S1", "S2"],
         )
     })
 

--- a/packages/baro-orchestrator/test/planning/domain/progressive-plan.test.ts
+++ b/packages/baro-orchestrator/test/planning/domain/progressive-plan.test.ts
@@ -92,6 +92,33 @@ describe("progressive plan v1", () => {
         ])
     })
 
+    // Issue #104: local admission precedes the host's verdict, so a refused
+    // fragment must be forgettable or its corrected retry can never land.
+    it("retracts only the newest fragment of an open session", () => {
+        const session = openProgressivePlanSession({
+            schemaVersion: 1,
+            planningSessionId: "planning-1",
+        })
+        session.admit(fragment("fragment-1", 1, [story("S1")]))
+        session.admit(fragment("fragment-2", 2, [story("S2", ["S1"])]))
+
+        assert.equal(session.retract("fragment-1"), false, "not the newest")
+        assert.equal(session.retract("fragment-2"), true)
+        assert.equal(session.nextOrdinal, 2)
+        assert.deepEqual(session.snapshot().stories.map((s) => s.id), ["S1"])
+        assert.equal(session.retract("fragment-2"), false, "already gone")
+
+        // The same id and ordinal are free again, with different content.
+        const again = session.admit(
+            fragment("fragment-2", 2, [story("S2", ["S1"], { title: "corrected" })]),
+        )
+        assert.equal(again.disposition, "admitted")
+        assert.equal(session.snapshot().stories[1]?.title, "corrected")
+
+        session.reconcile(finalPrd([story("S1"), story("S2", ["S1"], { title: "corrected" })]))
+        assert.equal(session.retract("fragment-2"), false, "reconciled sessions are sealed")
+    })
+
     it("allows dependencies within one fragment but rejects a same-fragment cycle", () => {
         const session = openProgressivePlanSession({
             schemaVersion: 1,

--- a/packages/baro-orchestrator/test/planning/planner-progressive-final-tail.test.ts
+++ b/packages/baro-orchestrator/test/planning/planner-progressive-final-tail.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+    createPlannerProgressivePublisher,
+    type PlannerOpenAIPlanFragmentEvent,
+} from "../../src/planning/adapters/planner-openai-progressive.js"
+
+// Issue #104: the planner's final tail used to meet the board only after the
+// session had closed, and a host refusal left the local session out of step.
+
+const STORY = {
+    id: "S1",
+    priority: 1,
+    title: "Foundation",
+    description: "First published story.",
+    dependsOn: [] as string[],
+    retries: 2,
+    acceptance: ["S1 is observable"],
+    tests: ["npm test -- S1"],
+    goalInvariantIds: [] as string[],
+    model: "standard",
+    writes: ["src/a.js"],
+}
+
+const TAIL = {
+    ...STORY,
+    id: "S2",
+    title: "Tail",
+    dependsOn: ["S1"],
+    writes: ["src/a.js"],
+}
+
+const CORRECTED_TAIL = { ...TAIL, writes: ["src/b.js"] }
+
+const METADATA = { project: "p", branchName: "b", description: "d" }
+const candidate = (stories: unknown[]) => JSON.stringify({ ...METADATA, userStories: stories })
+
+function publisherWithHost(host: (event: PlannerOpenAIPlanFragmentEvent) => void) {
+    const events: PlannerOpenAIPlanFragmentEvent[] = []
+    const publisher = createPlannerProgressivePublisher({
+        runId: "run-1",
+        planningId: "planning-1",
+        finalizationTailOnly: true,
+        publish: async (event) => {
+            events.push(event)
+            host(event)
+        },
+    })
+    return { publisher, events }
+}
+
+describe("progressive publisher and the host's verdict", () => {
+    it("forgets a fragment the host refused so the corrected retry lands on the same ordinal", async () => {
+        let refuse = false
+        const { publisher, events } = publisherWithHost(() => {
+            if (refuse) throw new Error("fragment rejected (graph_rejected): overlapping write surface")
+        })
+        await publisher.publish({ fragmentId: "f1", stories: [STORY] })
+
+        refuse = true
+        await assert.rejects(
+            publisher.publish({ fragmentId: "f2", stories: [TAIL] }),
+            /overlapping write surface/,
+        )
+        assert.equal(publisher.hasEarlyPlan(), true)
+
+        refuse = false
+        const receipt = await publisher.publish({ fragmentId: "f2", stories: [CORRECTED_TAIL] })
+        assert.equal(receipt.disposition, "admitted")
+        assert.equal(receipt.ordinal, 2)
+        assert.deepEqual(events.map((e) => [e.fragment_id, e.ordinal]), [
+            ["f1", 1],
+            ["f2", 2],
+            ["f2", 2],
+        ])
+        assert.deepEqual(events.at(-1)?.stories[0]?.writes, ["src/b.js"])
+    })
+
+    it("publishes the appended tail through the fragment path before the plan is composed", async () => {
+        const { publisher, events } = publisherWithHost(() => undefined)
+        await publisher.publish({ fragmentId: "f1", stories: [STORY] })
+
+        await publisher.publishFinalTail(candidate([CORRECTED_TAIL]))
+        assert.deepEqual(events.map((e) => [e.fragment_id, e.ordinal]), [
+            ["f1", 1],
+            ["final-tail-2", 2],
+        ])
+
+        // The tail is admitted now; composing the same candidate appends nothing twice.
+        const composed = publisher.reconcileFinalCandidate(candidate([CORRECTED_TAIL]))
+        assert.deepEqual(
+            (composed.userStories as Array<{ id: string }>).map((s) => s.id),
+            ["S1", "S2"],
+        )
+    })
+
+    it("publishes nothing for an empty tail or a reconciled session", async () => {
+        const { publisher, events } = publisherWithHost(() => undefined)
+        await publisher.publish({ fragmentId: "f1", stories: [STORY] })
+
+        await publisher.publishFinalTail(candidate([]))
+        assert.equal(events.length, 1)
+
+        publisher.reconcileFinalCandidate(candidate([]))
+        await publisher.publishFinalTail(candidate([CORRECTED_TAIL]))
+        assert.equal(events.length, 1, "a sealed session never publishes")
+    })
+
+    it("surfaces the host's refusal of the tail and leaves the session open for a retry", async () => {
+        const { publisher, events } = publisherWithHost((event) => {
+            if (event.fragment_id.startsWith("final-tail")) {
+                throw new Error("fragment rejected (graph_rejected): overlapping write surface")
+            }
+        })
+        await publisher.publish({ fragmentId: "f1", stories: [STORY] })
+
+        await assert.rejects(publisher.publishFinalTail(candidate([TAIL])), /overlapping/)
+        await assert.rejects(publisher.publishFinalTail(candidate([TAIL])), /overlapping/)
+        assert.deepEqual(
+            events.map((e) => e.ordinal),
+            [1, 2, 2],
+            "the refused tail never advances the local ordinal",
+        )
+        // The board's tolerance still gets the tail when the planner gives up.
+        const composed = publisher.reconcileFinalCandidate(candidate([TAIL]))
+        assert.deepEqual(
+            (composed.userStories as Array<{ id: string }>).map((s) => s.id),
+            ["S1", "S2"],
+        )
+    })
+})


### PR DESCRIPTION
Closes #104.

## What broke (run-55089, run-78950)

The planner's appended tail reached the board only inside `onPlanningStreamCompleted`, after the bus session had closed the planner's stdin and returned. A write-surface refusal there had nobody left to repair it: the rejection reason and the #111 remedy wording never reached the model, and the run closed on `final_tail_rejected` while both stories were merged and green.

A second defect sat underneath: `publish` admits a fragment into the local `ProgressivePlanSession` before the host's verdict and never undid it. After any host refusal the local session was one ordinal ahead and held the refused story ids, so a corrected retry met `duplicate_story` locally or `ordinal_gap` on the host.

## Changes

1. **`ProgressivePlanSession.retract(fragmentId)`** forgets the newest fragment of an open session. The publisher calls it whenever the host's `publish` throws, so the corrected fragment lands on the same ordinal with the same ids.
2. **`publishFinalTail(candidate)`** on the publisher and the harness support: composes the candidate against the admitted prefix (tail-only) and sends the appended tail through the ordinary fragment path. No-op for an empty tail or a reconciled session.
3. **Bus session finalization** calls `publishFinalTail` before `reconcileFinalCandidate`. A host refusal becomes a repair round with the overlap remedy (`Write-surface overlap (n): story 'S1' owns: …`), inside the existing three-attempt budget.
4. **Exhaustion keeps today's safety net**: a tail refused in every round is still handed to the board as the completed plan, so the coordinator's tail tolerance (PR #122) decides — redundant tail discarded and the run completes, load-bearing tail fails with the board's own reason. Before this PR the same situation was `planner_failed: finalization attempts exhausted`.

The stale-snapshot half of #104 (`unsettled_stories: S1, S2` reported seconds after both merged) was closed by 8fa5004 in #122: the decision is parked and re-evaluated on the fresh board.

## Verification

- `test/planning/domain/progressive-plan.test.ts`: retract semantics (newest only, ordinal and ids freed, sealed after reconcile)
- `test/planning/planner-progressive-final-tail.test.ts` (new): refused fragment retried on the same ordinal; tail published through the fragment path; no publish for empty tail / sealed session; repeated tail refusal leaves the session open and composable
- `test/planner-finalization-repair.test.ts`: two bus-session scenarios — one refusal → one repair round with the overlap remedy, retry reuses `final-tail-2`; three refusals → completion still delivered with the tail for the board to judge
- full baro-orchestrator suite: 2246 pass, 0 fail; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1bpAF6qY7wdqxL77pKxKE