### PR TITLE
fix(verification): refresh dependencies before the gate when the tree predates the manifests (#129)

### DIFF
--- a/packages/baro-orchestrator/src/verification/verify.ts
+++ b/packages/baro-orchestrator/src/verification/verify.ts
@@ -15,7 +15,7 @@
  *   - ok=false   only when a build/test that ACTUALLY RAN returned non-zero.
  */
 
-import { existsSync, readdirSync, readFileSync } from "node:fs"
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { isAbsolute, join, relative, resolve, sep } from "node:path"
 
 import type { VerificationCommandOutput } from "../events/verification.js"
@@ -134,6 +134,12 @@ export interface VerifyPlan {
 export interface VerifyBuildOptions {
     /** Cancels the current child and prevents later commands from starting. */
     signal?: AbortSignal
+    /**
+     * Re-run the package manager's install before the gates when the
+     * installed tree no longer matches the manifests. Default on; BARO_DEPS_REFRESH=0
+     * turns it off process-wide.
+     */
+    refreshDependencies?: boolean
     /** Snapshotted before agents mutate the target repo. */
     plan?: VerifyPlan
     /** Defaults to the process-wide TUI stream; injected only by tests. */
@@ -141,9 +147,12 @@ export interface VerifyBuildOptions {
 }
 
 interface PackageManifest {
+    name?: unknown
     packageManager?: unknown
     scripts?: Record<string, unknown>
     workspaces?: unknown
+    dependencies?: unknown
+    devDependencies?: unknown
 }
 
 export type JavaScriptPackageManager = "npm" | "pnpm" | "yarn"
@@ -471,6 +480,90 @@ function detectCommands(cwd: string): DetectedVerifyPlan {
     }
 
     return { commands: cmds, javascriptPackageManagers }
+}
+
+/**
+ * Why the installed JavaScript dependency tree no longer matches the
+ * manifests, or nothing when it does. Issue #129: a run converted a package
+ * into npm workspaces, every story merged green, and the run-level gate
+ * failed because nobody had run `npm install` after the manifest changed —
+ * the CLI workspace could not resolve the core one by name. The rules are
+ * deliberately git-free so a fresh clone and a mid-run manifest edit read
+ * the same way.
+ */
+export function staleDependencyReasons(cwd: string): string[] {
+    const pkgPath = join(cwd, "package.json")
+    if (!existsSync(pkgPath)) return []
+    const manifest = readPackageManifest(pkgPath)
+    if (!manifest) return []
+    const reasons: string[] = []
+    const nodeModules = join(cwd, "node_modules")
+    const declaresDependencies =
+        hasEntries(manifest.dependencies) || hasEntries(manifest.devDependencies)
+    const workspaceDirs = workspacePackageDirs(cwd, [
+        ...workspacePatterns(manifest.workspaces),
+        ...pnpmWorkspacePatterns(cwd),
+    ])
+    if (!existsSync(nodeModules)) {
+        if (declaresDependencies || workspaceDirs.length > 0) {
+            reasons.push("node_modules is missing")
+        }
+        return reasons
+    }
+    for (const dir of workspaceDirs) {
+        const name = readPackageManifest(join(dir, "package.json"))?.name
+        if (typeof name !== "string" || !name) continue
+        if (!existsSync(join(nodeModules, name))) {
+            reasons.push(`workspace ${name} is not linked in node_modules`)
+        }
+    }
+    // The manager leaves a marker when it finishes; manifests or lockfiles
+    // written after it mean the tree predates them.
+    const marker = [
+        "node_modules/.package-lock.json",
+        "node_modules/.modules.yaml",
+        "node_modules/.yarn-integrity",
+    ]
+        .map((relativePath) => join(cwd, relativePath))
+        .find((path) => existsSync(path))
+    if (marker) {
+        const installedAt = statSync(marker).mtimeMs
+        for (const file of ["package.json", "package-lock.json", "pnpm-lock.yaml", "yarn.lock"]) {
+            const path = join(cwd, file)
+            if (existsSync(path) && statSync(path).mtimeMs > installedAt + 1_000) {
+                reasons.push(`${file} changed after the last install`)
+            }
+        }
+    }
+    return reasons
+}
+
+function hasEntries(value: unknown): boolean {
+    return typeof value === "object" && value !== null && Object.keys(value).length > 0
+}
+
+function dependencyRefreshCommand(cwd: string, reasons: readonly string[]): VerifyCommandSpec {
+    const manifest = readPackageManifest(join(cwd, "package.json"))
+    const declared = declaredPackageManager(manifest?.packageManager)
+    const pm = detectPackageManager(cwd, manifest, existsSync(join(cwd, "pnpm-workspace.yaml")))
+    const yarnMajor = declared?.manager === "yarn"
+        ? Number.parseInt(declared.version.match(/^\d+/)?.[0] ?? "", 10)
+        : Number.NaN
+    const command =
+        pm === "yarn" && yarnMajor >= 2
+            ? { tool: "corepack", args: ["yarn", "install"] }
+            : pm === "npm"
+              ? { tool: "npm", args: ["install", "--no-audit", "--no-fund"] }
+              : { tool: pm, args: ["install"] }
+    return {
+        label: `${pm} install (dependencies stale: ${reasons.join("; ")})`,
+        ...command,
+    }
+}
+
+function dependencyRefreshEnabled(options: VerifyBuildOptions): boolean {
+    if (options.refreshDependencies === false) return false
+    return process.env.BARO_DEPS_REFRESH !== "0"
 }
 
 function dedupeVerifyCommands(
@@ -1103,6 +1196,33 @@ export async function verifyBuild(
     let ran = false
     const plan = options.plan ?? createVerifyPlan(cwd)
     const emitActivity = options.emitActivity ?? emit
+    // A gate run against a tree that predates the manifests judges the
+    // install, not the work. Refresh first and keep it in the evidence.
+    const stale = dependencyRefreshEnabled(options) && plan.commands.length > 0
+        ? staleDependencyReasons(cwd)
+        : []
+    if (stale.length > 0) {
+        throwIfAborted(options.signal)
+        const install = dependencyRefreshCommand(cwd, stale)
+        emitActivity({
+            type: "activity",
+            id: "_verify",
+            kind: "warn",
+            text: `refreshing dependencies before verification: ${stale.join("; ")}`,
+        })
+        const outcome = await runCmd(cwd, install, options.signal)
+        commands.push({
+            command: install.label,
+            status: outcome.status,
+            durationMs: outcome.durationMs,
+            ...("tail" in outcome && outcome.tail ? { tail: outcome.tail } : {}),
+            ...("output" in outcome && outcome.output ? { output: outcome.output } : {}),
+        })
+        if (outcome.status === "failed") {
+            ran = true
+            failures.push({ cmd: install.label, tail: outcome.tail })
+        }
+    }
     for (const c of plan.commands) {
         throwIfAborted(options.signal)
         let outcome = await runCmd(cwd, c, options.signal)

--- a/packages/baro-orchestrator/test/verification/verify.test.ts
+++ b/packages/baro-orchestrator/test/verification/verify.test.ts
@@ -13,6 +13,7 @@ import {
     createVerifyPlan,
     mergeVerifyPlans,
     recommendedVerifyTimeoutMs,
+    staleDependencyReasons,
     verifyBuild,
 } from "../../src/verification/verify.js"
 import { withTempDir } from "../execution/helpers.js"
@@ -337,6 +338,9 @@ setTimeout(() => process.exit(0), 120_000).unref?.(); setInterval(() => {}, 10_0
             assert.deepEqual(
                 r.commands.map(({ command, status }) => ({ command, status })),
                 [
+                    // A workspace fixture with no node_modules is stale by
+                    // definition; the refresh runs first and stays in evidence.
+                    { command: "npm install (dependencies stale: node_modules is missing)", status: "passed" },
                     { command: "npm run build (packages/app)", status: "passed" },
                     { command: "npm run test (packages/library)", status: "passed" },
                 ],
@@ -783,3 +787,67 @@ setTimeout(() => process.exit(0), 120_000).unref?.(); setInterval(() => {}, 10_0
         })
     })
 })
+
+// Issue #129: a run turned a package into npm workspaces, every story merged
+// green, and the gate failed on `npm test` because nobody had installed the
+// workspace links after the manifest changed.
+describe("dependency refresh before the gate", () => {
+    it("names why the installed tree is stale", async () => {
+        await withTempDir("baro-verify-deps-", async (dir) => {
+            writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "root", private: true }))
+            assert.deepEqual(staleDependencyReasons(dir), [], "no dependencies, nothing to install")
+
+            writeFileSync(
+                join(dir, "package.json"),
+                JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"] }),
+            )
+            mkdirSync(join(dir, "packages", "core"), { recursive: true })
+            writeFileSync(join(dir, "packages", "core", "package.json"), JSON.stringify({ name: "@t/core" }))
+            assert.deepEqual(staleDependencyReasons(dir), ["node_modules is missing"])
+
+            mkdirSync(join(dir, "node_modules"), { recursive: true })
+            assert.deepEqual(staleDependencyReasons(dir), ["workspace @t/core is not linked in node_modules"])
+        })
+    })
+
+    it("installs first, records it, and the gate then sees the workspace link", async () => {
+        await withTempDir("baro-verify-deps-", async (dir) => {
+            writeFileSync(
+                join(dir, "package.json"),
+                JSON.stringify({
+                    name: "root",
+                    private: true,
+                    workspaces: ["packages/*"],
+                    scripts: { test: "node -e \"require('fs').accessSync('node_modules/@t/core')\"" },
+                }),
+            )
+            mkdirSync(join(dir, "packages", "core"), { recursive: true })
+            writeFileSync(join(dir, "packages", "core", "package.json"), JSON.stringify({ name: "@t/core", version: "0.0.0" }))
+
+            const r = await verifyBuild(dir, { emitActivity: () => {} })
+            assert.deepEqual(
+                r.commands.map(({ command, status }) => ({ command, status })),
+                [
+                    { command: "npm install (dependencies stale: node_modules is missing)", status: "passed" },
+                    { command: "npm run test", status: "passed" },
+                ],
+            )
+            assert.equal(r.ok, true)
+            assert.ok(existsSync(join(dir, "node_modules", "@t", "core")))
+        })
+    })
+
+    it("stays out of the way when refresh is off", async () => {
+        await withTempDir("baro-verify-deps-", async (dir) => {
+            writeFileSync(
+                join(dir, "package.json"),
+                JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"], scripts: { test: "true" } }),
+            )
+            mkdirSync(join(dir, "packages", "core"), { recursive: true })
+            writeFileSync(join(dir, "packages", "core", "package.json"), JSON.stringify({ name: "@t/core" }))
+            const r = await verifyBuild(dir, { emitActivity: () => {}, refreshDependencies: false })
+            assert.deepEqual(r.commands.map(({ command }) => command), ["npm run test"])
+        })
+    })
+})
+


### PR DESCRIPTION
Closes #129.

A run turned the playground into npm workspaces; four stories merged, typecheck and the docs test passed, and the run still closed `success: false` on `npm run test`. The CLI workspace imports the core one by package name and `node_modules/@baro-dsh-playground/` did not exist: nobody had run `npm install` after the stories introduced `workspaces`. One install later everything was green. The checkpoint PR carried correct work with a false failure on it.

## Change

`verifyBuild` checks, without git, whether the installed JavaScript tree still matches the manifests:
- `node_modules` missing while dependencies or workspaces are declared
- a workspace package whose name is not linked under `node_modules`
- `package.json` or a lockfile written after the manager's install marker (`.package-lock.json`, `.modules.yaml`, `.yarn-integrity`)

If any applies it runs the manager's install first (`npm install --no-audit --no-fund`, `pnpm install`, `yarn install` / `corepack yarn install`) as a recorded verification command, then the gates. A failed install is evidence like any other failed command. `refreshDependencies: false` or `BARO_DEPS_REFRESH=0` turns it off. Story-level gates in worktrees and the continuous gate go through the same function, so they get it too.

## Verification

- `test/verification/verify.test.ts`: reasons named in order (no deps → nothing; workspaces without node_modules; unlinked workspace), install-then-gate end to end on a real `npm install`, opt-out; the existing workspace-scripts test now expects the refresh first
- full baro-orchestrator suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1bpAF6qY7wdqxL77pKxKE