### PR TITLE
fix(git): reconcile a rejected push with the remote instead of calling every failure a conflict (#106)

### DIFF
--- a/packages/baro-orchestrator/src/integration/git.ts
+++ b/packages/baro-orchestrator/src/integration/git.ts
@@ -270,24 +270,34 @@ export async function gitPushWithRetry(
                 options.onLog?.("[git] push ok")
                 return
             } catch (e) {
+                if (isRepositoryCommandTimeout(e)) throw e
                 lastError = extractStderr(e)
             }
 
             if (attempt === max) break
 
+            // Only a remote that moved can be reconciled. Issue #106: three
+            // runs died on "Rebase conflict detected" with the base unmoved —
+            // a failed push of any kind fell into a pull, and a pull failing
+            // for any reason (dirty tree left by a timed-out step, no remote
+            // branch yet, network) was reported as a conflict and ended it.
+            const summary = lastError.split("\n")[0]?.trim() || lastError
+            if (!(await hasRemoteBranch(options.cwd, branch))) {
+                options.onLog?.(
+                    `[git] push failed (attempt ${attempt}/${max}) with no remote branch to reconcile: ${summary}; retrying`,
+                )
+                continue
+            }
             options.onLog?.(
-                `[git] push rejected (attempt ${attempt}/${max}), pulling and retrying...`,
+                `[git] push rejected (attempt ${attempt}/${max}): ${summary}; reconciling with origin/${branch}`,
             )
-            try {
-                // --rebase=merges: preserve per-story `--no-ff` merge
-                // commits when reconciling a rejected push.
-                await exec("git", ["pull", "--rebase=merges", "origin", branch], {
-                    cwd: options.cwd,
-                })
-            } catch {
-                await execSafe("git", ["rebase", "--abort"], { cwd: options.cwd })
-                options.onLog?.("[git] conflict detected, skipping")
-                throw new Error("Rebase conflict detected, push skipped")
+            const outcome = await rebaseOntoRemote(options.cwd, branch, options.onLog)
+            if (outcome.status === "conflict") {
+                throw new Error(
+                    `Rebase conflict against origin/${branch}@${outcome.targetSha.slice(0, 8)}` +
+                        ` (local HEAD ${outcome.headSha.slice(0, 8)}): ` +
+                        `${outcome.paths.length > 0 ? outcome.paths.join(", ") : outcome.detail}; push skipped`,
+                )
             }
         }
 
@@ -298,6 +308,86 @@ export async function gitPushWithRetry(
         throw new Error(`Push failed after ${max} attempts: ${lastError}`)
     } finally {
         release()
+    }
+}
+
+type RebaseOutcome =
+    | { status: "rebased" }
+    | { status: "failed"; detail: string }
+    | {
+          status: "conflict"
+          targetSha: string
+          headSha: string
+          paths: string[]
+          detail: string
+      }
+
+/**
+ * Rebase the local branch onto the freshly fetched remote head. The target sha
+ * and any conflicting paths are logged, so the next occurrence is diagnosable
+ * from the run log alone. --autostash carries tracked edits a timed-out step
+ * may have left behind; --rebase-merges keeps per-story --no-ff merges.
+ */
+async function rebaseOntoRemote(
+    cwd: string,
+    branch: string,
+    onLog?: (line: string) => void,
+): Promise<RebaseOutcome> {
+    let targetSha = "unknown"
+    let headSha = "unknown"
+    try {
+        await exec("git", ["fetch", "origin", branch], { cwd })
+        targetSha = (await exec("git", ["rev-parse", "FETCH_HEAD"], { cwd })).stdout.trim()
+        headSha = (await exec("git", ["rev-parse", "HEAD"], { cwd })).stdout.trim()
+    } catch (error) {
+        if (isRepositoryCommandTimeout(error)) throw error
+        const detail = extractStderr(error).split("\n")[0]?.trim() ?? ""
+        onLog?.(`[git] fetch origin/${branch} failed: ${detail}`)
+        return { status: "failed", detail }
+    }
+    onLog?.(
+        `[git] rebasing ${headSha.slice(0, 8)} onto origin/${branch}@${targetSha.slice(0, 8)}`,
+    )
+    try {
+        await exec(
+            "git",
+            ["rebase", "--rebase-merges", "--autostash", "FETCH_HEAD"],
+            { cwd },
+        )
+        onLog?.(`[git] rebased onto origin/${branch}@${targetSha.slice(0, 8)}`)
+        return { status: "rebased" }
+    } catch (error) {
+        if (isRepositoryCommandTimeout(error)) throw error
+        const stderr = extractStderr(error)
+        const detail = stderr.split("\n")[0]?.trim() ?? ""
+        const paths = await unmergedPaths(cwd)
+        await execSafe("git", ["rebase", "--abort"], { cwd })
+        if (paths.length > 0 || /CONFLICT/i.test(stderr)) {
+            onLog?.(
+                `[git] rebase conflict against origin/${branch}@${targetSha.slice(0, 8)}: ` +
+                    `${paths.length > 0 ? paths.join(", ") : detail}`,
+            )
+            return { status: "conflict", targetSha, headSha, paths, detail }
+        }
+        onLog?.(`[git] rebase failed without a conflict: ${detail}; retrying push as is`)
+        return { status: "failed", detail }
+    }
+}
+
+async function unmergedPaths(cwd: string): Promise<string[]> {
+    try {
+        const { stdout } = await exec(
+            "git",
+            ["diff", "--name-only", "--diff-filter=U"],
+            { cwd },
+        )
+        return stdout
+            .split("\n")
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0)
+    } catch (error) {
+        if (isRepositoryCommandTimeout(error)) throw error
+        return []
     }
 }
 

--- a/packages/baro-orchestrator/test/integration/git.test.ts
+++ b/packages/baro-orchestrator/test/integration/git.test.ts
@@ -5,7 +5,12 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { createOrCheckoutBranch, getCommitCount } from "../../src/integration/git.js"
+import {
+    GitGate,
+    createOrCheckoutBranch,
+    getCommitCount,
+    gitPushWithRetry,
+} from "../../src/integration/git.js"
 
 function git(cwd: string, ...args: string[]): string {
     return execFileSync("git", args, { cwd, encoding: "utf8" }).trim()
@@ -37,6 +42,98 @@ afterEach(() => {
     if (remote) {
         try { rmSync(remote, { recursive: true, force: true }) } catch { /* */ }
     }
+})
+
+// Issue #106: three runs ended on "Rebase conflict detected" while their work
+// was complete; one of them with the remote unmoved. A push failure of any
+// kind fell into a pull, and a pull failing for any reason was called a
+// conflict and ended the run.
+describe("gitPushWithRetry", () => {
+    let peer: string
+
+    /** A bare origin holding `main`, plus a second clone that can race us. */
+    function armRemote(): void {
+        remote = mkdtempSync(join(tmpdir(), "baro-git-remote-"))
+        git(remote!, "init", "--bare")
+        git(repo, "remote", "add", "origin", remote!)
+        git(repo, "push", "-u", "origin", "main")
+        peer = mkdtempSync(join(tmpdir(), "baro-git-peer-"))
+        git(peer, "clone", "-q", remote!, ".")
+        git(peer, "config", "user.email", "p@p.p")
+        git(peer, "config", "user.name", "peer")
+    }
+
+    function peerPushes(file: string, content: string): void {
+        writeFileSync(join(peer, file), content)
+        git(peer, "add", "-A")
+        git(peer, "commit", "-m", `peer ${file}`)
+        git(peer, "push", "origin", "main")
+    }
+
+    function localCommits(file: string, content: string): void {
+        writeFileSync(join(repo, file), content)
+        git(repo, "add", "-A")
+        git(repo, "commit", "-m", `local ${file}`)
+    }
+
+    afterEach(() => {
+        try { rmSync(peer, { recursive: true, force: true }) } catch { /* */ }
+    })
+
+    it("rebases onto a moved remote and pushes, naming the target sha", async () => {
+        armRemote()
+        peerPushes("peer.txt", "peer\n")
+        localCommits("local.txt", "local\n")
+
+        await gitPushWithRetry(new GitGate(), { cwd: repo, onLog: (l) => logs.push(l) })
+
+        const remoteHead = git(remote!, "rev-parse", "main")
+        assert.equal(git(repo, "rev-parse", "HEAD"), remoteHead)
+        assert.equal(git(repo, "log", "--format=%s", "-3"), "local local.txt\npeer peer.txt\ninit")
+        const peerSha = git(peer, "rev-parse", "HEAD").slice(0, 8)
+        assert.ok(
+            logs.some((l) => l.includes(`onto origin/main@${peerSha}`)),
+            `rebase target missing from log: ${logs.join(" | ")}`,
+        )
+        assert.ok(logs.includes("[git] push ok"))
+    })
+
+    it("reports a real conflict with the target sha and the conflicting paths, leaving the tree clean", async () => {
+        armRemote()
+        peerPushes("a.txt", "peer version\n")
+        localCommits("a.txt", "local version\n")
+        const localHead = git(repo, "rev-parse", "HEAD")
+        const peerSha = git(peer, "rev-parse", "HEAD").slice(0, 8)
+
+        await assert.rejects(
+            gitPushWithRetry(new GitGate(), { cwd: repo, onLog: (l) => logs.push(l) }),
+            (error: unknown) => {
+                assert.equal(
+                    (error as Error).message,
+                    `Rebase conflict against origin/main@${peerSha} (local HEAD ${localHead.slice(0, 8)}): a.txt; push skipped`,
+                )
+                return true
+            },
+        )
+        assert.equal(git(repo, "rev-parse", "HEAD"), localHead, "aborted rebase restores HEAD")
+        assert.equal(git(repo, "status", "--porcelain"), "", "no rebase leftovers")
+        assert.ok(logs.some((l) => l.includes("rebase conflict against origin/main@") && l.includes("a.txt")))
+    })
+
+    it("does not mistake a dirty working tree for a rebase conflict", async () => {
+        armRemote()
+        peerPushes("peer.txt", "peer\n")
+        localCommits("local.txt", "local\n")
+        // Tracked, uncommitted edit — what a timed-out verification step leaves behind.
+        writeFileSync(join(repo, "a.txt"), "edited but not committed\n")
+
+        await gitPushWithRetry(new GitGate(), { cwd: repo, onLog: (l) => logs.push(l) })
+
+        assert.equal(git(repo, "rev-parse", "HEAD"), git(remote!, "rev-parse", "main"))
+        // The helper trims the porcelain line's leading space.
+        assert.equal(git(repo, "status", "--porcelain"), "M a.txt", "the edit survives the rebase")
+        assert.ok(!logs.some((l) => /conflict/i.test(l)), logs.join(" | "))
+    })
 })
 
 describe("createOrCheckoutBranch - branch name handling", () => {


### PR DESCRIPTION
Closes #106.

## What broke

`gitPushWithRetry` treated every failed `git push` as a rejected push and every failed `git pull --rebase` as a rebase conflict, then threw `Rebase conflict detected, push skipped` and stopped retrying. That is how run-27050 died with origin/main unmoved: the pull failed for a reason that was not a conflict (a dirty working tree from a timed-out verification step fits every symptom), and the message hid it.

## Changes

- After a failed push, check whether the remote branch even exists; if not, the push is retried as is (nothing to reconcile).
- Otherwise fetch `origin/<branch>`, log `rebasing <head> onto origin/<branch>@<sha>`, and rebase with `--rebase-merges --autostash`. Autostash carries tracked edits a timed-out step left behind; `--rebase-merges` keeps the per-story `--no-ff` merges as before.
- Classify the rebase result. A genuine conflict (unmerged paths, or CONFLICT in stderr) aborts the rebase and throws `Rebase conflict against origin/<branch>@<sha> (local HEAD <sha>): <paths>; push skipped`, so the next occurrence is diagnosable from the run log alone. Any other failure is logged and the push loop continues.
- Repository command timeouts still propagate unchanged.

## Verification

`test/integration/git.test.ts` gains three scenarios on a real bare remote with a racing peer clone:
- moved remote, no conflict: rebased and pushed, target sha in the log
- genuine conflict on the same file: exact message with target sha, local HEAD and `a.txt`; HEAD restored, tree clean
- moved remote plus a dirty tracked file: pushed, the edit survives, nothing logged as a conflict

Full baro-orchestrator suite: 2249 pass, 0 fail; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1bpAF6qY7wdqxL77pKxKE