### PR TITLE
feat: `baro operator` — Claude Code in front, baro runs behind (TUI + terminal)

### DIFF
--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -590,6 +590,30 @@ pub struct App {
     pub dialogue_enabled: bool,
     /// Live orchestrator stdin (JSON command lines); refreshed per spawn.
     pub orchestrator_stdin: Option<tokio::sync::mpsc::Sender<String>>,
+    /// `baro operator`: the session screen talks to operator.mjs instead of
+    /// the intake conversation. None outside that mode.
+    pub operator: Option<OperatorState>,
+}
+
+/// A question only the person can answer, relayed from the operator
+/// (a permission for a tool, or whether to stop runs on quit).
+#[derive(Debug, Clone)]
+pub struct OperatorAsk {
+    pub id: String,
+    pub kind: String,
+    pub prompt: String,
+    pub tool: Option<String>,
+    pub summary: Option<String>,
+}
+
+#[derive(Default)]
+pub struct OperatorState {
+    pub stdin: Option<tokio::sync::mpsc::Sender<String>>,
+    pub runs: Vec<crate::operator_client::OperatorRun>,
+    pub pending_ask: Option<OperatorAsk>,
+    /// The reply being streamed; becomes an assistant turn on turn_done.
+    pub reply: String,
+    pub gone: Option<String>,
 }
 
 impl App {
@@ -743,7 +767,20 @@ impl App {
             dialogue_enabled: std::env::var("BARO_WITH_DIALOGUE").is_ok_and(|value| value == "1")
                 || std::env::var("BARO_COORDINATION").is_ok_and(|value| value == "collective"),
             orchestrator_stdin: None,
+            operator: None,
         }
+    }
+
+    /// Operator mode: send a line to operator.mjs; false when it is gone.
+    pub fn operator_send(&self, line: String) -> bool {
+        match self.operator.as_ref().and_then(|state| state.stdin.as_ref()) {
+            Some(stdin) => stdin.try_send(line).is_ok(),
+            None => false,
+        }
+    }
+
+    pub fn operator_pending_ask(&self) -> Option<&OperatorAsk> {
+        self.operator.as_ref().and_then(|state| state.pending_ask.as_ref())
     }
 
     // Screen transitions

--- a/crates/baro-tui/src/cli/cli.rs
+++ b/crates/baro-tui/src/cli/cli.rs
@@ -247,7 +247,7 @@ pub struct Cli {
     pub operator: bool,
 
     /// Internal: how the operator handles Claude's permission prompts.
-    #[arg(long, hide = true, value_parser = ["ask", "auto"], default_value = "ask")]
+    #[arg(long, hide = true, value_parser = ["ask", "auto"], default_value = "auto")]
     pub operator_permission: String,
 }
 

--- a/crates/baro-tui/src/cli/cli.rs
+++ b/crates/baro-tui/src/cli/cli.rs
@@ -240,6 +240,15 @@ pub struct Cli {
     /// and wait (≤120s) for a confirm_mode command before planning continues.
     #[arg(long, env = "BARO_CONFIRM_MODE")]
     pub confirm_mode: bool,
+
+    /// Internal: `baro operator` sets this before clap; the session screen
+    /// then talks to operator.mjs instead of the intake conversation.
+    #[arg(long, hide = true)]
+    pub operator: bool,
+
+    /// Internal: how the operator handles Claude's permission prompts.
+    #[arg(long, hide = true, value_parser = ["ask", "auto"], default_value = "ask")]
+    pub operator_permission: String,
 }
 
 fn parse_shell_budget(raw: &str) -> Result<u64, String> {

--- a/crates/baro-tui/src/conversation/session.rs
+++ b/crates/baro-tui/src/conversation/session.rs
@@ -442,6 +442,31 @@ impl ConversationSession {
         Ok(())
     }
 
+    /// Operator sessions: the person's message, outside the request/response
+    /// state machine (the operator process owns that exchange).
+    pub fn record_user_turn(&mut self, text: impl Into<String>) -> Result<(), ConversationError> {
+        let text = normalized_text("user message", text.into(), MAX_MESSAGE_CHARS)?;
+        self.push_turn(TranscriptTurn {
+            role: TranscriptRole::User,
+            text,
+            request_id: None,
+            kind: None,
+        });
+        Ok(())
+    }
+
+    /// Operator sessions: one complete reply, after its deltas finished.
+    pub fn record_assistant_turn(&mut self, text: impl Into<String>) -> Result<(), ConversationError> {
+        let text = normalized_text("assistant message", text.into(), MAX_MESSAGE_CHARS)?;
+        self.push_turn(TranscriptTurn {
+            role: TranscriptRole::Assistant,
+            text,
+            request_id: None,
+            kind: None,
+        });
+        Ok(())
+    }
+
     /// Add a deterministic lifecycle/status line without a model call.
     pub fn record_system_turn(&mut self, text: impl Into<String>) -> Result<(), ConversationError> {
         let text = normalized_text("system message", text.into(), MAX_MESSAGE_CHARS)?;

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -3438,6 +3438,9 @@ fn apply_operator_event(app: &mut App, event: operator_client::OperatorEvent) {
         Event::ToolCall { name, summary } => {
             let _ = app.conversation.record_system_turn(format!("⚙ {name}({summary})"));
         }
+        Event::ToolResult { summary } => {
+            let _ = app.conversation.record_system_turn(format!("⎿ {summary}"));
+        }
         Event::AssistantDelta { text } => {
             let state = app.operator.as_mut().expect("checked above");
             state.reply.push_str(&text);

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -3436,7 +3436,7 @@ fn apply_operator_event(app: &mut App, event: operator_client::OperatorEvent) {
             let _ = app.conversation.record_system_turn(text);
         }
         Event::ToolCall { name, summary } => {
-            let _ = app.conversation.record_system_turn(format!("⚙ {name} {summary}"));
+            let _ = app.conversation.record_system_turn(format!("⚙ {name}({summary})"));
         }
         Event::AssistantDelta { text } => {
             let state = app.operator.as_mut().expect("checked above");

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -21,6 +21,7 @@ mod headless_transport;
 mod highlight;
 mod intake_runner;
 mod notification;
+mod operator_client;
 mod orchestrator_client;
 mod planner_host;
 mod planner_runner;
@@ -310,6 +311,8 @@ enum AppEvent {
     OrchestratorShutdown(tokio::sync::oneshot::Sender<()>),
     /// OS Ctrl-C observed by the headless host.
     Interrupt,
+    /// `baro operator`: one line from operator.mjs (docs/operator-protocol.md).
+    Operator(operator_client::OperatorEvent),
     Tick,
 }
 
@@ -414,6 +417,25 @@ async fn run_main() -> Result<(), Box<dyn std::error::Error>> {
     if raw_args.get(1).map(|s| s.as_str()) == Some("logs") {
         let code = cli::run_registry::run_logs(&raw_args[2..]);
         std::process::exit(code);
+    }
+    // `baro operator [--cwd …] [--model …] [--permission ask|auto] [--local-only]`:
+    // the session screen with operator.mjs behind it. No session lock and no
+    // run record here — the runs the operator delegates take those themselves.
+    if raw_args.get(1).map(|s| s.as_str()) == Some("operator") {
+        let mut argv = vec!["baro".to_string(), "--operator".to_string()];
+        let mut rest = raw_args[2..].iter();
+        while let Some(arg) = rest.next() {
+            if arg == "--permission" {
+                argv.push("--operator-permission".to_string());
+                if let Some(value) = rest.next() {
+                    argv.push(value.clone());
+                }
+            } else {
+                argv.push(arg.clone());
+            }
+        }
+        let cli = <cli::cli::Cli as clap::Parser>::try_parse_from(&argv)?;
+        return run_with_terminal(cli, None).await;
     }
 
     // Update notice: the network check runs in the JS layer (no HTTP dep
@@ -520,6 +542,18 @@ async fn run_main() -> Result<(), Box<dyn std::error::Error>> {
         return run_app(None, cli).await;
     }
 
+    let result = run_with_terminal(cli, update_notice).await;
+
+    // _lock is dropped here, removing baro.lock
+
+    result
+}
+
+/// The alternate screen around `run_app`, restored whatever the run did.
+async fn run_with_terminal(
+    cli: cli::cli::Cli,
+    update_notice: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut writer = open_terminal_writer()?;
     enable_raw_mode()?;
     execute!(writer, EnterAlternateScreen)?;
@@ -545,8 +579,6 @@ async fn run_main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(n) = &update_notice {
         eprint!("{n}");
     }
-
-    // _lock is dropped here, removing baro.lock
 
     result
 }
@@ -1314,7 +1346,7 @@ async fn run_app(
         conversation_host::purge_conversation_snapshots(&cwd);
     }
 
-    if !entered_resume && cli.goal.is_none() && !greenfield_initialized {
+    if !entered_resume && cli.goal.is_none() && !greenfield_initialized && !cli.operator {
         restore_pre_prd_conversation(&mut app, &cwd);
     }
 
@@ -1336,6 +1368,9 @@ async fn run_app(
                 submit_conversation_message(&mut app, &cwd, tx.clone(), message)
                     .map_err(|error| format!("cannot start conversation: {error}"))?;
             }
+        } else if cli.operator {
+            app.start_conversation();
+            start_operator(&mut app, &cwd, tx.clone(), &cli)?;
         } else {
             if headless {
                 return Err("--headless requires a goal argument".into());
@@ -1447,6 +1482,9 @@ async fn run_app(
             app.session_version = app.session_version.wrapping_add(1);
         }
         match received {
+            Some(AppEvent::Operator(event)) => {
+                apply_operator_event(&mut app, event);
+            }
             Some(AppEvent::Baro(ev)) => {
                 if matches!(ev, BaroEvent::NotificationReady) {
                     notification::notify_completion();
@@ -2148,10 +2186,20 @@ async fn run_app(
                         {
                             match app.quit_armed_tick {
                                 Some(armed) if app.tick_count.saturating_sub(armed) <= 20 => {
+                                    operator_quit(&app);
                                     return Ok(())
                                 }
                                 _ => app.quit_armed_tick = Some(app.tick_count),
                             }
+                        }
+                        KeyCode::Char(answer @ ('y' | 'n' | 'a'))
+                            if app.operator_pending_ask().is_some()
+                                && app.conversation_input.is_empty() =>
+                        {
+                            operator_answer(&mut app, answer);
+                        }
+                        KeyCode::Esc if app.operator_pending_ask().is_some() => {
+                            operator_answer(&mut app, 'n');
                         }
                         KeyCode::Esc => {
                             app.quit_armed_tick = None;
@@ -2279,7 +2327,10 @@ async fn run_app(
                             spawn_pending_conversation(&mut app, &cwd, tx.clone(), intent);
                         }
                         KeyCode::Enter | KeyCode::Char('\r') | KeyCode::Char('\n') => {
-                            if app.inline_mode_pick {
+                            if app.operator.is_some() {
+                                let message = app.input_take();
+                                operator_submit(&mut app, message);
+                            } else if app.inline_mode_pick {
                                 app.inline_mode_pick = false;
                                 let chosen = app::MODE_OPTIONS[app.mode_picker_index];
                                 let mode_json = match app.mode_proposal.take() {
@@ -3340,6 +3391,178 @@ fn conversation_model(app: &App) -> Option<String> {
             .then(|| app.architect_model.clone())
             .flatten()
     })
+}
+
+/// `baro operator`: spawn operator.mjs behind the session screen and route
+/// its lines into the app loop.
+fn start_operator(
+    app: &mut App,
+    cwd: &Path,
+    tx: mpsc::Sender<AppEvent>,
+    cli: &cli::cli::Cli,
+) -> Result<(), String> {
+    let (events_tx, mut events_rx) = mpsc::channel::<operator_client::OperatorEvent>(256);
+    let stdin = operator_client::spawn_operator(
+        operator_client::OperatorLaunch {
+            cwd: cwd.to_path_buf(),
+            model: Some(cli.model.clone().unwrap_or_else(|| "opus".to_string())),
+            permission_auto: cli.operator_permission == "auto",
+            local_only: cli.local_only,
+        },
+        events_tx,
+    )?;
+    tokio::spawn(async move {
+        while let Some(event) = events_rx.recv().await {
+            if tx.send(AppEvent::Operator(event)).await.is_err() {
+                break;
+            }
+        }
+    });
+    app.operator = Some(app::OperatorState {
+        stdin: Some(stdin),
+        ..Default::default()
+    });
+    Ok(())
+}
+
+fn apply_operator_event(app: &mut App, event: operator_client::OperatorEvent) {
+    use operator_client::OperatorEvent as Event;
+    if app.operator.is_none() {
+        return;
+    }
+    match event {
+        Event::Ready => {}
+        Event::Note { text } => {
+            let _ = app.conversation.record_system_turn(text);
+        }
+        Event::ToolCall { name, summary } => {
+            let _ = app.conversation.record_system_turn(format!("⚙ {name} {summary}"));
+        }
+        Event::AssistantDelta { text } => {
+            let state = app.operator.as_mut().expect("checked above");
+            state.reply.push_str(&text);
+            app.conversation_stream = Some(("operator".to_string(), state.reply.clone()));
+        }
+        Event::TurnDone { duration_ms, cost_usd } => {
+            let reply = {
+                let state = app.operator.as_mut().expect("checked above");
+                std::mem::take(&mut state.reply)
+            };
+            if !reply.trim().is_empty() {
+                let _ = app.conversation.record_assistant_turn(reply);
+            }
+            let facts: Vec<String> = [
+                duration_ms.map(|ms| format!("{}s", (ms / 1000.0).round() as u64)),
+                cost_usd.map(|usd| format!("${usd:.2}")),
+            ]
+            .into_iter()
+            .flatten()
+            .collect();
+            if !facts.is_empty() {
+                let _ = app.conversation.record_system_turn(facts.join(" · "));
+            }
+            app.conversation_stream = None;
+            app.conversation_busy = false;
+        }
+        Event::Ask {
+            id,
+            kind,
+            prompt,
+            tool,
+            summary,
+        } => {
+            let state = app.operator.as_mut().expect("checked above");
+            state.pending_ask = Some(app::OperatorAsk {
+                id,
+                kind,
+                prompt,
+                tool,
+                summary,
+            });
+        }
+        Event::Runs { runs } => {
+            let state = app.operator.as_mut().expect("checked above");
+            state.runs = runs;
+        }
+        Event::Exit => {}
+        Event::Gone { reason } => {
+            let text = reason.unwrap_or_else(|| "operator exited".to_string());
+            let state = app.operator.as_mut().expect("checked above");
+            state.gone = Some(text.clone());
+            state.stdin = None;
+            state.pending_ask = None;
+            app.conversation_stream = None;
+            app.conversation_busy = false;
+            let _ = app.conversation.record_system_turn(text);
+        }
+    }
+}
+
+/// Enter in operator mode: an answer to the pending question, a local slash
+/// command, or a message for the operator.
+fn operator_submit(app: &mut App, message: String) {
+    let text = message.trim().to_string();
+    if text.is_empty() {
+        return;
+    }
+    if app.operator_pending_ask().is_some() {
+        let first = text.chars().next().unwrap_or('n').to_ascii_lowercase();
+        operator_answer(app, if matches!(first, 'y' | 'a') { first } else { 'n' });
+        return;
+    }
+    if app.operator.as_ref().is_some_and(|state| state.stdin.is_none()) {
+        app.conversation_error = Some("the operator is gone; quit and start again".to_string());
+        return;
+    }
+    let command = match text.as_str() {
+        "/quit" | "/exit" => Some(operator_client::quit_command(false)),
+        "/runs" => Some(serde_json::json!({ "type": "runs" }).to_string()),
+        other if other.starts_with("/status") || other.starts_with("/stop") => {
+            let mut parts = other.splitn(2, char::is_whitespace);
+            let verb = parts.next().unwrap_or("").trim_start_matches('/');
+            let id = parts.next().unwrap_or("").trim();
+            Some(serde_json::json!({ "type": verb, "id": id }).to_string())
+        }
+        _ => None,
+    };
+    if let Some(command) = command {
+        app.operator_send(command);
+        return;
+    }
+    let _ = app.conversation.record_user_turn(text.clone());
+    app.input_history.push(text.clone());
+    app.conversation_busy = true;
+    app.conversation_error = None;
+    app.operator_send(operator_client::user_command(&text));
+}
+
+fn operator_answer(app: &mut App, answer: char) {
+    let Some(ask) = app
+        .operator
+        .as_mut()
+        .and_then(|state| state.pending_ask.take())
+    else {
+        return;
+    };
+    let reply = answer.to_string();
+    app.operator_send(operator_client::answer_command(&ask.id, &reply));
+    let label = match answer {
+        'y' => "allowed",
+        'a' => "always allowed",
+        _ => "declined",
+    };
+    let _ = app.conversation.record_system_turn(format!(
+        "{} {} — {label}",
+        ask.tool.unwrap_or_else(|| ask.kind.clone()),
+        ask.summary.unwrap_or_default()
+    ));
+}
+
+/// The TUI is leaving: the operator shuts down, its delegated runs stay.
+fn operator_quit(app: &App) {
+    if app.operator.is_some() {
+        app.operator_send(operator_client::quit_command(false));
+    }
 }
 
 fn spawn_pending_conversation(

--- a/crates/baro-tui/src/operator_client.rs
+++ b/crates/baro-tui/src/operator_client.rs
@@ -43,6 +43,8 @@ pub enum OperatorEvent {
     AssistantDelta { text: String },
     #[serde(rename = "tool_call")]
     ToolCall { name: String, summary: String },
+    #[serde(rename = "tool_result")]
+    ToolResult { summary: String },
     #[serde(rename = "ask")]
     Ask {
         id: String,

--- a/crates/baro-tui/src/operator_client.rs
+++ b/crates/baro-tui/src/operator_client.rs
@@ -1,0 +1,207 @@
+//! The operator as a subprocess: `operator.mjs --protocol json`, one JSON
+//! object per line each way (docs/operator-protocol.md). The TUI draws what
+//! arrives and forwards what the person types; the Node side owns the model,
+//! its tools and the baro runs it delegates.
+
+use serde::Deserialize;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::mpsc;
+
+use crate::discovery::{self, ScriptEntry};
+
+const SCRIPT_REL_PATH: &str = "packages/baro-orchestrator/scripts/operator.ts";
+const BUNDLE_NAME: &str = "operator.mjs";
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OperatorRun {
+    pub id: String,
+    pub state: String,
+    pub phase: String,
+    #[serde(default)]
+    pub completed: u32,
+    #[serde(default)]
+    pub total: u32,
+    // Carried for the run drill-in that follows; the strip shows the rest.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub goal: String,
+    #[serde(default)]
+    pub elapsed: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub pr_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum OperatorEvent {
+    #[serde(rename = "ready")]
+    Ready,
+    #[serde(rename = "note")]
+    Note { text: String },
+    #[serde(rename = "assistant_delta")]
+    AssistantDelta { text: String },
+    #[serde(rename = "tool_call")]
+    ToolCall { name: String, summary: String },
+    #[serde(rename = "ask")]
+    Ask {
+        id: String,
+        kind: String,
+        prompt: String,
+        #[serde(default)]
+        tool: Option<String>,
+        #[serde(default)]
+        summary: Option<String>,
+    },
+    #[serde(rename = "turn_done")]
+    TurnDone {
+        #[serde(default)]
+        duration_ms: Option<f64>,
+        #[serde(default)]
+        cost_usd: Option<f64>,
+    },
+    #[serde(rename = "runs")]
+    Runs { runs: Vec<OperatorRun> },
+    #[serde(rename = "exit")]
+    Exit,
+    /// The process is gone; `reason` is set when it did not say goodbye.
+    #[serde(skip)]
+    Gone { reason: Option<String> },
+}
+
+pub struct OperatorLaunch {
+    pub cwd: std::path::PathBuf,
+    pub model: Option<String>,
+    pub permission_auto: bool,
+    pub local_only: bool,
+}
+
+/// Spawn the operator; events arrive on `tx`, stdin lines leave through the
+/// returned sender. The child dies with the TUI (kill_on_drop); the baro runs
+/// it delegated are detached and outlive both.
+pub fn spawn_operator(
+    launch: OperatorLaunch,
+    tx: mpsc::Sender<OperatorEvent>,
+) -> Result<mpsc::Sender<String>, String> {
+    let entry = discovery::locate_script(&launch.cwd, SCRIPT_REL_PATH, BUNDLE_NAME)?;
+    let mut cmd = match &entry {
+        ScriptEntry::Tsx { tsx, script } => {
+            let mut c = tokio::process::Command::new(tsx);
+            c.arg(script);
+            c
+        }
+        ScriptEntry::NodeJs(js) => {
+            let mut c = tokio::process::Command::new("node");
+            c.arg(js);
+            c
+        }
+    };
+    cmd.arg("--protocol").arg("json");
+    cmd.arg("--cwd").arg(&launch.cwd);
+    if let Some(model) = &launch.model {
+        cmd.arg("--model").arg(model);
+    }
+    if launch.permission_auto {
+        cmd.arg("--permission").arg("auto");
+    }
+    if launch.local_only {
+        cmd.arg("--local-only");
+    }
+    // A child that inherits the host's run id believes it is that run.
+    cmd.env_remove("BARO_RUN_ID");
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    cmd.kill_on_drop(true);
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|error| format!("failed to spawn the operator: {error}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "operator stdout missing".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "operator stderr missing".to_string())?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "operator stdin missing".to_string())?;
+
+    let (stdin_tx, mut stdin_rx) = mpsc::channel::<String>(64);
+    tokio::spawn(async move {
+        while let Some(line) = stdin_rx.recv().await {
+            if stdin.write_all(line.as_bytes()).await.is_err()
+                || stdin.write_all(b"\n").await.is_err()
+            {
+                break;
+            }
+            let _ = stdin.flush().await;
+        }
+    });
+
+    let stderr_tail = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let tail_writer = stderr_tail.clone();
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            let mut tail = tail_writer.lock().unwrap();
+            tail.push(line);
+            if tail.len() > 20 {
+                tail.remove(0);
+            }
+        }
+    });
+
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stdout).lines();
+        let mut said_goodbye = false;
+        while let Ok(Some(line)) = lines.next_line().await {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<OperatorEvent>(trimmed) {
+                Ok(event) => {
+                    if matches!(event, OperatorEvent::Exit) {
+                        said_goodbye = true;
+                    }
+                    if tx.send(event).await.is_err() {
+                        break;
+                    }
+                }
+                Err(_) => {
+                    // Unknown event types are the protocol growing; ignore.
+                }
+            }
+        }
+        let status = child.wait().await.ok();
+        let reason = if said_goodbye {
+            None
+        } else {
+            let tail = stderr_tail.lock().unwrap().join("\n");
+            Some(match status {
+                Some(status) if tail.is_empty() => format!("operator exited ({status})"),
+                Some(status) => format!("operator exited ({status}): {tail}"),
+                None => "operator exited".to_string(),
+            })
+        };
+        let _ = tx.send(OperatorEvent::Gone { reason }).await;
+    });
+
+    Ok(stdin_tx)
+}
+
+pub fn user_command(text: &str) -> String {
+    serde_json::json!({ "type": "user", "text": text }).to_string()
+}
+
+pub fn answer_command(id: &str, answer: &str) -> String {
+    serde_json::json!({ "type": "answer", "id": id, "answer": answer }).to_string()
+}
+
+pub fn quit_command(stop_runs: bool) -> String {
+    serde_json::json!({ "type": "quit", "stop_runs": stop_runs }).to_string()
+}

--- a/crates/baro-tui/src/operator_client.rs
+++ b/crates/baro-tui/src/operator_client.rs
@@ -27,9 +27,35 @@ pub struct OperatorRun {
     pub goal: String,
     #[serde(default)]
     pub elapsed: String,
+    #[serde(default)]
+    pub started_ms: Option<u64>,
+    #[serde(default)]
+    pub finished_ms: Option<u64>,
     #[allow(dead_code)]
     #[serde(default)]
     pub pr_url: Option<String>,
+}
+
+impl OperatorRun {
+    /// Elapsed as of now: snapshots only arrive on events and intake is
+    /// silent for minutes, so the strip must not freeze at the last one.
+    pub fn elapsed_now(&self) -> String {
+        let Some(started) = self.started_ms else {
+            return self.elapsed.clone();
+        };
+        let end = self.finished_ms.unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(started)
+        });
+        let secs = end.saturating_sub(started) / 1000;
+        if secs < 60 {
+            format!("{secs}s")
+        } else {
+            format!("{}m {:02}s", secs / 60, secs % 60)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/baro-tui/src/screens/session.rs
+++ b/crates/baro-tui/src/screens/session.rs
@@ -294,6 +294,13 @@ fn turn_lines(
         TranscriptRole::System => {
             // Operator tool calls: "⚙ Name(args)" drawn like a coding agent's
             // call line — bullet, bold name, dim arguments.
+            if let Some(result) = turn.text.strip_prefix("⎿ ") {
+                lines.push(Line::from(vec![
+                    Span::styled("  ⎿  ".to_string(), Style::default().fg(theme::MUTED)),
+                    Span::styled(result.to_string(), Style::default().fg(theme::TEXT_DIM)),
+                ]));
+                return;
+            }
             if let Some(call) = turn.text.strip_prefix("⚙ ") {
                 let (name, args) = match call.find('(') {
                     Some(at) => (&call[..at], &call[at..]),

--- a/crates/baro-tui/src/screens/session.rs
+++ b/crates/baro-tui/src/screens/session.rs
@@ -165,7 +165,7 @@ fn header_line(app: &App) -> Paragraph<'static> {
             };
             let (label, color) = match run.state.as_str() {
                 "queued" => ("queued".to_string(), theme::MUTED),
-                "running" => (format!("{}{} · {}", run.phase, progress, run.elapsed), theme::TEXT_DIM),
+                "running" => (format!("{}{} · {}", run.phase, progress, run.elapsed_now()), theme::TEXT_DIM),
                 "completed" => ("done".to_string(), theme::ACCENT),
                 other => (other.to_string(), theme::ERROR),
             };

--- a/crates/baro-tui/src/screens/session.rs
+++ b/crates/baro-tui/src/screens/session.rs
@@ -143,6 +143,41 @@ fn render_focus(frame: &mut Frame, app: &App, id: &str, area: ratatui::layout::R
 }
 
 fn header_line(app: &App) -> Paragraph<'static> {
+    if let Some(operator) = &app.operator {
+        let mut spans = vec![
+            Span::styled(
+                " baro ",
+                Style::default()
+                    .fg(theme::ACCENT_BRIGHT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("· ", Style::default().fg(theme::MUTED)),
+            Span::styled(
+                if operator.gone.is_some() { "operator gone" } else { "operator" }.to_string(),
+                Style::default().fg(theme::ACCENT),
+            ),
+        ];
+        for run in &operator.runs {
+            let progress = if run.total > 0 {
+                format!(" {}/{}", run.completed, run.total)
+            } else {
+                String::new()
+            };
+            let (label, color) = match run.state.as_str() {
+                "queued" => ("queued".to_string(), theme::MUTED),
+                "running" => (format!("{}{} · {}", run.phase, progress, run.elapsed), theme::TEXT_DIM),
+                "completed" => ("done".to_string(), theme::ACCENT),
+                other => (other.to_string(), theme::ERROR),
+            };
+            spans.push(Span::styled("  ", Style::default()));
+            spans.push(Span::styled(
+                format!("{} ", run.id),
+                Style::default().fg(theme::TEXT),
+            ));
+            spans.push(Span::styled(label, Style::default().fg(color)));
+        }
+        return Paragraph::new(Line::from(spans));
+    }
     let phase = match app.conversation.phase() {
         ConversationPhase::Clarifying => "listening",
         ConversationPhase::NeedsInput => "needs input",
@@ -783,7 +818,29 @@ fn planning_lines(app: &App, width: usize, lines: &mut Vec<Line<'static>>) {
 }
 
 fn input_box(app: &App) -> Paragraph<'static> {
-    let text = if app.conversation_busy && app.conversation_input.is_empty() {
+    if let Some(ask) = app.operator_pending_ask() {
+        let question = match ask.kind.as_str() {
+            "permission" => format!(
+                " ⚠ {} {} — allow?  y · n · a (always for {})",
+                ask.tool.clone().unwrap_or_else(|| "tool".to_string()),
+                ask.summary.clone().unwrap_or_default(),
+                ask.tool.clone().unwrap_or_else(|| "this tool".to_string()),
+            ),
+            _ => format!(" {}  y · n", ask.prompt),
+        };
+        return Paragraph::new(question).wrap(Wrap { trim: false }).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(theme::ACCENT_BRIGHT)),
+        );
+    }
+    let text = if app.operator.is_some() && app.conversation_input.is_empty() {
+        if app.conversation_busy {
+            " Operator is working — keep typing, it queues…".to_string()
+        } else {
+            " Ask, change something, or hand baro a goal…".to_string()
+        }
+    } else if app.conversation_busy && app.conversation_input.is_empty() {
         " Baro is working — you can keep typing…".to_string()
     } else if app.conversation_input.is_empty() {
         if app.inline_mode_pick {

--- a/crates/baro-tui/src/screens/session.rs
+++ b/crates/baro-tui/src/screens/session.rs
@@ -292,12 +292,29 @@ fn turn_lines(
             }
         }
         TranscriptRole::System => {
+            // Operator tool calls: "⚙ Name(args)" drawn like a coding agent's
+            // call line — bullet, bold name, dim arguments.
+            if let Some(call) = turn.text.strip_prefix("⚙ ") {
+                let (name, args) = match call.find('(') {
+                    Some(at) => (&call[..at], &call[at..]),
+                    None => (call, ""),
+                };
+                lines.push(Line::from(vec![
+                    Span::styled("● ".to_string(), Style::default().fg(theme::SUCCESS)),
+                    Span::styled(
+                        name.to_string(),
+                        Style::default().fg(theme::TEXT).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(args.to_string(), Style::default().fg(theme::TEXT_DIM)),
+                ]));
+                return;
+            }
             for text in turn.text.lines() {
                 lines.push(Line::from(vec![
                     Span::styled("· ".to_string(), Style::default().fg(theme::MUTED)),
                     Span::styled(
                         text.to_string(),
-                        Style::default().fg(theme::MUTED),
+                        Style::default().fg(theme::TEXT_DIM),
                     ),
                 ]));
             }

--- a/docs/operator-protocol.md
+++ b/docs/operator-protocol.md
@@ -17,7 +17,7 @@ Every event carries `ts` (ISO 8601).
 | `tool_result` | `summary` | first meaningful line of what the last tool returned, with `(+N lines)` when there was more |
 | `ask` | `id`, `kind` (`permission` \| `quit`), `prompt`, `tool?`, `summary?`, `options` | a question only the person can answer; answer with `answer` |
 | `turn_done` | `duration_ms`, `cost_usd` (nullable) | the reply is complete |
-| `runs` | `runs[]`: `id`, `state`, `phase`, `completed`, `total`, `goal`, `elapsed`, `pr_url?` | snapshot after anything about a run changed |
+| `runs` | `runs[]`: `id`, `state`, `phase`, `completed`, `total`, `goal`, `elapsed`, `started_ms?`, `finished_ms?`, `pr_url?` | snapshot after anything about a run changed; a surface with a clock derives elapsed from `started_ms` between snapshots |
 | `exit` | | the operator is shutting down |
 
 `state` is `queued`, `running`, `completed`, `error`, `max-tokens` or `aborted`.

--- a/docs/operator-protocol.md
+++ b/docs/operator-protocol.md
@@ -1,0 +1,45 @@
+# Operator protocol
+
+`operator.mjs --protocol json` is the operator with its surface removed: one
+JSON object per line on stdout, one per line on stdin. The Rust TUI speaks it;
+`--protocol terminal` (the default) is the same session drawn as a plain chat.
+
+Every event carries `ts` (ISO 8601).
+
+## Events (stdout)
+
+| type | fields | meaning |
+|---|---|---|
+| `ready` | | the operator accepts commands |
+| `note` | `text` | one dim line: banner, milestone, queue note, refusal |
+| `assistant_delta` | `text` | a slice of the reply, in order; the turn ends with `turn_done` |
+| `tool_call` | `name`, `summary` | the operator invoked a tool; `name` is `baro delegate` etc. for its own tools |
+| `ask` | `id`, `kind` (`permission` \| `quit`), `prompt`, `tool?`, `summary?`, `options` | a question only the person can answer; answer with `answer` |
+| `turn_done` | `duration_ms`, `cost_usd` (nullable) | the reply is complete |
+| `runs` | `runs[]`: `id`, `state`, `phase`, `completed`, `total`, `goal`, `elapsed`, `pr_url?` | snapshot after anything about a run changed |
+| `exit` | | the operator is shutting down |
+
+`state` is `queued`, `running`, `completed`, `error`, `max-tokens` or `aborted`.
+`phase` follows the run tracker: `intake`, `architect`, `planning`, `executing`,
+`finalizing`, `done`, or `queued`.
+
+## Commands (stdin)
+
+| type | fields | meaning |
+|---|---|---|
+| `user` | `text` | a message from the person; the operator replies with deltas |
+| `answer` | `id`, `answer` | reply to an `ask`; permission answers are `y`, `n` or `a` (always for that tool) |
+| `runs` | | print the run table as a `note` |
+| `status` | `id` | print one run's status as a `note` |
+| `stop` | `id` | stop a running or queued run |
+| `quit` | `stop_runs` (bool) | shut down; when omitted the operator asks with `ask` kind `quit` |
+
+Closing stdin is a `quit` that leaves runs running.
+
+## Guarantees
+
+- One `ask` is outstanding at a time; the operator serializes them.
+- `assistant_delta` never interleaves with another turn's deltas; `turn_done`
+  separates turns.
+- A finished run is reported twice: as a `note` and, through the model, as a
+  normal reply that starts after a `[baro] run-N finished` message.

--- a/docs/operator-protocol.md
+++ b/docs/operator-protocol.md
@@ -14,6 +14,7 @@ Every event carries `ts` (ISO 8601).
 | `note` | `text` | one dim line: banner, milestone, queue note, refusal |
 | `assistant_delta` | `text` | a slice of the reply, in order; the turn ends with `turn_done` |
 | `tool_call` | `name`, `summary` | the operator invoked a tool; `name` is `baro delegate` etc. for its own tools |
+| `tool_result` | `summary` | first meaningful line of what the last tool returned, with `(+N lines)` when there was more |
 | `ask` | `id`, `kind` (`permission` \| `quit`), `prompt`, `tool?`, `summary?`, `options` | a question only the person can answer; answer with `answer` |
 | `turn_done` | `duration_ms`, `cost_usd` (nullable) | the reply is complete |
 | `runs` | `runs[]`: `id`, `state`, `phase`, `completed`, `total`, `goal`, `elapsed`, `pr_url?` | snapshot after anything about a run changed |

--- a/packages/baro-app/tsup.config.ts
+++ b/packages/baro-app/tsup.config.ts
@@ -89,4 +89,10 @@ export default defineConfig([
         entry: { runner: "../baro-orchestrator/scripts/runner.ts" },
         ...sharedBundleConfig,
     },
+    {
+        // `baro operator` — Claude Code in front, baro runs behind; doubles as
+        // the MCP stdio child Claude spawns to reach the operator's tools.
+        entry: { operator: "../baro-orchestrator/scripts/operator.ts" },
+        ...sharedBundleConfig,
+    },
 ])

--- a/packages/baro-orchestrator/scripts/operator.ts
+++ b/packages/baro-orchestrator/scripts/operator.ts
@@ -24,7 +24,7 @@ async function main(): Promise<void> {
     let model: string | undefined = "opus"
     let effort: string | undefined
     let claudeBin: string | undefined
-    let permission: "ask" | "auto" = "ask"
+    let permission: "ask" | "auto" = "auto"
     let protocol: "terminal" | "json" = "terminal"
     const baroArgs: string[] = []
     for (let index = 0; index < argv.length; index += 1) {
@@ -71,7 +71,7 @@ async function main(): Promise<void> {
             case "--help":
             case "-h":
                 process.stdout.write(
-                    "usage: operator [--cwd <repo>] [--model opus] [--effort high] [--permission ask|auto] [--protocol terminal|json] [--local-only] [--llm <backend>]\n",
+                    "usage: operator [--cwd <repo>] [--model opus] [--effort high] [--permission auto|ask] [--protocol terminal|json] [--local-only] [--llm <backend>]\n",
                 )
                 return
             default:

--- a/packages/baro-orchestrator/scripts/operator.ts
+++ b/packages/baro-orchestrator/scripts/operator.ts
@@ -1,0 +1,84 @@
+import { resolve } from "node:path"
+
+import {
+    parseOperatorMcpInvocation,
+    runOperatorMcpServer,
+} from "../src/operator/host-tools-relay.js"
+import { runOperator } from "../src/operator/operator-session.js"
+
+/* `baro operator`: a conversation with Claude Code in front and baro behind.
+   The same bundle also serves as the MCP stdio child Claude spawns to reach
+   the operator's tools (`__operator-mcp`). */
+
+async function main(): Promise<void> {
+    const argv = process.argv.slice(2)
+    const mcp = parseOperatorMcpInvocation(argv)
+    if (mcp) {
+        await runOperatorMcpServer(mcp)
+        return
+    }
+
+    let cwd = process.cwd()
+    let model: string | undefined = "opus"
+    let effort: string | undefined
+    let claudeBin: string | undefined
+    let permission: "ask" | "auto" = "ask"
+    const baroArgs: string[] = []
+    for (let index = 0; index < argv.length; index += 1) {
+        const flag = argv[index]
+        const value = argv[index + 1]
+        switch (flag) {
+            case "--cwd":
+                cwd = resolve(value ?? cwd)
+                index += 1
+                break
+            case "--model":
+                model = value
+                index += 1
+                break
+            case "--effort":
+                effort = value
+                index += 1
+                break
+            case "--claude-bin":
+                claudeBin = value
+                index += 1
+                break
+            case "--permission":
+                if (value !== "ask" && value !== "auto") {
+                    throw new Error("--permission must be ask or auto")
+                }
+                permission = value
+                index += 1
+                break
+            case "--local-only":
+                baroArgs.push("--local-only")
+                break
+            case "--llm":
+                baroArgs.push("--llm", value ?? "")
+                index += 1
+                break
+            case "--help":
+            case "-h":
+                process.stdout.write(
+                    "usage: operator [--cwd <repo>] [--model opus] [--effort high] [--permission ask|auto] [--local-only] [--llm <backend>]\n",
+                )
+                return
+            default:
+                throw new Error(`unknown flag: ${flag}`)
+        }
+    }
+    await runOperator({
+        cwd,
+        ...(model ? { model } : {}),
+        ...(effort ? { effort } : {}),
+        ...(claudeBin ? { claudeBin } : {}),
+        permission,
+        baroArgs,
+    })
+}
+
+main().catch((error) => {
+    process.stderr.write(`operator: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(1)
+})

--- a/packages/baro-orchestrator/scripts/operator.ts
+++ b/packages/baro-orchestrator/scripts/operator.ts
@@ -5,6 +5,8 @@ import {
     runOperatorMcpServer,
 } from "../src/operator/host-tools-relay.js"
 import { runOperator } from "../src/operator/operator-session.js"
+import { JsonUi } from "../src/operator/json-ui.js"
+import { TerminalUi } from "../src/operator/terminal-ui.js"
 
 /* `baro operator`: a conversation with Claude Code in front and baro behind.
    The same bundle also serves as the MCP stdio child Claude spawns to reach
@@ -23,6 +25,7 @@ async function main(): Promise<void> {
     let effort: string | undefined
     let claudeBin: string | undefined
     let permission: "ask" | "auto" = "ask"
+    let protocol: "terminal" | "json" = "terminal"
     const baroArgs: string[] = []
     for (let index = 0; index < argv.length; index += 1) {
         const flag = argv[index]
@@ -51,6 +54,13 @@ async function main(): Promise<void> {
                 permission = value
                 index += 1
                 break
+            case "--protocol":
+                if (value !== "terminal" && value !== "json") {
+                    throw new Error("--protocol must be terminal or json")
+                }
+                protocol = value
+                index += 1
+                break
             case "--local-only":
                 baroArgs.push("--local-only")
                 break
@@ -61,21 +71,24 @@ async function main(): Promise<void> {
             case "--help":
             case "-h":
                 process.stdout.write(
-                    "usage: operator [--cwd <repo>] [--model opus] [--effort high] [--permission ask|auto] [--local-only] [--llm <backend>]\n",
+                    "usage: operator [--cwd <repo>] [--model opus] [--effort high] [--permission ask|auto] [--protocol terminal|json] [--local-only] [--llm <backend>]\n",
                 )
                 return
             default:
                 throw new Error(`unknown flag: ${flag}`)
         }
     }
-    await runOperator({
-        cwd,
-        ...(model ? { model } : {}),
-        ...(effort ? { effort } : {}),
-        ...(claudeBin ? { claudeBin } : {}),
-        permission,
-        baroArgs,
-    })
+    await runOperator(
+        {
+            cwd,
+            ...(model ? { model } : {}),
+            ...(effort ? { effort } : {}),
+            ...(claudeBin ? { claudeBin } : {}),
+            permission,
+            baroArgs,
+        },
+        protocol === "json" ? new JsonUi() : new TerminalUi(),
+    )
 }
 
 main().catch((error) => {

--- a/packages/baro-orchestrator/src/operator/host-tools-relay.ts
+++ b/packages/baro-orchestrator/src/operator/host-tools-relay.ts
@@ -1,0 +1,310 @@
+import { randomBytes, timingSafeEqual } from "node:crypto"
+import { createConnection, createServer, type Server, type Socket } from "node:net"
+import { StringDecoder } from "node:string_decoder"
+
+import type { HostFunction } from "../harness/lane-adapter.js"
+
+/* Host functions reachable from a Claude CLI living in another process: a
+   loopback JSON-lines relay in this process, and a stdio MCP server (this same
+   bundle in `__operator-mcp` mode) that the CLI spawns and that forwards every
+   tools/call here. General where the planner's relay was single-purpose. */
+
+export const OPERATOR_MCP_MODE = "__operator-mcp"
+export const OPERATOR_MCP_SERVER_NAME = "baro"
+const RELAY_TOKEN_ENV = "BARO_OPERATOR_RELAY_TOKEN"
+const LOOPBACK_HOST = "127.0.0.1"
+const RELAY_TIMEOUT_MS = 10 * 60_000
+const MAX_MESSAGE_BYTES = 4 * 1024 * 1024
+const MCP_PROTOCOL_VERSION = "2025-06-18"
+
+export interface RelayConnection {
+    readonly command: string
+    readonly args: readonly string[]
+    readonly env: Readonly<Record<string, string>>
+}
+
+export class HostToolsRelay {
+    private readonly token = randomBytes(32).toString("hex")
+    private readonly sockets = new Set<Socket>()
+    private server: Server | null = null
+
+    constructor(
+        private readonly functions: readonly HostFunction[],
+        private readonly instructions: string,
+    ) {}
+
+    async open(): Promise<RelayConnection> {
+        const server = createServer((socket) => this.handleSocket(socket))
+        this.server = server
+        await new Promise<void>((resolve, reject) => {
+            server.once("error", reject)
+            server.listen(0, LOOPBACK_HOST, () => resolve())
+        })
+        const address = server.address()
+        if (!address || typeof address === "string") {
+            throw new Error("operator relay did not receive a TCP port")
+        }
+        const entry = process.argv[1]
+        if (!entry) throw new Error("operator relay requires a script entry path")
+        return {
+            command: process.execPath,
+            args: [
+                ...process.execArgv,
+                entry,
+                OPERATOR_MCP_MODE,
+                "--bridge-host",
+                LOOPBACK_HOST,
+                "--bridge-port",
+                String(address.port),
+            ],
+            env: { [RELAY_TOKEN_ENV]: this.token },
+        }
+    }
+
+    async close(): Promise<void> {
+        const server = this.server
+        this.server = null
+        if (!server) return
+        await new Promise<void>((resolve) => {
+            server.close(() => resolve())
+            for (const socket of this.sockets) socket.destroy()
+        })
+    }
+
+    private handleSocket(socket: Socket): void {
+        this.sockets.add(socket)
+        socket.setEncoding("utf8")
+        socket.setTimeout(RELAY_TIMEOUT_MS, () => socket.destroy())
+        let buffer = ""
+        let handled = false
+        socket.on("data", (chunk: string) => {
+            if (handled) return
+            buffer += chunk
+            if (Buffer.byteLength(buffer, "utf8") > MAX_MESSAGE_BYTES) {
+                handled = true
+                reply(socket, { ok: false, error: "relay message exceeded the size limit" })
+                return
+            }
+            const newline = buffer.indexOf("\n")
+            if (newline < 0) return
+            handled = true
+            void this.dispatch(buffer.slice(0, newline))
+                .then((result) => reply(socket, { ok: true, result }))
+                .catch((error) => reply(socket, { ok: false, error: messageOf(error) }))
+        })
+        socket.on("error", () => undefined)
+        socket.on("close", () => this.sockets.delete(socket))
+    }
+
+    private async dispatch(line: string): Promise<unknown> {
+        let request: unknown
+        try {
+            request = JSON.parse(line)
+        } catch {
+            throw new Error("relay request is not valid JSON")
+        }
+        if (!isRecord(request) || !safeToken(request.token, this.token)) {
+            throw new Error("relay authentication failed")
+        }
+        if (request.type === "describe") {
+            return {
+                instructions: this.instructions,
+                tools: this.functions.map((fn) => ({
+                    name: fn.name,
+                    description: fn.description,
+                    inputSchema: fn.parameters,
+                })),
+            }
+        }
+        if (request.type === "call") {
+            const fn = this.functions.find((candidate) => candidate.name === request.name)
+            if (!fn) throw new Error(`unknown tool: ${String(request.name)}`)
+            return await fn.invoke(request.args)
+        }
+        throw new Error("relay request has an unknown type")
+    }
+}
+
+interface McpInvocation {
+    readonly host: string
+    readonly port: number
+    readonly token: string
+}
+
+export function parseOperatorMcpInvocation(
+    argv: readonly string[],
+    environment: Readonly<NodeJS.ProcessEnv> = process.env,
+): McpInvocation | null {
+    if (argv[0] !== OPERATOR_MCP_MODE) return null
+    let host: string | undefined
+    let port: number | undefined
+    for (let index = 1; index < argv.length; index += 2) {
+        const flag = argv[index]
+        const value = argv[index + 1]
+        if (flag === "--bridge-host") host = value
+        else if (flag === "--bridge-port") port = Number(value)
+        else throw new Error(`unknown operator MCP flag: ${flag}`)
+    }
+    const token = environment[RELAY_TOKEN_ENV]
+    if (host !== LOOPBACK_HOST) throw new Error("operator MCP bridge must use IPv4 loopback")
+    if (!Number.isInteger(port) || port! < 1 || port! > 65_535) {
+        throw new Error("operator MCP bridge port is invalid")
+    }
+    if (!token || !/^[a-f0-9]{64}$/u.test(token)) {
+        throw new Error("operator MCP bridge token is invalid")
+    }
+    return { host, port: port!, token }
+}
+
+/** The stdio side the CLI spawns: newline-delimited JSON-RPC, forwarded to the relay. */
+export async function runOperatorMcpServer(connection: McpInvocation): Promise<void> {
+    const decoder = new StringDecoder("utf8")
+    let buffer = ""
+    for await (const chunk of process.stdin) {
+        buffer += typeof chunk === "string" ? chunk : decoder.write(chunk)
+        let newline: number
+        while ((newline = buffer.indexOf("\n")) >= 0) {
+            const line = buffer.slice(0, newline).trim()
+            buffer = buffer.slice(newline + 1)
+            if (line) await handleLine(line, connection)
+        }
+    }
+}
+
+async function handleLine(line: string, connection: McpInvocation): Promise<void> {
+    let request: unknown
+    try {
+        request = JSON.parse(line)
+    } catch {
+        write({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } })
+        return
+    }
+    if (!isRecord(request) || request.jsonrpc !== "2.0") return
+    const id = request.id
+    const method = typeof request.method === "string" ? request.method : ""
+    if (id === undefined || !method) return
+    try {
+        switch (method) {
+            case "initialize": {
+                const described = (await callRelay(connection, { type: "describe" })) as {
+                    instructions: string
+                }
+                write({
+                    jsonrpc: "2.0",
+                    id,
+                    result: {
+                        protocolVersion: MCP_PROTOCOL_VERSION,
+                        capabilities: { tools: {} },
+                        serverInfo: { name: "baro-operator", version: "1.0.0" },
+                        instructions: described.instructions,
+                    },
+                })
+                return
+            }
+            case "ping":
+                write({ jsonrpc: "2.0", id, result: {} })
+                return
+            case "tools/list": {
+                const described = (await callRelay(connection, { type: "describe" })) as {
+                    tools: unknown[]
+                }
+                write({ jsonrpc: "2.0", id, result: { tools: described.tools } })
+                return
+            }
+            case "tools/call": {
+                const params = isRecord(request.params) ? request.params : {}
+                try {
+                    const result = await callRelay(connection, {
+                        type: "call",
+                        name: params.name,
+                        args: params.arguments,
+                    })
+                    const text = typeof result === "string" ? result : JSON.stringify(result)
+                    write({
+                        jsonrpc: "2.0",
+                        id,
+                        result: { content: [{ type: "text", text }], isError: false },
+                    })
+                } catch (error) {
+                    write({
+                        jsonrpc: "2.0",
+                        id,
+                        result: {
+                            content: [{ type: "text", text: `Error: ${messageOf(error)}` }],
+                            isError: true,
+                        },
+                    })
+                }
+                return
+            }
+            default:
+                write({ jsonrpc: "2.0", id, error: { code: -32601, message: "Method not found" } })
+        }
+    } catch (error) {
+        write({ jsonrpc: "2.0", id, error: { code: -32000, message: messageOf(error) } })
+    }
+}
+
+async function callRelay(connection: McpInvocation, request: Record<string, unknown>): Promise<unknown> {
+    return await new Promise<unknown>((resolve, reject) => {
+        const socket = createConnection({ host: connection.host, port: connection.port })
+        socket.setEncoding("utf8")
+        socket.setTimeout(RELAY_TIMEOUT_MS, () => socket.destroy(new Error("operator relay timed out")))
+        let buffer = ""
+        socket.once("connect", () => {
+            socket.write(JSON.stringify({ ...request, token: connection.token }) + "\n")
+        })
+        socket.on("data", (chunk: string) => {
+            buffer += chunk
+            const newline = buffer.indexOf("\n")
+            if (newline < 0) return
+            socket.destroy()
+            let response: unknown
+            try {
+                response = JSON.parse(buffer.slice(0, newline))
+            } catch {
+                reject(new Error("operator relay returned invalid JSON"))
+                return
+            }
+            if (!isRecord(response) || typeof response.ok !== "boolean") {
+                reject(new Error("operator relay returned an invalid response"))
+                return
+            }
+            if (!response.ok) {
+                reject(new Error(messageOf(response.error)))
+                return
+            }
+            resolve(response.result)
+        })
+        socket.once("error", reject)
+        socket.once("close", () => {
+            if (!buffer.includes("\n")) reject(new Error("operator relay closed without a response"))
+        })
+    })
+}
+
+function write(message: Record<string, unknown>): void {
+    process.stdout.write(JSON.stringify(message) + "\n")
+}
+
+function reply(socket: Socket, response: Record<string, unknown>): void {
+    if (socket.destroyed) return
+    socket.end(JSON.stringify(response) + "\n")
+}
+
+function safeToken(actual: unknown, expected: string): boolean {
+    if (typeof actual !== "string") return false
+    const left = Buffer.from(actual)
+    const right = Buffer.from(expected)
+    return left.length === right.length && timingSafeEqual(left, right)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function messageOf(value: unknown): string {
+    if (value instanceof Error) return value.message
+    if (typeof value === "string" && value.trim()) return value
+    return String(value)
+}

--- a/packages/baro-orchestrator/src/operator/json-ui.ts
+++ b/packages/baro-orchestrator/src/operator/json-ui.ts
@@ -39,6 +39,10 @@ export class JsonUi implements OperatorUi {
         this.emit({ type: "tool_call", name, summary })
     }
 
+    toolResult(summary: string): void {
+        this.emit({ type: "tool_result", summary })
+    }
+
     ask(prompt: string, meta: AskMeta): Promise<string> {
         this.askSequence += 1
         const id = `ask-${this.askSequence}`

--- a/packages/baro-orchestrator/src/operator/json-ui.ts
+++ b/packages/baro-orchestrator/src/operator/json-ui.ts
@@ -1,0 +1,124 @@
+import { createInterface } from "node:readline"
+
+import type { AskMeta, OperatorUi, RunRow, TurnResult, UiCommand } from "./ui.js"
+
+/* The wire the Rust TUI speaks: one JSON object per line on stdout, one per
+   line on stdin. Events out: ready, assistant_delta, tool_call, note,
+   ask (id, kind, prompt, tool, summary, options), turn_done, runs, exit.
+   Commands in: user {text}, answer {id, answer}, runs, status {id},
+   stop {id}, quit {stop_runs}. Documented in docs/operator-protocol.md. */
+export class JsonUi implements OperatorUi {
+    private handler: ((command: UiCommand) => void) | null = null
+    private readonly pendingAsks = new Map<string, (answer: string) => void>()
+    private askSequence = 0
+
+    constructor() {
+        createInterface({ input: process.stdin, crlfDelay: Number.POSITIVE_INFINITY })
+            .on("line", (line) => this.onLine(line))
+            .on("close", () => this.handler?.({ type: "quit", stopRuns: false }))
+    }
+
+    onCommand(handler: (command: UiCommand) => void): void {
+        this.handler = handler
+        this.emit({ type: "ready" })
+    }
+
+    banner(text: string): void {
+        this.emit({ type: "note", text })
+    }
+
+    stream(text: string): void {
+        this.emit({ type: "assistant_delta", text })
+    }
+
+    note(text: string): void {
+        this.emit({ type: "note", text: text.trim() })
+    }
+
+    toolCall(name: string, summary: string): void {
+        this.emit({ type: "tool_call", name, summary })
+    }
+
+    ask(prompt: string, meta: AskMeta): Promise<string> {
+        this.askSequence += 1
+        const id = `ask-${this.askSequence}`
+        return new Promise((resolve) => {
+            this.pendingAsks.set(id, resolve)
+            this.emit({
+                type: "ask",
+                id,
+                kind: meta.kind,
+                prompt,
+                ...(meta.tool ? { tool: meta.tool } : {}),
+                ...(meta.summary ? { summary: meta.summary } : {}),
+                options: meta.options,
+            })
+        })
+    }
+
+    turnDone(result: TurnResult): void {
+        this.emit({ type: "turn_done", duration_ms: result.durationMs, cost_usd: result.totalCostUsd })
+    }
+
+    runsChanged(rows: readonly RunRow[]): void {
+        this.emit({
+            type: "runs",
+            runs: rows.map((row) => ({
+                id: row.id,
+                state: row.state,
+                phase: row.phase,
+                completed: row.completed,
+                total: row.total,
+                goal: row.goal,
+                elapsed: row.elapsed,
+                ...(row.prUrl ? { pr_url: row.prUrl } : {}),
+            })),
+        })
+    }
+
+    close(): void {
+        this.emit({ type: "exit" })
+    }
+
+    private onLine(line: string): void {
+        let command: Record<string, unknown>
+        try {
+            command = JSON.parse(line) as Record<string, unknown>
+        } catch {
+            return
+        }
+        switch (command.type) {
+            case "user":
+                if (typeof command.text === "string" && command.text.trim()) {
+                    this.handler?.({ type: "user", text: command.text.trim() })
+                }
+                return
+            case "answer": {
+                const resolve = this.pendingAsks.get(String(command.id))
+                if (resolve) {
+                    this.pendingAsks.delete(String(command.id))
+                    resolve(String(command.answer ?? "").trim())
+                }
+                return
+            }
+            case "runs":
+                this.handler?.({ type: "runs" })
+                return
+            case "status":
+                this.handler?.({ type: "status", id: String(command.id ?? "") })
+                return
+            case "stop":
+                this.handler?.({ type: "stop", id: String(command.id ?? "") })
+                return
+            case "quit":
+                this.handler?.({ type: "quit", stopRuns: command.stop_runs === true })
+                return
+            default:
+                return
+        }
+    }
+
+    private emit(event: Record<string, unknown>): void {
+        process.stdout.write(JSON.stringify({ ...event, ts: new Date().toISOString() }) + "\n")
+    }
+}

--- a/packages/baro-orchestrator/src/operator/json-ui.ts
+++ b/packages/baro-orchestrator/src/operator/json-ui.ts
@@ -75,6 +75,8 @@ export class JsonUi implements OperatorUi {
                 total: row.total,
                 goal: row.goal,
                 elapsed: row.elapsed,
+                ...(row.startedMs !== undefined ? { started_ms: row.startedMs } : {}),
+                ...(row.finishedMs !== undefined ? { finished_ms: row.finishedMs } : {}),
                 ...(row.prUrl ? { pr_url: row.prUrl } : {}),
             })),
         })

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -355,7 +355,20 @@ class Renderer extends BaseObserver {
 
 /** First meaningful line of a tool's output, and how much more there was. */
 function summarizeToolOutput(output: unknown): string {
-    const text = typeof output === "string" ? output : JSON.stringify(output)
+    // Claude's tool_result content is an InputText array; a plain string
+    // arrives from providers that never block their output.
+    const text =
+        typeof output === "string"
+            ? output
+            : Array.isArray(output)
+              ? output
+                    .map((block) =>
+                        typeof block === "object" && block !== null && typeof (block as { text?: unknown }).text === "string"
+                            ? (block as { text: string }).text
+                            : "",
+                    )
+                    .join("\n")
+              : JSON.stringify(output)
     const lines = text
         .replace(/\u001b\[[0-9;]*m/g, "")
         .split("\n")

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -78,11 +78,12 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
     })
 
     const alwaysAllowed = new Set<string>()
-    // Files edited in the current turn. A strong model prefers to do the work
-    // itself; the third distinct file in one turn is where "direct" has become
-    // a multi-file job and the edit is refused with the remedy instead.
+    // Files edited in the current turn. Measured 9.9.2026: the operator built a
+    // four-file CLI with tests in under a minute, while baro spent seven on
+    // intake and architect for three helpers. Direct work is capped where it
+    // stops being one component; past that the edit is refused with the remedy.
     const editedThisTurn = new Set<string>()
-    const DIRECT_FILE_LIMIT = 2
+    const DIRECT_FILE_LIMIT = 5
     const ask = (question: string): Promise<string> =>
         new Promise((resolve) => {
             asking = true
@@ -406,10 +407,10 @@ function summarizeToolInput(name: string, input: unknown): string {
 function systemPrompt(cwd: string): string {
     return `You are baro's operator: a coding agent working inside the repository at ${cwd}, with baro as your back office. baro runs multi-story goals as a verified pipeline (architect, planner, parallel coding agents, independent per-story review, verification, pull request) in the background through the \`delegate\` tool.
 
-Every request gets an altitude. Your FIRST line of every reply is the altitude and a short reason, e.g. "direct — one file plus its test." Decide before you touch anything; reading a file or two to decide is fine.
+Every request gets an altitude. Your FIRST line of every reply is the altitude and a short reason, e.g. "direct — one component, five files, tests exist." Decide before you touch anything; reading a file or two to decide is fine.
 - answer: questions, explanations, lookups. Reply directly.
-- direct: at most two files (a file and its test), clear intent, no new component. Do it yourself like a normal coding agent: edit, run the relevant tests, say what changed. Do not commit unless asked. Never push and never open a pull request yourself. The host refuses a third file in one turn; when that happens, delegate.
-- delegate: anything else. Three or more files, a new component (a CLI, a module, a package entry) plus its tests or docs, work in several parts, unclear scope, or anything the user asks to run through baro. Being able to do it yourself is not a reason to; baro gives it a plan, parallel agents, independent review and a verified pull request. Call \`delegate\` with a precise, self-contained goal (what, where, constraints, how to verify); baro's planner reads only that text. It returns at once with a run id and the run continues in the background. Do not poll in a loop. Tell the user the run id and one sentence on what to expect, then keep talking.
+- direct: one component you can finish in roughly ten minutes, up to five files, clear intent. Do it yourself like a normal coding agent: edit, run the relevant tests, say what changed. Do not commit unless asked. Never push and never open a pull request yourself. The host refuses a sixth file in one turn; when that happens, delegate the rest.
+- delegate: work whose scope you cannot see to the end, changes across several modules or owned by different people, anything that needs independent review and a verified pull request, or anything the user asks to run through baro. baro has a fixed cost: intake, architect and goal contract take ten to fifteen minutes before the first story starts, whatever the size. So for a goal you could finish directly in a few minutes, say so and offer the choice in one line ("direct in ~3 min, or baro in ~15 with review and a PR?") instead of delegating by default. When you delegate, call \`delegate\` with a precise, self-contained goal (what, where, constraints, how to verify); baro's planner reads only that text. Warn first if the working tree has uncommitted changes the goal depends on: baro's agents work from the last commit. It returns at once with a run id and the run continues in the background. Do not poll in a loop. Tell the user the run id and one sentence on what to expect, then keep talking.
 
 When asked what the agents are doing, call \`run_status\` (or \`runs\`) and summarize plainly: phase, stories done of total, last activity, recent milestones. When a run finishes you receive a message starting with [baro]; report the outcome and the pull request link if there is one. If the user overrides your altitude ("just do it yourself" / "send it to baro"), follow them.
 

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -1,5 +1,5 @@
 import { AgenticEnvironment, BaseObserver } from "../runtime/mozaik.js"
-import type { Participant, SemanticEvent } from "../runtime/mozaik.js"
+import type { FunctionCallOutputItem, Participant, SemanticEvent } from "../runtime/mozaik.js"
 import { AgentResult, ClaudeStreamChunk } from "../events/harness-stream.js"
 import { ClaudeCliParticipant } from "../harness/claude/cli-participant.js"
 import type { HostFunction } from "../harness/lane-adapter.js"
@@ -296,6 +296,10 @@ class Renderer extends BaseObserver {
         super()
     }
 
+    override onExternalFunctionCallOutput(_source: Participant, item: FunctionCallOutputItem): void {
+        this.ui.toolResult(summarizeToolOutput(item.output))
+    }
+
     override onExternalEvent(_source: Participant, event: SemanticEvent<unknown>): void {
         if (ClaudeStreamChunk.is(event)) {
             this.render(event.data.raw)
@@ -347,6 +351,20 @@ class Renderer extends BaseObserver {
                 return
         }
     }
+}
+
+/** First meaningful line of a tool's output, and how much more there was. */
+function summarizeToolOutput(output: unknown): string {
+    const text = typeof output === "string" ? output : JSON.stringify(output)
+    const lines = text
+        .replace(/\u001b\[[0-9;]*m/g, "")
+        .split("\n")
+        .map((line) => line.trimEnd())
+        .filter((line) => line.trim().length > 0)
+    if (lines.length === 0) return "(no output)"
+    const first = lines[0]!.trim()
+    const head = first.length > 120 ? `${first.slice(0, 119)}…` : first
+    return lines.length > 1 ? `${head}  (+${lines.length - 1} lines)` : head
 }
 
 function summarizeToolInput(name: string, input: unknown): string {

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -93,7 +93,7 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
     // intake and architect for three helpers. Direct work is capped where it
     // stops being one component; past that the edit is refused with the remedy.
     const editedThisTurn = new Set<string>()
-    const DIRECT_FILE_LIMIT = 5
+    const DIRECT_FILE_LIMIT = 10
     // Parallel tool calls arrive as parallel permission checks; they are asked
     // one at a time, in order, and an "always" answer settles the rest.
     let askChain: Promise<unknown> = Promise.resolve()
@@ -431,9 +431,9 @@ function summarizeToolInput(name: string, input: unknown): string {
 function systemPrompt(cwd: string): string {
     return `You are baro's operator: a coding agent working inside the repository at ${cwd}, with baro as your back office. baro runs multi-story goals as a verified pipeline (architect, planner, parallel coding agents, independent per-story review, verification, pull request) in the background through the \`delegate\` tool.
 
-Every request gets an altitude. Your FIRST line of every reply is the altitude and a short reason, e.g. "direct — one component, five files, tests exist." Decide before you touch anything; reading a file or two to decide is fine.
+Every request gets an altitude. Your FIRST line of every reply is the altitude and a short reason, e.g. "direct — one component, eight files, tests exist." Decide before you touch anything; reading a file or two to decide is fine.
 - answer: questions, explanations, lookups. Reply directly.
-- direct: one component you can finish in roughly ten minutes, up to five files, clear intent. Do it yourself like a normal coding agent: edit, run the relevant tests, say what changed. Do not commit unless asked. Never push and never open a pull request yourself. The host refuses a sixth file in one turn; when that happens, delegate the rest.
+- direct: one component you can finish in roughly ten minutes, clear intent, typically up to eight files. Do it yourself like a normal coding agent: edit, run the relevant tests, say what changed. Finish the whole thing in one turn; do not split a job to stay under a limit. Do not commit unless asked. Never push and never open a pull request yourself. The host refuses the eleventh file in one turn as a runaway-scope guard; if you hit it, delegate the rest.
 - delegate: work whose scope you cannot see to the end, changes across several modules or owned by different people, anything that needs independent review and a verified pull request, or anything the user asks to run through baro. baro has a fixed cost: intake, architect and goal contract take ten to fifteen minutes before the first story starts, whatever the size. So for a goal you could finish directly in a few minutes, say so and offer the choice in one line ("direct in ~3 min, or baro in ~15 with review and a PR?") instead of delegating by default. When you delegate, call \`delegate\` with a precise, self-contained goal (what, where, constraints, how to verify); baro's planner reads only that text. Warn first if the working tree has uncommitted changes the goal depends on: baro's agents work from the last commit. It returns at once with a run id and the run continues in the background. Do not poll in a loop. Tell the user the run id and one sentence on what to expect, then keep talking.
 
 When asked what the agents are doing, call \`run_status\` (or \`runs\`) and summarize plainly: phase, stories done of total, last activity, recent milestones. When a run finishes you receive a message starting with [baro]; report the outcome and the pull request link if there is one. If the user overrides your altitude ("just do it yourself" / "send it to baro"), follow them.

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -288,6 +288,8 @@ export async function runOperator(options: OperatorOptions, ui: OperatorUi): Pro
 class Renderer extends BaseObserver {
     /** Tool calls in flight, by content block index; input arrives as JSON deltas. */
     private readonly toolBlocks = new Map<number, { name: string; json: string }>()
+    /** Claude Code's internal schema loader; neither its call nor its result is news. */
+    private hiddenResults = 0
 
     constructor(
         private readonly ui: OperatorUi,
@@ -297,6 +299,10 @@ class Renderer extends BaseObserver {
     }
 
     override onExternalFunctionCallOutput(_source: Participant, item: FunctionCallOutputItem): void {
+        if (this.hiddenResults > 0) {
+            this.hiddenResults -= 1
+            return
+        }
         this.ui.toolResult(summarizeToolOutput(item.output))
     }
 
@@ -342,6 +348,10 @@ class Renderer extends BaseObserver {
                     input = pending.json ? JSON.parse(pending.json) : {}
                 } catch {
                     input = {}
+                }
+                if (pending.name === "ToolSearch") {
+                    this.hiddenResults += 1
+                    return
                 }
                 const name = pending.name.replace(`mcp__${OPERATOR_MCP_SERVER_NAME}__`, "baro ")
                 this.ui.toolCall(name, summarizeToolInput(name, input))
@@ -413,8 +423,8 @@ function summarizeToolInput(name: string, input: unknown): string {
 function systemPrompt(cwd: string): string {
     return `You are baro's operator: a coding agent working inside the repository at ${cwd}, with baro as your back office. baro runs multi-story goals as a verified pipeline (architect, planner, parallel coding agents, independent per-story review, verification, pull request) in the background through the \`delegate\` tool.
 
-Every request gets an altitude. Your FIRST line of every reply is the altitude and a short reason, e.g. "direct — one component, eight files, tests exist." Decide before you touch anything; reading a file or two to decide is fine.
-- answer: questions, explanations, lookups. Reply directly.
+Every request gets an altitude. Decide before you touch anything; reading a file or two to decide is fine. When the altitude is direct or delegate, say it in your FIRST line with a short reason, e.g. "direct — one component, eight files, tests exist." For an answer, never announce the altitude; just answer.
+- answer: questions, explanations, lookups. Reply directly, no preamble.
 - direct: one component you can finish in roughly ten minutes, clear intent, typically up to eight files. Do it yourself like a normal coding agent: edit, run the relevant tests, say what changed. Finish the whole thing in one turn; do not split a job to stay under a limit. Do not commit unless asked. Never push and never open a pull request yourself. The host refuses the eleventh file in one turn as a runaway-scope guard; if you hit it, delegate the rest.
 - delegate: work whose scope you cannot see to the end, changes across several modules or owned by different people, anything that needs independent review and a verified pull request, or anything the user asks to run through baro. baro has a fixed cost: intake, architect and goal contract take ten to fifteen minutes before the first story starts, whatever the size. So for a goal you could finish directly in a few minutes, say so and offer the choice in one line ("direct in ~3 min, or baro in ~15 with review and a PR?") instead of delegating by default. When you delegate, call \`delegate\` with a precise, self-contained goal (what, where, constraints, how to verify); baro's planner reads only that text. Warn first if the working tree has uncommitted changes the goal depends on: baro's agents work from the last commit. It returns at once with a run id and the run continues in the background. Do not poll in a loop. Tell the user the run id and one sentence on what to expect, then keep talking.
 

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -1,0 +1,384 @@
+import { createInterface, clearLine, cursorTo, type Interface } from "node:readline"
+
+import { AgenticEnvironment, BaseObserver } from "../runtime/mozaik.js"
+import type { Participant, SemanticEvent } from "../runtime/mozaik.js"
+import { AgentResult, ClaudeStreamChunk } from "../events/harness-stream.js"
+import { ClaudeCliParticipant } from "../harness/claude/cli-participant.js"
+import type { HostFunction } from "../harness/lane-adapter.js"
+import { HostToolsRelay, OPERATOR_MCP_SERVER_NAME } from "./host-tools-relay.js"
+import { RunRegistry } from "./run-registry.js"
+
+/* One conversation that outlives its runs. Claude Code is the operator: it
+   answers, edits directly, or delegates to baro, and says which. Everything
+   baro does arrives here as protocol events, so "what are they doing" is a
+   question the operator can answer from the registry, not from a log. */
+
+export interface OperatorOptions {
+    readonly cwd: string
+    readonly model?: string
+    readonly effort?: string
+    readonly claudeBin?: string
+    /** `ask` routes Claude's permission prompts to this terminal; `auto` bypasses them. */
+    readonly permission: "ask" | "auto"
+    readonly baroArgs?: readonly string[]
+}
+
+const AGENT_ID = "operator"
+const DIM = "[2m"
+const RESET = "[0m"
+const AMBER = "[33m"
+
+export async function runOperator(options: OperatorOptions): Promise<void> {
+    const out = process.stdout
+    const rl = createInterface({ input: process.stdin, output: out, prompt: "you › " })
+    let busy = false
+    let asking = false
+    let lineOpen = false
+
+    const clearPrompt = (): void => {
+        if (asking) return
+        clearLine(out, 0)
+        cursorTo(out, 0)
+    }
+    const reprompt = (): void => {
+        if (!busy && !asking) rl.prompt(true)
+    }
+    const note = (text: string): void => {
+        clearPrompt()
+        if (lineOpen) {
+            out.write("\n")
+            lineOpen = false
+        }
+        out.write(`${DIM}${text}${RESET}\n`)
+        reprompt()
+    }
+    const stream = (text: string): void => {
+        if (!lineOpen) clearPrompt()
+        out.write(text)
+        lineOpen = !text.endsWith("\n")
+    }
+
+    const registry = new RunRegistry({
+        ...(options.baroArgs ? { baroArgs: options.baroArgs } : {}),
+        onMilestone: (run, line) => note(`  ${run.id} · ${line}`),
+        onFinished: (run, outcome) => {
+            note(`  ${run.id} · finished (${run.terminal})`)
+            busy = true
+            participant.sendUserMessage(
+                `[baro] ${run.id} finished.\n${outcome}\n\nTell the user in two or three sentences what happened and what they can do next.`,
+            )
+        },
+    })
+
+    const alwaysAllowed = new Set<string>()
+    const ask = (question: string): Promise<string> =>
+        new Promise((resolve) => {
+            asking = true
+            if (lineOpen) {
+                out.write("\n")
+                lineOpen = false
+            }
+            rl.question(question, (answer) => {
+                asking = false
+                resolve(answer.trim())
+            })
+        })
+
+    const functions: HostFunction[] = [
+        {
+            name: "delegate",
+            description:
+                "Start a baro run in the background for a multi-story goal. Returns the run id at once; the run keeps going while the conversation continues.",
+            parameters: {
+                type: "object",
+                properties: {
+                    goal: {
+                        type: "string",
+                        description:
+                            "Self-contained goal: what to build, where, constraints, how to verify. baro's planner reads only this.",
+                    },
+                    cwd: { type: "string", description: "Repository path; defaults to the session repository." },
+                },
+                required: ["goal"],
+                additionalProperties: false,
+            },
+            invoke: async (args) => {
+                const { goal, cwd } = args as { goal?: unknown; cwd?: unknown }
+                if (typeof goal !== "string" || !goal.trim()) throw new Error("delegate requires a goal")
+                const run = registry.delegate(goal.trim(), typeof cwd === "string" && cwd ? cwd : options.cwd)
+                note(`  ${run.id} · delegated: ${run.goal.slice(0, 90)}`)
+                return `${run.id} started in the background (cwd ${run.cwd}). Intake and planning take a few minutes before stories start; ask run_status for progress.`
+            },
+        },
+        {
+            name: "runs",
+            description: "List every run of this session with state, phase and progress.",
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+            invoke: async () => registry.table(),
+        },
+        {
+            name: "run_status",
+            description: "Where one run is: phase, stories done/total, last activity, recent milestones, or its outcome.",
+            parameters: {
+                type: "object",
+                properties: { run_id: { type: "string" } },
+                required: ["run_id"],
+                additionalProperties: false,
+            },
+            invoke: async (args) => registry.status(String((args as { run_id?: unknown }).run_id ?? "")),
+        },
+        {
+            name: "stop",
+            description: "Stop a running baro run. Work already merged stays on the branch.",
+            parameters: {
+                type: "object",
+                properties: { run_id: { type: "string" } },
+                required: ["run_id"],
+                additionalProperties: false,
+            },
+            invoke: async (args) => {
+                const id = String((args as { run_id?: unknown }).run_id ?? "")
+                return registry.stop(id) ? `${id} stopping` : `${id} is not running`
+            },
+        },
+    ]
+    if (options.permission === "ask") {
+        functions.push({
+            name: "permission",
+            description: "Internal: asks the person at the terminal before a tool runs.",
+            parameters: {
+                type: "object",
+                properties: { tool_name: { type: "string" }, input: { type: "object" } },
+                required: ["tool_name", "input"],
+            },
+            invoke: async (args) => {
+                const { tool_name: tool, input } = args as { tool_name?: string; input?: unknown }
+                const name = tool ?? "tool"
+                if (alwaysAllowed.has(name)) {
+                    return JSON.stringify({ behavior: "allow", updatedInput: input })
+                }
+                const answer = await ask(
+                    `${AMBER}⚠ ${name}${RESET} ${summarizeToolInput(name, input)}\n  allow? [y/N/a=always for ${name}] `,
+                )
+                if (answer === "a" || answer === "always") alwaysAllowed.add(name)
+                if (answer === "y" || answer === "yes" || answer === "a" || answer === "always") {
+                    return JSON.stringify({ behavior: "allow", updatedInput: input })
+                }
+                return JSON.stringify({ behavior: "deny", message: "the user declined at the terminal" })
+            },
+        })
+    }
+
+    const relay = new HostToolsRelay(functions, "baro operator tools")
+    const connection = await relay.open()
+    for (const [name, value] of Object.entries(connection.env)) process.env[name] = value
+
+    const toolNames = functions
+        .filter((fn) => fn.name !== "permission")
+        .map((fn) => `mcp__${OPERATOR_MCP_SERVER_NAME}__${fn.name}`)
+    const participant = new ClaudeCliParticipant(AGENT_ID, {
+        cwd: options.cwd,
+        ...(options.model ? { model: options.model } : {}),
+        ...(options.effort ? { effort: options.effort } : {}),
+        ...(options.claudeBin ? { claudeBin: options.claudeBin } : {}),
+        includePartialMessages: true,
+        replayUserMessages: false,
+        permissionMode: options.permission === "ask" ? "default" : "bypassPermissions",
+        extraArgs: [
+            "--strict-mcp-config",
+            "--mcp-config",
+            JSON.stringify({
+                mcpServers: {
+                    [OPERATOR_MCP_SERVER_NAME]: {
+                        type: "stdio",
+                        command: connection.command,
+                        args: connection.args,
+                        // Claude expands ${VAR} from its own environment, so
+                        // the relay secret never enters argv.
+                        env: Object.fromEntries(Object.keys(connection.env).map((n) => [n, `\${${n}}`])),
+                    },
+                },
+            }),
+            "--allowed-tools",
+            toolNames.join(","),
+            ...(options.permission === "ask"
+                ? ["--permission-prompt-tool", `mcp__${OPERATOR_MCP_SERVER_NAME}__permission`]
+                : []),
+            "--system-prompt",
+            systemPrompt(options.cwd),
+        ],
+    })
+
+    const env = new AgenticEnvironment("baro-operator")
+    const renderer = new Renderer(stream, note, (result) => {
+        if (lineOpen) {
+            out.write("\n")
+            lineOpen = false
+        }
+        const facts = [
+            result.durationMs !== null ? `${(result.durationMs / 1000).toFixed(0)}s` : undefined,
+            result.totalCostUsd !== null ? `$${result.totalCostUsd.toFixed(2)}` : undefined,
+        ].filter(Boolean)
+        if (facts.length) out.write(`${DIM}· ${facts.join(" · ")}${RESET}\n`)
+        busy = false
+        reprompt()
+    })
+    renderer.join(env)
+    participant.join(env)
+    participant.start(env)
+
+    out.write(
+        `${DIM}baro operator · ${options.model ?? "default model"} · ${options.cwd}\n` +
+            `/runs  /status <id>  /stop <id>  /quit${RESET}\n`,
+    )
+
+    let closing = false
+    const shutdown = async (): Promise<void> => {
+        if (closing) return
+        closing = true
+        const running = registry.running()
+        if (running.length > 0) {
+            const answer = await ask(
+                `${running.length} run(s) still running (${running.map((r) => r.id).join(", ")}). stop them? [y/N] `,
+            )
+            if (answer === "y" || answer === "yes") for (const run of running) registry.stop(run.id)
+            else out.write(`${DIM}leaving them running; stop later with: baro stop <id>${RESET}\n`)
+        }
+        participant.closeStdin()
+        await Promise.race([participant.done, new Promise((r) => setTimeout(r, 4_000))])
+        await participant.abortAndWait()
+        await relay.close()
+        rl.close()
+        process.exit(0)
+    }
+
+    rl.on("line", (line) => {
+        const text = line.trim()
+        if (!text) {
+            reprompt()
+            return
+        }
+        if (text === "/quit" || text === "/exit") {
+            void shutdown()
+            return
+        }
+        if (text === "/runs") {
+            note(registry.table())
+            return
+        }
+        if (text.startsWith("/status")) {
+            note(registry.status(text.split(/\s+/)[1] ?? ""))
+            return
+        }
+        if (text.startsWith("/stop")) {
+            const id = text.split(/\s+/)[1] ?? ""
+            note(registry.stop(id) ? `${id} stopping` : `${id} is not running`)
+            return
+        }
+        busy = true
+        participant.sendUserMessage(text)
+    })
+    rl.on("close", () => void shutdown())
+    rl.on("SIGINT", () => void shutdown())
+    rl.prompt()
+
+    await participant.done
+    if (!closing) {
+        out.write(`${DIM}operator session ended: ${participant.sessionEndDetail()}${RESET}\n`)
+        await relay.close()
+        rl.close()
+        process.exit(1)
+    }
+}
+
+class Renderer extends BaseObserver {
+    constructor(
+        private readonly stream: (text: string) => void,
+        private readonly note: (text: string) => void,
+        private readonly onResult: (result: { durationMs: number | null; totalCostUsd: number | null }) => void,
+    ) {
+        super()
+    }
+
+    override onExternalEvent(_source: Participant, event: SemanticEvent<unknown>): void {
+        if (ClaudeStreamChunk.is(event)) {
+            this.render(event.data.raw)
+            return
+        }
+        if (AgentResult.is(event) && event.data.agentId === AGENT_ID) {
+            this.onResult(event.data)
+        }
+    }
+
+    /** Tool calls in flight, by content block index; input arrives as JSON deltas. */
+    private readonly toolBlocks = new Map<number, { name: string; json: string }>()
+
+    private render(raw: Readonly<Record<string, unknown>>): void {
+        if (raw.type !== "stream_event") return
+        const inner = raw.event as Record<string, unknown> | undefined
+        if (!inner) return
+        const index = typeof inner.index === "number" ? inner.index : -1
+        const delta = inner.delta as Record<string, unknown> | undefined
+        switch (inner.type) {
+            case "content_block_start": {
+                const block = inner.content_block as Record<string, unknown> | undefined
+                if (block?.type === "tool_use") {
+                    this.toolBlocks.set(index, { name: String(block.name ?? "tool"), json: "" })
+                }
+                return
+            }
+            case "content_block_delta": {
+                if (delta?.type === "text_delta") {
+                    this.stream(String(delta.text ?? ""))
+                } else if (delta?.type === "input_json_delta") {
+                    const pending = this.toolBlocks.get(index)
+                    if (pending) pending.json += String(delta.partial_json ?? "")
+                }
+                return
+            }
+            case "content_block_stop": {
+                const pending = this.toolBlocks.get(index)
+                if (!pending) return
+                this.toolBlocks.delete(index)
+                let input: unknown = {}
+                try {
+                    input = pending.json ? JSON.parse(pending.json) : {}
+                } catch {
+                    input = {}
+                }
+                const name = pending.name.replace(`mcp__${OPERATOR_MCP_SERVER_NAME}__`, "baro ")
+                this.note(`  ⚙ ${name} ${summarizeToolInput(name, input)}`)
+                return
+            }
+            default:
+                return
+        }
+    }
+}
+
+function summarizeToolInput(name: string, input: unknown): string {
+    const record = (typeof input === "object" && input !== null ? input : {}) as Record<string, unknown>
+    const pick = (...keys: string[]): string => {
+        for (const key of keys) {
+            const value = record[key]
+            if (typeof value === "string" && value) return value
+        }
+        return ""
+    }
+    const text = pick("file_path", "command", "pattern", "goal", "run_id", "path", "url")
+    const single = text.replace(/\s+/g, " ")
+    return single.length > 100 ? `${single.slice(0, 99)}…` : single
+}
+
+function systemPrompt(cwd: string): string {
+    return `You are baro's operator: a coding agent working inside the repository at ${cwd}, with baro as your back office. baro runs multi-story goals as a verified pipeline (architect, planner, parallel coding agents, independent per-story review, verification, pull request) in the background through the \`delegate\` tool.
+
+Choose an altitude for every request and state it in one short line before acting:
+- answer: questions, explanations, lookups. Reply directly; read files if needed.
+- direct: small, well-bounded changes (one or two files, clear intent, tests exist or are trivial). Do it yourself like a normal coding agent: edit, run the relevant tests, say what changed. Do not commit unless asked. Never push and never open a pull request yourself.
+- delegate: multi-file or multi-module work, features with several parts, unclear scope, or anything the user asks to run through baro. Call \`delegate\` with a precise, self-contained goal (what, where, constraints, how to verify); baro's planner reads only that text. It returns at once with a run id and the run continues in the background. Do not poll in a loop. Tell the user the run id and one sentence on what to expect, then keep talking.
+
+When asked what the agents are doing, call \`run_status\` (or \`runs\`) and summarize plainly: phase, stories done of total, last activity, recent milestones. When a run finishes you receive a message starting with [baro]; report the outcome and the pull request link if there is one. Escalate from direct to delegate the moment a "small" change turns out to touch many files. If the user overrides your altitude, follow them.
+
+Keep replies short and concrete.`
+}

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -71,6 +71,11 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
     })
 
     const alwaysAllowed = new Set<string>()
+    // Files edited in the current turn. A strong model prefers to do the work
+    // itself; the third distinct file in one turn is where "direct" has become
+    // a multi-file job and the edit is refused with the remedy instead.
+    const editedThisTurn = new Set<string>()
+    const DIRECT_FILE_LIMIT = 2
     const ask = (question: string): Promise<string> =>
         new Promise((resolve) => {
             asking = true
@@ -154,6 +159,19 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
             invoke: async (args) => {
                 const { tool_name: tool, input } = args as { tool_name?: string; input?: unknown }
                 const name = tool ?? "tool"
+                if (name === "Edit" || name === "Write" || name === "MultiEdit" || name === "NotebookEdit") {
+                    const path = summarizeToolInput(name, input)
+                    if (path && !editedThisTurn.has(path) && editedThisTurn.size >= DIRECT_FILE_LIMIT) {
+                        note(`  ✋ ${name} ${path} refused: direct work is capped at ${DIRECT_FILE_LIMIT} files per turn`)
+                        return JSON.stringify({
+                            behavior: "deny",
+                            message:
+                                `This change now spans more than ${DIRECT_FILE_LIMIT} files (${[...editedThisTurn, path].join(", ")}). ` +
+                                "That is delegate altitude: stop editing, revert nothing, and call the delegate tool with a self-contained goal that includes the files you already touched.",
+                        })
+                    }
+                    if (path) editedThisTurn.add(path)
+                }
                 if (alwaysAllowed.has(name)) {
                     return JSON.stringify({ behavior: "allow", updatedInput: input })
                 }
@@ -220,6 +238,7 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
             result.totalCostUsd !== null ? `$${result.totalCostUsd.toFixed(2)}` : undefined,
         ].filter(Boolean)
         if (facts.length) out.write(`${DIM}· ${facts.join(" · ")}${RESET}\n`)
+        editedThisTurn.clear()
         busy = false
         reprompt()
     })
@@ -373,12 +392,12 @@ function summarizeToolInput(name: string, input: unknown): string {
 function systemPrompt(cwd: string): string {
     return `You are baro's operator: a coding agent working inside the repository at ${cwd}, with baro as your back office. baro runs multi-story goals as a verified pipeline (architect, planner, parallel coding agents, independent per-story review, verification, pull request) in the background through the \`delegate\` tool.
 
-Choose an altitude for every request and state it in one short line before acting:
-- answer: questions, explanations, lookups. Reply directly; read files if needed.
-- direct: small, well-bounded changes (one or two files, clear intent, tests exist or are trivial). Do it yourself like a normal coding agent: edit, run the relevant tests, say what changed. Do not commit unless asked. Never push and never open a pull request yourself.
-- delegate: multi-file or multi-module work, features with several parts, unclear scope, or anything the user asks to run through baro. Call \`delegate\` with a precise, self-contained goal (what, where, constraints, how to verify); baro's planner reads only that text. It returns at once with a run id and the run continues in the background. Do not poll in a loop. Tell the user the run id and one sentence on what to expect, then keep talking.
+Every request gets an altitude. Your FIRST line of every reply is the altitude and a short reason, e.g. "direct — one file plus its test." Decide before you touch anything; reading a file or two to decide is fine.
+- answer: questions, explanations, lookups. Reply directly.
+- direct: at most two files (a file and its test), clear intent, no new component. Do it yourself like a normal coding agent: edit, run the relevant tests, say what changed. Do not commit unless asked. Never push and never open a pull request yourself. The host refuses a third file in one turn; when that happens, delegate.
+- delegate: anything else. Three or more files, a new component (a CLI, a module, a package entry) plus its tests or docs, work in several parts, unclear scope, or anything the user asks to run through baro. Being able to do it yourself is not a reason to; baro gives it a plan, parallel agents, independent review and a verified pull request. Call \`delegate\` with a precise, self-contained goal (what, where, constraints, how to verify); baro's planner reads only that text. It returns at once with a run id and the run continues in the background. Do not poll in a loop. Tell the user the run id and one sentence on what to expect, then keep talking.
 
-When asked what the agents are doing, call \`run_status\` (or \`runs\`) and summarize plainly: phase, stories done of total, last activity, recent milestones. When a run finishes you receive a message starting with [baro]; report the outcome and the pull request link if there is one. Escalate from direct to delegate the moment a "small" change turns out to touch many files. If the user overrides your altitude, follow them.
+When asked what the agents are doing, call \`run_status\` (or \`runs\`) and summarize plainly: phase, stories done of total, last activity, recent milestones. When a run finishes you receive a message starting with [baro]; report the outcome and the pull request link if there is one. If the user overrides your altitude ("just do it yourself" / "send it to baro"), follow them.
 
 Keep replies short and concrete.`
 }

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -355,15 +355,22 @@ class Renderer extends BaseObserver {
 
 /** First meaningful line of a tool's output, and how much more there was. */
 function summarizeToolOutput(output: unknown): string {
-    // Claude's tool_result content is an InputText array; a plain string
-    // arrives from providers that never block their output.
+    // Claude's tool_result content reaches us as mozaik InputText: an
+    // array-like object of {type, text} blocks that only looks like an array
+    // once serialized. A plain string comes from providers that never block.
     let value: unknown = output
     if (typeof value === "string" && /^\s*\[/.test(value)) {
-        // The stream mapper serializes the content array to a string.
         try {
             value = JSON.parse(value)
         } catch {
             /* plain text that happens to start with a bracket */
+        }
+    }
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        try {
+            value = JSON.parse(JSON.stringify(value))
+        } catch {
+            value = String(value)
         }
     }
     const text =

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -18,7 +18,7 @@ export interface OperatorOptions {
     readonly model?: string
     readonly effort?: string
     readonly claudeBin?: string
-    /** `ask` routes Claude's permission prompts to the surface; `auto` bypasses them. */
+    /** `auto` allows every tool (Claude Code auto mode); `ask` routes each prompt to the surface. */
     readonly permission: "ask" | "auto"
     readonly baroArgs?: readonly string[]
 }
@@ -131,10 +131,11 @@ export async function runOperator(options: OperatorOptions, ui: OperatorUi): Pro
             },
         },
     ]
-    if (options.permission === "ask") {
-        functions.push({
+    // Always wired, even in auto mode: it is where the runaway-scope guard
+    // lives and how every tool call becomes visible before it runs.
+    functions.push({
             name: "permission",
-            description: "Internal: asks the person at the surface before a tool runs.",
+            description: "Internal: decides before a tool runs; asks the person only in ask mode.",
             parameters: {
                 type: "object",
                 properties: { tool_name: { type: "string" }, input: { type: "object" } },
@@ -156,7 +157,7 @@ export async function runOperator(options: OperatorOptions, ui: OperatorUi): Pro
                     }
                     if (summary) editedThisTurn.add(summary)
                 }
-                if (alwaysAllowed.has(name)) {
+                if (options.permission === "auto" || alwaysAllowed.has(name)) {
                     return JSON.stringify({ behavior: "allow", updatedInput: input })
                 }
                 const answer = await ask("allow?", {
@@ -171,8 +172,7 @@ export async function runOperator(options: OperatorOptions, ui: OperatorUi): Pro
                 }
                 return JSON.stringify({ behavior: "deny", message: "the user declined" })
             },
-        })
-    }
+    })
 
     const relay = new HostToolsRelay(functions, "baro operator tools")
     const connection = await relay.open()
@@ -188,7 +188,7 @@ export async function runOperator(options: OperatorOptions, ui: OperatorUi): Pro
         ...(options.claudeBin ? { claudeBin: options.claudeBin } : {}),
         includePartialMessages: true,
         replayUserMessages: false,
-        permissionMode: options.permission === "ask" ? "default" : "bypassPermissions",
+        permissionMode: "default",
         extraArgs: [
             "--strict-mcp-config",
             "--mcp-config",
@@ -210,9 +210,8 @@ export async function runOperator(options: OperatorOptions, ui: OperatorUi): Pro
             // model picks a default on its own. Questions go through text.
             "--disallowed-tools",
             "AskUserQuestion",
-            ...(options.permission === "ask"
-                ? ["--permission-prompt-tool", `mcp__${OPERATOR_MCP_SERVER_NAME}__permission`]
-                : []),
+            "--permission-prompt-tool",
+            `mcp__${OPERATOR_MCP_SERVER_NAME}__permission`,
             "--system-prompt",
             systemPrompt(options.cwd),
         ],

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -1,5 +1,3 @@
-import { createInterface, clearLine, cursorTo, type Interface } from "node:readline"
-
 import { AgenticEnvironment, BaseObserver } from "../runtime/mozaik.js"
 import type { Participant, SemanticEvent } from "../runtime/mozaik.js"
 import { AgentResult, ClaudeStreamChunk } from "../events/harness-stream.js"
@@ -7,80 +5,48 @@ import { ClaudeCliParticipant } from "../harness/claude/cli-participant.js"
 import type { HostFunction } from "../harness/lane-adapter.js"
 import { HostToolsRelay, OPERATOR_MCP_SERVER_NAME } from "./host-tools-relay.js"
 import { RunRegistry } from "./run-registry.js"
+import type { OperatorUi, TurnResult } from "./ui.js"
 
 /* One conversation that outlives its runs. Claude Code is the operator: it
    answers, edits directly, or delegates to baro, and says which. Everything
    baro does arrives here as protocol events, so "what are they doing" is a
-   question the operator can answer from the registry, not from a log. */
+   question the operator can answer from the registry, not from a log. The
+   surface is a port: the same session drives a terminal or the Rust TUI. */
 
 export interface OperatorOptions {
     readonly cwd: string
     readonly model?: string
     readonly effort?: string
     readonly claudeBin?: string
-    /** `ask` routes Claude's permission prompts to this terminal; `auto` bypasses them. */
+    /** `ask` routes Claude's permission prompts to the surface; `auto` bypasses them. */
     readonly permission: "ask" | "auto"
     readonly baroArgs?: readonly string[]
 }
 
 const AGENT_ID = "operator"
-const DIM = "[2m"
-const RESET = "[0m"
-const AMBER = "[33m"
+// Measured 9.9.2026: the operator built a four-file CLI with tests in under a
+// minute, while baro spent seven on intake and architect for three helpers.
+// Direct work is capped where it stops being one component; past that the
+// edit is refused with the remedy.
+const DIRECT_FILE_LIMIT = 10
 
-export async function runOperator(options: OperatorOptions): Promise<void> {
-    const out = process.stdout
-    const rl = createInterface({ input: process.stdin, output: out, prompt: "you › " })
-    let busy = false
-    let asking = false
-    let lineOpen = false
-
-    const clearPrompt = (): void => {
-        if (asking) return
-        clearLine(out, 0)
-        cursorTo(out, 0)
-    }
-    const reprompt = (): void => {
-        if (!busy && !asking) rl.prompt(true)
-    }
-    // Nothing prints over an open question: notes wait until it is answered.
-    const heldNotes: string[] = []
-    const note = (text: string): void => {
-        if (asking) {
-            heldNotes.push(text)
-            return
-        }
-        clearPrompt()
-        if (lineOpen) {
-            out.write("\n")
-            lineOpen = false
-        }
-        out.write(`${DIM}${text}${RESET}\n`)
-        reprompt()
-    }
-    const releaseNotes = (): void => {
-        const held = heldNotes.splice(0)
-        for (const text of held) note(text)
-    }
-    const stream = (text: string): void => {
-        if (!lineOpen) clearPrompt()
-        out.write(text)
-        lineOpen = !text.endsWith("\n")
-    }
-
+export async function runOperator(options: OperatorOptions, ui: OperatorUi): Promise<void> {
     const registry = new RunRegistry({
         ...(options.baroArgs ? { baroArgs: options.baroArgs } : {}),
         onStarted: (run) => {
-            note(`  ${run.id} · started (was queued)`)
-            busy = true
+            ui.note(`${run.id} · started (was queued)`)
+            ui.runsChanged(registry.rows())
             participant.sendUserMessage(
                 `[baro] ${run.id} left the queue and is now running. Tell the user in one sentence.`,
             )
         },
-        onMilestone: (run, line) => note(`  ${run.id} · ${line}`),
+        onMilestone: (run, line) => {
+            ui.note(`${run.id} · ${line}`)
+            ui.runsChanged(registry.rows())
+        },
         onFinished: (run, outcome) => {
-            note(`  ${run.id} · finished (${run.terminal})`)
-            busy = true
+            ui.note(`${run.id} · finished (${run.terminal})`)
+            ui.runsChanged(registry.rows())
             participant.sendUserMessage(
                 `[baro] ${run.id} finished.\n${outcome}\n\nTell the user in two or three sentences what happened and what they can do next.`,
             )
@@ -88,31 +54,11 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
     })
 
     const alwaysAllowed = new Set<string>()
-    // Files edited in the current turn. Measured 9.9.2026: the operator built a
-    // four-file CLI with tests in under a minute, while baro spent seven on
-    // intake and architect for three helpers. Direct work is capped where it
-    // stops being one component; past that the edit is refused with the remedy.
     const editedThisTurn = new Set<string>()
-    const DIRECT_FILE_LIMIT = 10
-    // Parallel tool calls arrive as parallel permission checks; they are asked
-    // one at a time, in order, and an "always" answer settles the rest.
+    // The surface answers one question at a time, in order.
     let askChain: Promise<unknown> = Promise.resolve()
-    const ask = (question: string): Promise<string> => {
-        const turn = askChain.then(
-            () =>
-                new Promise<string>((resolve) => {
-                    asking = true
-                    if (lineOpen) {
-                        out.write("\n")
-                        lineOpen = false
-                    }
-                    rl.question(question, (answer) => {
-                        asking = false
-                        resolve(answer.trim())
-                        releaseNotes()
-                    })
-                }),
-        )
+    const ask = (prompt: string, meta: Parameters<OperatorUi["ask"]>[1]): Promise<string> => {
+        const turn = askChain.then(() => ui.ask(prompt, meta))
         askChain = turn.catch(() => undefined)
         return turn
     }
@@ -142,11 +88,12 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
                     goal.trim(),
                     typeof cwd === "string" && cwd ? cwd : options.cwd,
                 )
+                ui.runsChanged(registry.rows())
                 if (behind) {
-                    note(`  ${run.id} · queued behind ${behind.id}: ${run.goal.slice(0, 80)}`)
+                    ui.note(`${run.id} · queued behind ${behind.id}: ${run.goal.slice(0, 80)}`)
                     return `${run.id} queued behind ${behind.id}: baro allows one run per repository at a time, so it starts automatically the moment ${behind.id} exits. Tell the user it is queued, not running. stop ${behind.id} only if the user asks for that.`
                 }
-                note(`  ${run.id} · delegated: ${run.goal.slice(0, 90)}`)
+                ui.note(`${run.id} · delegated: ${run.goal.slice(0, 90)}`)
                 return `${run.id} started in the background (cwd ${run.cwd}). Intake and planning take a few minutes before stories start; ask run_status for progress.`
             },
         },
@@ -178,14 +125,16 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
             },
             invoke: async (args) => {
                 const id = String((args as { run_id?: unknown }).run_id ?? "")
-                return registry.stop(id) ? `${id} stopping` : `${id} is not running`
+                const stopped = registry.stop(id)
+                ui.runsChanged(registry.rows())
+                return stopped ? `${id} stopping` : `${id} is not running`
             },
         },
     ]
     if (options.permission === "ask") {
         functions.push({
             name: "permission",
-            description: "Internal: asks the person at the terminal before a tool runs.",
+            description: "Internal: asks the person at the surface before a tool runs.",
             parameters: {
                 type: "object",
                 properties: { tool_name: { type: "string" }, input: { type: "object" } },
@@ -194,30 +143,33 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
             invoke: async (args) => {
                 const { tool_name: tool, input } = args as { tool_name?: string; input?: unknown }
                 const name = tool ?? "tool"
+                const summary = summarizeToolInput(name, input)
                 if (name === "Edit" || name === "Write" || name === "MultiEdit" || name === "NotebookEdit") {
-                    const path = summarizeToolInput(name, input)
-                    if (path && !editedThisTurn.has(path) && editedThisTurn.size >= DIRECT_FILE_LIMIT) {
-                        note(`  ✋ ${name} ${path} refused: direct work is capped at ${DIRECT_FILE_LIMIT} files per turn`)
+                    if (summary && !editedThisTurn.has(summary) && editedThisTurn.size >= DIRECT_FILE_LIMIT) {
+                        ui.note(`✋ ${name} ${summary} refused: direct work is capped at ${DIRECT_FILE_LIMIT} files per turn`)
                         return JSON.stringify({
                             behavior: "deny",
                             message:
-                                `This change now spans more than ${DIRECT_FILE_LIMIT} files (${[...editedThisTurn, path].join(", ")}). ` +
+                                `This change now spans more than ${DIRECT_FILE_LIMIT} files (${[...editedThisTurn, summary].join(", ")}). ` +
                                 "That is delegate altitude: stop editing, revert nothing, and call the delegate tool with a self-contained goal that includes the files you already touched.",
                         })
                     }
-                    if (path) editedThisTurn.add(path)
+                    if (summary) editedThisTurn.add(summary)
                 }
                 if (alwaysAllowed.has(name)) {
                     return JSON.stringify({ behavior: "allow", updatedInput: input })
                 }
-                const answer = await ask(
-                    `${AMBER}⚠ ${name}${RESET} ${summarizeToolInput(name, input)}\n  allow? [y/N/a=always for ${name}] `,
-                )
+                const answer = await ask("allow?", {
+                    kind: "permission",
+                    tool: name,
+                    summary,
+                    options: ["y", "N", `a=always for ${name}`],
+                })
                 if (answer === "a" || answer === "always") alwaysAllowed.add(name)
                 if (answer === "y" || answer === "yes" || answer === "a" || answer === "always") {
                     return JSON.stringify({ behavior: "allow", updatedInput: input })
                 }
-                return JSON.stringify({ behavior: "deny", message: "the user declined at the terminal" })
+                return JSON.stringify({ behavior: "deny", message: "the user declined" })
             },
         })
     }
@@ -267,93 +219,80 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
     })
 
     const env = new AgenticEnvironment("baro-operator")
-    const renderer = new Renderer(stream, note, (result) => {
-        if (lineOpen) {
-            out.write("\n")
-            lineOpen = false
-        }
-        const facts = [
-            result.durationMs !== null ? `${(result.durationMs / 1000).toFixed(0)}s` : undefined,
-            result.totalCostUsd !== null ? `$${result.totalCostUsd.toFixed(2)}` : undefined,
-        ].filter(Boolean)
-        if (facts.length) out.write(`${DIM}· ${facts.join(" · ")}${RESET}\n`)
+    const renderer = new Renderer(ui, (result) => {
         editedThisTurn.clear()
-        busy = false
-        reprompt()
+        ui.turnDone(result)
     })
     renderer.join(env)
     participant.join(env)
     participant.start(env)
 
-    out.write(
-        `${DIM}baro operator · ${options.model ?? "default model"} · ${options.cwd}\n` +
-            `/runs  /status <id>  /stop <id>  /quit${RESET}\n`,
-    )
+    ui.banner(`baro operator · ${options.model ?? "default model"} · ${options.cwd}`)
 
     let closing = false
-    const shutdown = async (): Promise<void> => {
+    const shutdown = async (stopRuns: boolean | undefined): Promise<void> => {
         if (closing) return
         closing = true
         const running = registry.running()
         if (running.length > 0) {
-            const answer = await ask(
-                `${running.length} run(s) still running (${running.map((r) => r.id).join(", ")}). stop them? [y/N] `,
-            )
-            if (answer === "y" || answer === "yes") for (const run of running) registry.stop(run.id)
-            else out.write(`${DIM}leaving them running; stop later with: baro stop <id>${RESET}\n`)
+            let stop = stopRuns
+            if (stop === undefined) {
+                const answer = await ask(
+                    `${running.length} run(s) still running (${running.map((r) => r.id).join(", ")}). stop them?`,
+                    { kind: "quit", options: ["y", "N"] },
+                )
+                stop = answer === "y" || answer === "yes"
+            }
+            if (stop) for (const run of running) registry.stop(run.id)
+            else ui.note("leaving them running; stop later with: baro stop <id>")
         }
         participant.closeStdin()
         await Promise.race([participant.done, new Promise((r) => setTimeout(r, 4_000))])
         await participant.abortAndWait()
         await relay.close()
-        rl.close()
+        ui.close()
         process.exit(0)
     }
 
-    rl.on("line", (line) => {
-        const text = line.trim()
-        if (!text) {
-            reprompt()
-            return
+    ui.onCommand((command) => {
+        switch (command.type) {
+            case "quit":
+                void shutdown(command.stopRuns)
+                return
+            case "runs":
+                ui.note(registry.table())
+                return
+            case "status":
+                ui.note(registry.status(command.id))
+                return
+            case "stop": {
+                const stopped = registry.stop(command.id)
+                ui.runsChanged(registry.rows())
+                ui.note(stopped ? `${command.id} stopping` : `${command.id} is not running`)
+                return
+            }
+            case "user":
+                participant.sendUserMessage(command.text)
+                return
         }
-        if (text === "/quit" || text === "/exit") {
-            void shutdown()
-            return
-        }
-        if (text === "/runs") {
-            note(registry.table())
-            return
-        }
-        if (text.startsWith("/status")) {
-            note(registry.status(text.split(/\s+/)[1] ?? ""))
-            return
-        }
-        if (text.startsWith("/stop")) {
-            const id = text.split(/\s+/)[1] ?? ""
-            note(registry.stop(id) ? `${id} stopping` : `${id} is not running`)
-            return
-        }
-        busy = true
-        participant.sendUserMessage(text)
     })
-    rl.on("close", () => void shutdown())
-    rl.on("SIGINT", () => void shutdown())
-    rl.prompt()
 
     await participant.done
     if (!closing) {
-        out.write(`${DIM}operator session ended: ${participant.sessionEndDetail()}${RESET}\n`)
+        ui.note(`operator session ended: ${participant.sessionEndDetail()}`)
         await relay.close()
-        rl.close()
+        ui.close()
         process.exit(1)
     }
 }
 
 class Renderer extends BaseObserver {
+    /** Tool calls in flight, by content block index; input arrives as JSON deltas. */
+    private readonly toolBlocks = new Map<number, { name: string; json: string }>()
+
     constructor(
-        private readonly stream: (text: string) => void,
-        private readonly note: (text: string) => void,
-        private readonly onResult: (result: { durationMs: number | null; totalCostUsd: number | null }) => void,
+        private readonly ui: OperatorUi,
+        private readonly onResult: (result: TurnResult) => void,
     ) {
         super()
     }
@@ -364,12 +303,9 @@ class Renderer extends BaseObserver {
             return
         }
         if (AgentResult.is(event) && event.data.agentId === AGENT_ID) {
-            this.onResult(event.data)
+            this.onResult({ durationMs: event.data.durationMs, totalCostUsd: event.data.totalCostUsd })
         }
     }
-
-    /** Tool calls in flight, by content block index; input arrives as JSON deltas. */
-    private readonly toolBlocks = new Map<number, { name: string; json: string }>()
 
     private render(raw: Readonly<Record<string, unknown>>): void {
         if (raw.type !== "stream_event") return
@@ -387,7 +323,7 @@ class Renderer extends BaseObserver {
             }
             case "content_block_delta": {
                 if (delta?.type === "text_delta") {
-                    this.stream(String(delta.text ?? ""))
+                    this.ui.stream(String(delta.text ?? ""))
                 } else if (delta?.type === "input_json_delta") {
                     const pending = this.toolBlocks.get(index)
                     if (pending) pending.json += String(delta.partial_json ?? "")
@@ -405,7 +341,7 @@ class Renderer extends BaseObserver {
                     input = {}
                 }
                 const name = pending.name.replace(`mcp__${OPERATOR_MCP_SERVER_NAME}__`, "baro ")
-                this.note(`  ⚙ ${name} ${summarizeToolInput(name, input)}`)
+                this.ui.toolCall(name, summarizeToolInput(name, input))
                 return
             }
             default:

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -43,7 +43,13 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
     const reprompt = (): void => {
         if (!busy && !asking) rl.prompt(true)
     }
+    // Nothing prints over an open question: notes wait until it is answered.
+    const heldNotes: string[] = []
     const note = (text: string): void => {
+        if (asking) {
+            heldNotes.push(text)
+            return
+        }
         clearPrompt()
         if (lineOpen) {
             out.write("\n")
@@ -51,6 +57,10 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
         }
         out.write(`${DIM}${text}${RESET}\n`)
         reprompt()
+    }
+    const releaseNotes = (): void => {
+        const held = heldNotes.splice(0)
+        for (const text of held) note(text)
     }
     const stream = (text: string): void => {
         if (!lineOpen) clearPrompt()
@@ -84,18 +94,28 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
     // stops being one component; past that the edit is refused with the remedy.
     const editedThisTurn = new Set<string>()
     const DIRECT_FILE_LIMIT = 5
-    const ask = (question: string): Promise<string> =>
-        new Promise((resolve) => {
-            asking = true
-            if (lineOpen) {
-                out.write("\n")
-                lineOpen = false
-            }
-            rl.question(question, (answer) => {
-                asking = false
-                resolve(answer.trim())
-            })
-        })
+    // Parallel tool calls arrive as parallel permission checks; they are asked
+    // one at a time, in order, and an "always" answer settles the rest.
+    let askChain: Promise<unknown> = Promise.resolve()
+    const ask = (question: string): Promise<string> => {
+        const turn = askChain.then(
+            () =>
+                new Promise<string>((resolve) => {
+                    asking = true
+                    if (lineOpen) {
+                        out.write("\n")
+                        lineOpen = false
+                    }
+                    rl.question(question, (answer) => {
+                        asking = false
+                        resolve(answer.trim())
+                        releaseNotes()
+                    })
+                }),
+        )
+        askChain = turn.catch(() => undefined)
+        return turn
+    }
 
     const functions: HostFunction[] = [
         {

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -234,6 +234,10 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
             }),
             "--allowed-tools",
             toolNames.join(","),
+            // A dialog nobody can render: the CLI reports it dismissed and the
+            // model picks a default on its own. Questions go through text.
+            "--disallowed-tools",
+            "AskUserQuestion",
             ...(options.permission === "ask"
                 ? ["--permission-prompt-tool", `mcp__${OPERATOR_MCP_SERVER_NAME}__permission`]
                 : []),
@@ -413,6 +417,8 @@ Every request gets an altitude. Your FIRST line of every reply is the altitude a
 - delegate: work whose scope you cannot see to the end, changes across several modules or owned by different people, anything that needs independent review and a verified pull request, or anything the user asks to run through baro. baro has a fixed cost: intake, architect and goal contract take ten to fifteen minutes before the first story starts, whatever the size. So for a goal you could finish directly in a few minutes, say so and offer the choice in one line ("direct in ~3 min, or baro in ~15 with review and a PR?") instead of delegating by default. When you delegate, call \`delegate\` with a precise, self-contained goal (what, where, constraints, how to verify); baro's planner reads only that text. Warn first if the working tree has uncommitted changes the goal depends on: baro's agents work from the last commit. It returns at once with a run id and the run continues in the background. Do not poll in a loop. Tell the user the run id and one sentence on what to expect, then keep talking.
 
 When asked what the agents are doing, call \`run_status\` (or \`runs\`) and summarize plainly: phase, stories done of total, last activity, recent milestones. When a run finishes you receive a message starting with [baro]; report the outcome and the pull request link if there is one. If the user overrides your altitude ("just do it yourself" / "send it to baro"), follow them.
+
+There is no dialog tool here: when you need a decision from the user (which altitude, whether to commit first, an ambiguity), ask in one or two plain sentences and END YOUR TURN. Never pick a default on the user's behalf for a question you just asked.
 
 Keep replies short and concrete.`
 }

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -60,6 +60,13 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
 
     const registry = new RunRegistry({
         ...(options.baroArgs ? { baroArgs: options.baroArgs } : {}),
+        onStarted: (run) => {
+            note(`  ${run.id} · started (was queued)`)
+            busy = true
+            participant.sendUserMessage(
+                `[baro] ${run.id} left the queue and is now running. Tell the user in one sentence.`,
+            )
+        },
         onMilestone: (run, line) => note(`  ${run.id} · ${line}`),
         onFinished: (run, outcome) => {
             note(`  ${run.id} · finished (${run.terminal})`)
@@ -110,7 +117,14 @@ export async function runOperator(options: OperatorOptions): Promise<void> {
             invoke: async (args) => {
                 const { goal, cwd } = args as { goal?: unknown; cwd?: unknown }
                 if (typeof goal !== "string" || !goal.trim()) throw new Error("delegate requires a goal")
-                const run = registry.delegate(goal.trim(), typeof cwd === "string" && cwd ? cwd : options.cwd)
+                const { run, behind } = registry.delegate(
+                    goal.trim(),
+                    typeof cwd === "string" && cwd ? cwd : options.cwd,
+                )
+                if (behind) {
+                    note(`  ${run.id} · queued behind ${behind.id}: ${run.goal.slice(0, 80)}`)
+                    return `${run.id} queued behind ${behind.id}: baro allows one run per repository at a time, so it starts automatically the moment ${behind.id} exits. Tell the user it is queued, not running. stop ${behind.id} only if the user asks for that.`
+                }
                 note(`  ${run.id} · delegated: ${run.goal.slice(0, 90)}`)
                 return `${run.id} started in the background (cwd ${run.cwd}). Intake and planning take a few minutes before stories start; ask run_status for progress.`
             },

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -357,18 +357,27 @@ class Renderer extends BaseObserver {
 function summarizeToolOutput(output: unknown): string {
     // Claude's tool_result content is an InputText array; a plain string
     // arrives from providers that never block their output.
+    let value: unknown = output
+    if (typeof value === "string" && /^\s*\[/.test(value)) {
+        // The stream mapper serializes the content array to a string.
+        try {
+            value = JSON.parse(value)
+        } catch {
+            /* plain text that happens to start with a bracket */
+        }
+    }
     const text =
-        typeof output === "string"
-            ? output
-            : Array.isArray(output)
-              ? output
+        typeof value === "string"
+            ? value
+            : Array.isArray(value)
+              ? value
                     .map((block) =>
                         typeof block === "object" && block !== null && typeof (block as { text?: unknown }).text === "string"
                             ? (block as { text: string }).text
                             : "",
                     )
                     .join("\n")
-              : JSON.stringify(output)
+              : JSON.stringify(value)
     const lines = text
         .replace(/\u001b\[[0-9;]*m/g, "")
         .split("\n")

--- a/packages/baro-orchestrator/src/operator/protocol.ts
+++ b/packages/baro-orchestrator/src/operator/protocol.ts
@@ -1,0 +1,85 @@
+/* baro's TUI protocol v3 (docs/tui-protocol-v3.md) as a delegating host reads
+   it: the milestone subset is a type list by contract, so "certified outcome
+   or live feed" is a membership test. Twin of packages/baro-dsh/src/domain. */
+
+export interface BaroEvent {
+    readonly type: string
+    readonly ts?: string
+    readonly [key: string]: unknown
+}
+
+export const MILESTONE_TYPES: ReadonlySet<string> = new Set([
+    "init",
+    "story_start",
+    "story_suspended",
+    "critique",
+    "story_merged",
+    "merge_failed",
+    "story_complete",
+    "story_error",
+    "level_started",
+    "level_completed",
+    "recovery_started",
+    "replan",
+    "progress",
+    "push_status",
+    "finalize_start",
+    "finalize_complete",
+    "done",
+])
+
+export function parseLine(line: string): BaroEvent | null {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith("{")) return null
+    try {
+        const value: unknown = JSON.parse(trimmed)
+        if (typeof value !== "object" || value === null) return null
+        const type = (value as { type?: unknown }).type
+        return typeof type === "string" ? (value as BaroEvent) : null
+    } catch {
+        return null
+    }
+}
+
+export function isMilestone(event: BaroEvent): boolean {
+    return MILESTONE_TYPES.has(event.type)
+}
+
+export function stringField(event: BaroEvent, ...keys: string[]): string | undefined {
+    for (const key of keys) {
+        const value = event[key]
+        if (typeof value === "string" && value) return value
+    }
+    return undefined
+}
+
+export function numberField(event: BaroEvent, ...keys: string[]): number | undefined {
+    for (const key of keys) {
+        const value = event[key]
+        if (typeof value === "number") return value
+    }
+    return undefined
+}
+
+/** One human line per milestone. */
+export function describe(event: BaroEvent): string {
+    const id = stringField(event, "id", "storyId", "story_id")
+    const at = typeof event.ts === "string" ? event.ts.slice(11, 19) : ""
+    const head = at ? `${at} ${event.type}` : event.type
+    switch (event.type) {
+        case "init": {
+            const stories = Array.isArray(event.stories) ? event.stories.length : 0
+            return `${head} ${stringField(event, "project") ?? ""} (${stories} stories)`.replace("  ", " ")
+        }
+        case "progress":
+            return `${head} ${numberField(event, "completed", "done") ?? "?"}/${numberField(event, "total") ?? "?"}`
+        case "critique":
+            return `${head} ${id ?? ""} ${stringField(event, "verdict", "status") ?? ""}`.trim()
+        case "done": {
+            const code = stringField(event, "abort_code")
+            return `${head} ${event.success === true ? "success" : `failed${code ? ` (${code})` : ""}`}`
+        }
+        default:
+            return id ? `${head} ${id}` : head
+    }
+}

--- a/packages/baro-orchestrator/src/operator/run-registry.ts
+++ b/packages/baro-orchestrator/src/operator/run-registry.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path"
 import { createInterface } from "node:readline"
 
 import { parseLine } from "./protocol.js"
+import type { RunRow } from "./ui.js"
 import {
     RunTracker,
     renderOutcome,
@@ -124,6 +125,23 @@ export class RunRegistry {
     stateOf(run: RunRecord): RunState {
         if (run.finishedAt !== null) return "finished"
         return run.startedAt === null ? "queued" : "running"
+    }
+
+    /** Structured rows for a surface that draws its own strip. */
+    rows(): RunRow[] {
+        return this.list().map((run) => {
+            const s = run.tracker.summary()
+            return {
+                id: run.id,
+                state: run.terminal ?? (run.startedAt === null ? "queued" : "running"),
+                phase: run.startedAt === null ? "queued" : s.phase,
+                completed: s.completed,
+                total: s.total > 0 ? s.total : s.storiesTotal,
+                goal: run.goal,
+                elapsed: elapsed(run),
+                prUrl: s.prUrl,
+            }
+        })
     }
 
     /** One line per run, for the terminal strip and the `runs` tool. */

--- a/packages/baro-orchestrator/src/operator/run-registry.ts
+++ b/packages/baro-orchestrator/src/operator/run-registry.ts
@@ -139,6 +139,8 @@ export class RunRegistry {
                 total: s.total > 0 ? s.total : s.storiesTotal,
                 goal: run.goal,
                 elapsed: elapsed(run),
+                startedMs: run.startedAt ?? undefined,
+                finishedMs: run.finishedAt ?? undefined,
                 prUrl: s.prUrl,
             }
         })

--- a/packages/baro-orchestrator/src/operator/run-registry.ts
+++ b/packages/baro-orchestrator/src/operator/run-registry.ts
@@ -15,13 +15,21 @@ import {
 
 /* The operator's back office: every delegated goal is one headless baro
    child, watched through its protocol stream. Runs outlive turns of the
-   conversation; the registry is what "what are they doing" reads. */
+   conversation; the registry is what "what are they doing" reads.
+
+   baro holds one session lock per repository, so a second goal for the same
+   cwd is queued here and started when the first one exits — run-2 of the
+   first live session died in 0s on that lock. Disjoint-write concurrency
+   within one repository is baro's to grant, not this registry's to assume. */
+
+export type RunState = "queued" | "running" | "finished"
 
 export interface RunRecord {
     readonly id: string
     readonly goal: string
     readonly cwd: string
-    readonly startedAt: number
+    readonly queuedAt: number
+    startedAt: number | null
     finishedAt: number | null
     terminal: Terminal | null
     exitCode: number | null
@@ -33,6 +41,7 @@ export interface RunRegistryOptions {
     /** Extra args every child gets (`--local-only`, `--llm …`). */
     readonly baroArgs?: readonly string[]
     readonly baroBin?: string
+    onStarted?(run: RunRecord, behind: RunRecord | null): void
     onMilestone?(run: RunRecord, line: string): void
     onFinished?(run: RunRecord, outcome: string): void
 }
@@ -42,81 +51,55 @@ const STDERR_TAIL = 20
 export class RunRegistry {
     private readonly runs = new Map<string, RunRecord>()
     private readonly children = new Map<string, ChildProcess>()
+    private readonly active = new Map<string, string>()
+    private readonly queues = new Map<string, RunRecord[]>()
     private sequence = 0
 
     constructor(private readonly options: RunRegistryOptions = {}) {}
 
-    delegate(goal: string, cwd: string): RunRecord {
+    /** Starts the run, or queues it behind the run holding this repository. */
+    delegate(goal: string, cwd: string): { run: RunRecord; behind: RunRecord | null } {
         this.sequence += 1
-        const id = `run-${this.sequence}`
         const record: RunRecord = {
-            id,
+            id: `run-${this.sequence}`,
             goal,
             cwd,
-            startedAt: Date.now(),
+            queuedAt: Date.now(),
+            startedAt: null,
             finishedAt: null,
             terminal: null,
             exitCode: null,
             tracker: new RunTracker(),
             stderrTail: [],
         }
-        this.runs.set(id, record)
-
-        const env = { ...process.env }
-        // A child that inherits the parent's run id believes it is that run.
-        delete env.BARO_RUN_ID
-        const child = spawn(
-            resolveBaroBin(this.options.baroBin),
-            [goal, "--headless", "--cwd", cwd, ...(this.options.baroArgs ?? [])],
-            {
-                cwd,
-                env,
-                // Closed, not merely silent: headless baro answers its own
-                // intake questions only once stdin reaches EOF.
-                stdio: ["ignore", "pipe", "pipe"],
-                detached: true,
-            },
-        )
-        this.children.set(id, child)
-
-        createInterface({ input: child.stdout!, crlfDelay: Number.POSITIVE_INFINITY }).on(
-            "line",
-            (line) => {
-                const event = parseLine(line)
-                if (!event) return
-                const milestone = record.tracker.accept(event)
-                if (milestone) this.options.onMilestone?.(record, milestone)
-            },
-        )
-        createInterface({ input: child.stderr!, crlfDelay: Number.POSITIVE_INFINITY }).on(
-            "line",
-            (line) => {
-                record.stderrTail.push(line)
-                if (record.stderrTail.length > STDERR_TAIL) record.stderrTail.shift()
-            },
-        )
-        child.once("exit", (code) => {
-            record.exitCode = code
-            record.finishedAt = Date.now()
-            const summary = record.tracker.summary()
-            record.terminal = resolveTerminal(
-                record.terminal === "aborted",
-                code,
-                summary.done,
-            )
-            this.children.delete(id)
-            this.options.onFinished?.(record, renderOutcome(summary, record.terminal))
-        })
-        child.once("error", (error) => {
-            record.stderrTail.push(`spawn failed: ${error.message}`)
-        })
-        return record
+        this.runs.set(record.id, record)
+        const holder = this.active.get(cwd)
+        const behind = holder ? (this.runs.get(holder) ?? null) : null
+        if (behind) {
+            const queue = this.queues.get(cwd) ?? []
+            queue.push(record)
+            this.queues.set(cwd, queue)
+            return { run: record, behind }
+        }
+        this.start(record)
+        return { run: record, behind: null }
     }
 
     stop(id: string): boolean {
         const record = this.runs.get(id)
+        if (!record || record.finishedAt !== null) return false
+        if (record.startedAt === null) {
+            const queue = this.queues.get(record.cwd) ?? []
+            this.queues.set(
+                record.cwd,
+                queue.filter((queued) => queued.id !== id),
+            )
+            record.terminal = "aborted"
+            record.finishedAt = Date.now()
+            return true
+        }
         const child = this.children.get(id)
-        if (!record || !child || child.pid === undefined) return false
+        if (!child || child.pid === undefined) return false
         record.terminal = "aborted"
         try {
             process.kill(-child.pid, "SIGTERM")
@@ -138,16 +121,22 @@ export class RunRegistry {
         return this.list().filter((run) => run.finishedAt === null)
     }
 
+    stateOf(run: RunRecord): RunState {
+        if (run.finishedAt !== null) return "finished"
+        return run.startedAt === null ? "queued" : "running"
+    }
+
     /** One line per run, for the terminal strip and the `runs` tool. */
     table(): string {
         if (this.runs.size === 0) return "no runs yet"
         return this.list()
             .map((run) => {
                 const s = run.tracker.summary()
-                const state = run.terminal ?? "running"
+                const state = run.terminal ?? this.stateOf(run)
                 const progress =
                     s.total > 0 ? ` ${s.completed}/${s.total}` : s.storiesTotal ? ` ${s.storiesTotal} stories` : ""
-                return `${run.id} [${state}] ${s.phase}${progress} · ${elapsed(run)} · ${run.goal.slice(0, 70)}`
+                const phase = run.startedAt === null ? `queued behind ${this.active.get(run.cwd) ?? "?"}` : s.phase
+                return `${run.id} [${state}] ${phase}${progress} · ${elapsed(run)} · ${run.goal.slice(0, 70)}`
             })
             .join("\n")
     }
@@ -156,15 +145,71 @@ export class RunRegistry {
         const run = this.runs.get(id)
         if (!run) return `unknown run: ${id}`
         const summary: RunSummary = run.tracker.summary()
-        const head = `${run.id} [${run.terminal ?? "running"}] · ${elapsed(run)}\ngoal: ${run.goal}\ncwd: ${run.cwd}`
-        const body = run.terminal
-            ? renderOutcome(summary, run.terminal)
-            : renderProgress(summary)
+        const state = run.terminal ?? this.stateOf(run)
+        const head = `${run.id} [${state}] · ${elapsed(run)}\ngoal: ${run.goal}\ncwd: ${run.cwd}`
+        if (run.startedAt === null && run.finishedAt === null) {
+            return `${head}\n\nqueued: baro allows one run per repository; starts automatically when ${this.active.get(run.cwd) ?? "the current run"} exits.`
+        }
+        const body = run.terminal ? renderOutcome(summary, run.terminal) : renderProgress(summary)
         const stderr =
             run.terminal && run.terminal !== "completed" && run.stderrTail.length
                 ? `\n\nstderr tail:\n${run.stderrTail.join("\n")}`
                 : ""
         return `${head}\n\n${body}${stderr}`
+    }
+
+    private start(record: RunRecord): void {
+        record.startedAt = Date.now()
+        this.active.set(record.cwd, record.id)
+
+        const env = { ...process.env }
+        // A child that inherits the parent's run id believes it is that run.
+        delete env.BARO_RUN_ID
+        const child = spawn(
+            resolveBaroBin(this.options.baroBin),
+            [record.goal, "--headless", "--cwd", record.cwd, ...(this.options.baroArgs ?? [])],
+            {
+                cwd: record.cwd,
+                env,
+                // Closed, not merely silent: headless baro answers its own
+                // intake questions only once stdin reaches EOF.
+                stdio: ["ignore", "pipe", "pipe"],
+                detached: true,
+            },
+        )
+        this.children.set(record.id, child)
+
+        createInterface({ input: child.stdout!, crlfDelay: Number.POSITIVE_INFINITY }).on("line", (line) => {
+            const event = parseLine(line)
+            if (!event) return
+            const milestone = record.tracker.accept(event)
+            if (milestone) this.options.onMilestone?.(record, milestone)
+        })
+        createInterface({ input: child.stderr!, crlfDelay: Number.POSITIVE_INFINITY }).on("line", (line) => {
+            record.stderrTail.push(line)
+            if (record.stderrTail.length > STDERR_TAIL) record.stderrTail.shift()
+        })
+        child.once("error", (error) => {
+            record.stderrTail.push(`spawn failed: ${error.message}`)
+        })
+        child.once("exit", (code) => {
+            record.exitCode = code
+            record.finishedAt = Date.now()
+            const summary = record.tracker.summary()
+            record.terminal = resolveTerminal(record.terminal === "aborted", code, summary.done)
+            this.children.delete(record.id)
+            if (this.active.get(record.cwd) === record.id) this.active.delete(record.cwd)
+            this.options.onFinished?.(record, renderOutcome(summary, record.terminal))
+            this.startNext(record.cwd)
+        })
+    }
+
+    private startNext(cwd: string): void {
+        const queue = this.queues.get(cwd) ?? []
+        const next = queue.shift()
+        if (!next) return
+        this.start(next)
+        this.options.onStarted?.(next, null)
     }
 }
 
@@ -181,7 +226,8 @@ function resolveBaroBin(explicit: string | undefined): string {
 }
 
 function elapsed(run: RunRecord): string {
-    const ms = (run.finishedAt ?? Date.now()) - run.startedAt
+    const from = run.startedAt ?? run.queuedAt
+    const ms = (run.finishedAt ?? Date.now()) - from
     const s = Math.floor(ms / 1000)
     return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, "0")}s`
 }

--- a/packages/baro-orchestrator/src/operator/run-registry.ts
+++ b/packages/baro-orchestrator/src/operator/run-registry.ts
@@ -1,0 +1,187 @@
+import { spawn, type ChildProcess } from "node:child_process"
+import { existsSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { createInterface } from "node:readline"
+
+import { parseLine } from "./protocol.js"
+import {
+    RunTracker,
+    renderOutcome,
+    renderProgress,
+    resolveTerminal,
+    type RunSummary,
+    type Terminal,
+} from "./run-tracker.js"
+
+/* The operator's back office: every delegated goal is one headless baro
+   child, watched through its protocol stream. Runs outlive turns of the
+   conversation; the registry is what "what are they doing" reads. */
+
+export interface RunRecord {
+    readonly id: string
+    readonly goal: string
+    readonly cwd: string
+    readonly startedAt: number
+    finishedAt: number | null
+    terminal: Terminal | null
+    exitCode: number | null
+    readonly tracker: RunTracker
+    readonly stderrTail: string[]
+}
+
+export interface RunRegistryOptions {
+    /** Extra args every child gets (`--local-only`, `--llm …`). */
+    readonly baroArgs?: readonly string[]
+    readonly baroBin?: string
+    onMilestone?(run: RunRecord, line: string): void
+    onFinished?(run: RunRecord, outcome: string): void
+}
+
+const STDERR_TAIL = 20
+
+export class RunRegistry {
+    private readonly runs = new Map<string, RunRecord>()
+    private readonly children = new Map<string, ChildProcess>()
+    private sequence = 0
+
+    constructor(private readonly options: RunRegistryOptions = {}) {}
+
+    delegate(goal: string, cwd: string): RunRecord {
+        this.sequence += 1
+        const id = `run-${this.sequence}`
+        const record: RunRecord = {
+            id,
+            goal,
+            cwd,
+            startedAt: Date.now(),
+            finishedAt: null,
+            terminal: null,
+            exitCode: null,
+            tracker: new RunTracker(),
+            stderrTail: [],
+        }
+        this.runs.set(id, record)
+
+        const env = { ...process.env }
+        // A child that inherits the parent's run id believes it is that run.
+        delete env.BARO_RUN_ID
+        const child = spawn(
+            resolveBaroBin(this.options.baroBin),
+            [goal, "--headless", "--cwd", cwd, ...(this.options.baroArgs ?? [])],
+            {
+                cwd,
+                env,
+                // Closed, not merely silent: headless baro answers its own
+                // intake questions only once stdin reaches EOF.
+                stdio: ["ignore", "pipe", "pipe"],
+                detached: true,
+            },
+        )
+        this.children.set(id, child)
+
+        createInterface({ input: child.stdout!, crlfDelay: Number.POSITIVE_INFINITY }).on(
+            "line",
+            (line) => {
+                const event = parseLine(line)
+                if (!event) return
+                const milestone = record.tracker.accept(event)
+                if (milestone) this.options.onMilestone?.(record, milestone)
+            },
+        )
+        createInterface({ input: child.stderr!, crlfDelay: Number.POSITIVE_INFINITY }).on(
+            "line",
+            (line) => {
+                record.stderrTail.push(line)
+                if (record.stderrTail.length > STDERR_TAIL) record.stderrTail.shift()
+            },
+        )
+        child.once("exit", (code) => {
+            record.exitCode = code
+            record.finishedAt = Date.now()
+            const summary = record.tracker.summary()
+            record.terminal = resolveTerminal(
+                record.terminal === "aborted",
+                code,
+                summary.done,
+            )
+            this.children.delete(id)
+            this.options.onFinished?.(record, renderOutcome(summary, record.terminal))
+        })
+        child.once("error", (error) => {
+            record.stderrTail.push(`spawn failed: ${error.message}`)
+        })
+        return record
+    }
+
+    stop(id: string): boolean {
+        const record = this.runs.get(id)
+        const child = this.children.get(id)
+        if (!record || !child || child.pid === undefined) return false
+        record.terminal = "aborted"
+        try {
+            process.kill(-child.pid, "SIGTERM")
+        } catch {
+            child.kill("SIGTERM")
+        }
+        return true
+    }
+
+    get(id: string): RunRecord | undefined {
+        return this.runs.get(id)
+    }
+
+    list(): RunRecord[] {
+        return [...this.runs.values()]
+    }
+
+    running(): RunRecord[] {
+        return this.list().filter((run) => run.finishedAt === null)
+    }
+
+    /** One line per run, for the terminal strip and the `runs` tool. */
+    table(): string {
+        if (this.runs.size === 0) return "no runs yet"
+        return this.list()
+            .map((run) => {
+                const s = run.tracker.summary()
+                const state = run.terminal ?? "running"
+                const progress =
+                    s.total > 0 ? ` ${s.completed}/${s.total}` : s.storiesTotal ? ` ${s.storiesTotal} stories` : ""
+                return `${run.id} [${state}] ${s.phase}${progress} · ${elapsed(run)} · ${run.goal.slice(0, 70)}`
+            })
+            .join("\n")
+    }
+
+    status(id: string): string {
+        const run = this.runs.get(id)
+        if (!run) return `unknown run: ${id}`
+        const summary: RunSummary = run.tracker.summary()
+        const head = `${run.id} [${run.terminal ?? "running"}] · ${elapsed(run)}\ngoal: ${run.goal}\ncwd: ${run.cwd}`
+        const body = run.terminal
+            ? renderOutcome(summary, run.terminal)
+            : renderProgress(summary)
+        const stderr =
+            run.terminal && run.terminal !== "completed" && run.stderrTail.length
+                ? `\n\nstderr tail:\n${run.stderrTail.join("\n")}`
+                : ""
+        return `${head}\n\n${body}${stderr}`
+    }
+}
+
+function resolveBaroBin(explicit: string | undefined): string {
+    if (explicit) return explicit
+    if (process.env.BARO_BIN) return process.env.BARO_BIN
+    // Staged next to the bundles in ~/.baro/bin; dev checkouts fall back to PATH.
+    const entry = process.argv[1]
+    if (entry) {
+        const sibling = join(dirname(entry), "baro")
+        if (existsSync(sibling)) return sibling
+    }
+    return "baro"
+}
+
+function elapsed(run: RunRecord): string {
+    const ms = (run.finishedAt ?? Date.now()) - run.startedAt
+    const s = Math.floor(ms / 1000)
+    return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, "0")}s`
+}

--- a/packages/baro-orchestrator/src/operator/run-tracker.ts
+++ b/packages/baro-orchestrator/src/operator/run-tracker.ts
@@ -1,0 +1,227 @@
+import { type BaroEvent, describe, isMilestone, numberField, stringField } from "./protocol.js"
+
+/* A bounded fold of one run's stream into what an operator needs to answer
+   "what are they doing" and "how did it end". Twin of baro-dsh's domain/run. */
+
+export type Terminal = "completed" | "error" | "max-tokens" | "aborted"
+
+/* A run whose stories all merged with verification passed but whose goal
+   contract stayed open delivered for the person who delegated it; calling it
+   an error made a parent agent conclude nothing was produced. */
+export function classifyDone(done: BaroEvent): Terminal {
+    if (done.success === true) return "completed"
+    if (done.abort_code === "token_ceiling") return "max-tokens"
+    return deliveredDespiteContract(done) ? "completed" : "error"
+}
+
+export function deliveredDespiteContract(done: BaroEvent): boolean {
+    if (done.success === true || done.abort_code !== undefined) return false
+    const stats = done.stats as Record<string, unknown> | undefined
+    const completed = typeof stats?.stories_completed === "number" ? stats.stories_completed : 0
+    const skipped = typeof stats?.stories_skipped === "number" ? stats.stories_skipped : 0
+    return completed > 0 && skipped === 0 && done.verification_status === "passed"
+}
+
+export function resolveTerminal(
+    aborted: boolean,
+    exitCode: number | null,
+    done: BaroEvent | undefined,
+): Terminal {
+    if (aborted) return "aborted"
+    if (done) return classifyDone(done)
+    return exitCode === 0 ? "completed" : "error"
+}
+
+export type Phase = "intake" | "architect" | "planning" | "executing" | "finalizing" | "done"
+
+export interface RunSummary {
+    readonly project: string | undefined
+    readonly phase: Phase
+    readonly activity: string | undefined
+    readonly storiesTotal: number
+    readonly completed: number
+    readonly total: number
+    readonly prUrl: string | undefined
+    readonly done: BaroEvent | undefined
+    readonly milestones: readonly string[]
+    readonly revision: number
+}
+
+const ACTIVITY_LIMIT = 140
+
+export class RunTracker {
+    private project: string | undefined
+    private phase: Phase = "intake"
+    private activity: string | undefined
+    private storiesTotal = 0
+    private completed = 0
+    private total = 0
+    private prUrl: string | undefined
+    private done: BaroEvent | undefined
+    private readonly milestones: string[] = []
+    private revision = 0
+
+    constructor(private readonly limit = 200) {}
+
+    /** Returns the milestone line when the event was one. */
+    accept(event: BaroEvent): string | null {
+        switch (event.type) {
+            case "architect_start":
+                this.setPhase("architect")
+                this.setActivity("architect is examining the repository")
+                break
+            case "architect_complete":
+            case "architect_skipped":
+            case "planning_open":
+                this.setPhase("planning")
+                this.setActivity("planner is composing the stories")
+                break
+            case "plan_fragment": {
+                this.setPhase("planning")
+                const stories = Array.isArray(event.stories) ? event.stories : []
+                this.storiesTotal += stories.length
+                const titles = stories
+                    .map((s) =>
+                        typeof s === "object" && s !== null
+                            ? stringField(s as BaroEvent, "title", "id")
+                            : undefined,
+                    )
+                    .filter(Boolean)
+                if (titles.length) this.setActivity(`plan: ${titles.join(", ")}`)
+                break
+            }
+            case "plan_complete":
+            case "plan_complete_summary":
+                this.setPhase("planning")
+                this.setActivity("plan complete, starting execution")
+                break
+            case "init":
+                this.project = stringField(event, "project")
+                this.storiesTotal =
+                    (Array.isArray(event.stories) ? event.stories.length : 0) || this.storiesTotal
+                this.setPhase("executing")
+                break
+            case "activity": {
+                const text = stringField(event, "text")
+                const id = stringField(event, "id")
+                if (text) this.setActivity(id && id !== "plan" ? `${id}: ${text}` : text)
+                break
+            }
+            case "story_log": {
+                const line = stringField(event, "line")
+                const id = stringField(event, "id")
+                if (line) this.setActivity(id && id !== "plan" ? `${id}: ${line}` : line)
+                break
+            }
+            case "progress": {
+                const completed = numberField(event, "completed", "done")
+                const total = numberField(event, "total")
+                if (completed !== undefined) this.completed = completed
+                if (total !== undefined) this.total = total
+                break
+            }
+            case "finalize_start":
+                this.setPhase("finalizing")
+                break
+            case "push_status":
+            case "finalize_complete": {
+                const url = stringField(event, "pr_url", "url")
+                if (url) this.prUrl = url
+                break
+            }
+            case "done":
+                this.done = event
+                this.setPhase("done")
+                break
+        }
+        if (!isMilestone(event)) return null
+        const line = describe(event)
+        this.milestones.push(line)
+        if (this.milestones.length > this.limit) this.milestones.shift()
+        this.revision += 1
+        return line
+    }
+
+    summary(): RunSummary {
+        return {
+            project: this.project,
+            phase: this.phase,
+            activity: this.activity,
+            storiesTotal: this.storiesTotal,
+            completed: this.completed,
+            total: this.total,
+            prUrl: this.prUrl,
+            done: this.done,
+            milestones: [...this.milestones],
+            revision: this.revision,
+        }
+    }
+
+    private setPhase(phase: Phase): void {
+        if (this.phase === phase) return
+        this.phase = phase
+        this.revision += 1
+    }
+
+    private setActivity(text: string): void {
+        const next = text.length > ACTIVITY_LIMIT ? `${text.slice(0, ACTIVITY_LIMIT - 1)}…` : text
+        if (this.activity === next) return
+        this.activity = next
+        this.revision += 1
+    }
+}
+
+export function renderProgress(summary: RunSummary): string {
+    const head = [
+        `phase: ${summary.phase}`,
+        summary.activity ? `activity: ${summary.activity}` : undefined,
+        summary.project ? `project: ${summary.project}` : undefined,
+        summary.total > 0
+            ? `progress: ${summary.completed}/${summary.total}`
+            : summary.storiesTotal
+              ? `stories: ${summary.storiesTotal}`
+              : undefined,
+        summary.prUrl ? `pr: ${summary.prUrl}` : undefined,
+    ].filter((line): line is string => line !== undefined)
+    return [...head, ...(head.length ? [""] : []), ...summary.milestones.slice(-12)].join("\n")
+}
+
+export function renderOutcome(summary: RunSummary, terminal: Terminal): string {
+    const done = summary.done
+    const lines: string[] = []
+    if (done) {
+        const code = stringField(done, "abort_code")
+        const reason = stringField(done, "abort_reason")
+        const stats = done.stats as Record<string, unknown> | undefined
+        if (done.success === true) {
+            lines.push("baro run succeeded.")
+        } else if (deliveredDespiteContract(done)) {
+            lines.push(
+                "baro run delivered: every story merged and verification passed, but baro left its goal contract open.",
+            )
+            if (reason) lines.push(`open contract: ${reason}`)
+        } else {
+            lines.push(`baro run failed${code ? ` (${code})` : ""}.`)
+            if (reason) lines.push(reason)
+        }
+        if (stats) {
+            lines.push(
+                `stories completed: ${String(stats.stories_completed ?? "?")}, skipped: ${String(stats.stories_skipped ?? "?")}`,
+            )
+            if (typeof stats.total_commits === "number") lines.push(`commits: ${stats.total_commits}`)
+            if (typeof stats.files_created === "number" || typeof stats.files_modified === "number") {
+                lines.push(
+                    `files created: ${String(stats.files_created ?? 0)}, modified: ${String(stats.files_modified ?? 0)}`,
+                )
+            }
+        }
+        const verification = stringField(done, "verification_status")
+        if (verification) lines.push(`verification: ${verification}`)
+    } else {
+        lines.push(`baro run ended without a result (${terminal}).`)
+    }
+    if (summary.prUrl) lines.push(`pull request: ${summary.prUrl}`)
+    const tail = summary.milestones.slice(-12)
+    if (tail.length) lines.push("", "milestones:", ...tail)
+    return lines.join("\n")
+}

--- a/packages/baro-orchestrator/src/operator/terminal-ui.ts
+++ b/packages/baro-orchestrator/src/operator/terminal-ui.ts
@@ -54,6 +54,10 @@ export class TerminalUi implements OperatorUi {
         this.note(`  ⚙ ${name} ${summary}`)
     }
 
+    toolResult(summary: string): void {
+        this.note(`    ⎿ ${summary}`)
+    }
+
     ask(prompt: string, meta: AskMeta): Promise<string> {
         const question =
             meta.kind === "permission"

--- a/packages/baro-orchestrator/src/operator/terminal-ui.ts
+++ b/packages/baro-orchestrator/src/operator/terminal-ui.ts
@@ -1,0 +1,127 @@
+import { createInterface, clearLine, cursorTo } from "node:readline"
+
+import type { AskMeta, OperatorUi, RunRow, TurnResult, UiCommand } from "./ui.js"
+
+const DIM = "[2m"
+const RESET = "[0m"
+const AMBER = "[33m"
+
+/* The bare chat: white for the model, dim for everything else, questions
+   inline. Nothing prints over an open question; notes wait for the answer. */
+export class TerminalUi implements OperatorUi {
+    private readonly out = process.stdout
+    private readonly rl = createInterface({ input: process.stdin, output: this.out, prompt: "you › " })
+    private handler: ((command: UiCommand) => void) | null = null
+    private busy = false
+    private asking = false
+    private lineOpen = false
+    private readonly heldNotes: string[] = []
+    private askChain: Promise<unknown> = Promise.resolve()
+
+    constructor() {
+        this.rl.on("line", (line) => this.onLine(line))
+        this.rl.on("close", () => this.handler?.({ type: "quit" }))
+        this.rl.on("SIGINT", () => this.handler?.({ type: "quit" }))
+    }
+
+    onCommand(handler: (command: UiCommand) => void): void {
+        this.handler = handler
+        this.rl.prompt()
+    }
+
+    banner(text: string): void {
+        this.out.write(`${DIM}${text}${RESET}\n`)
+    }
+
+    stream(text: string): void {
+        if (!this.lineOpen) this.clearPrompt()
+        this.out.write(text)
+        this.lineOpen = !text.endsWith("\n")
+    }
+
+    note(text: string): void {
+        if (this.asking) {
+            this.heldNotes.push(text)
+            return
+        }
+        this.clearPrompt()
+        this.endLine()
+        this.out.write(`${DIM}${text}${RESET}\n`)
+        this.reprompt()
+    }
+
+    toolCall(name: string, summary: string): void {
+        this.note(`  ⚙ ${name} ${summary}`)
+    }
+
+    ask(prompt: string, meta: AskMeta): Promise<string> {
+        const question =
+            meta.kind === "permission"
+                ? `${AMBER}⚠ ${meta.tool ?? "tool"}${RESET} ${meta.summary ?? ""}\n  ${prompt} [${meta.options.join("/")}] `
+                : `${prompt} [${meta.options.join("/")}] `
+        const turn = this.askChain.then(
+            () =>
+                new Promise<string>((resolve) => {
+                    this.asking = true
+                    this.endLine()
+                    this.rl.question(question, (answer) => {
+                        this.asking = false
+                        resolve(answer.trim())
+                        for (const held of this.heldNotes.splice(0)) this.note(held)
+                    })
+                }),
+        )
+        this.askChain = turn.catch(() => undefined)
+        return turn
+    }
+
+    turnDone(result: TurnResult): void {
+        this.endLine()
+        const facts = [
+            result.durationMs !== null ? `${(result.durationMs / 1000).toFixed(0)}s` : undefined,
+            result.totalCostUsd !== null ? `$${result.totalCostUsd.toFixed(2)}` : undefined,
+        ].filter(Boolean)
+        if (facts.length) this.out.write(`${DIM}· ${facts.join(" · ")}${RESET}\n`)
+        this.busy = false
+        this.reprompt()
+    }
+
+    runsChanged(_rows: readonly RunRow[]): void {
+        // The terminal reads runs on demand (/runs); milestones arrive as notes.
+    }
+
+    close(): void {
+        this.rl.close()
+    }
+
+    private onLine(line: string): void {
+        const text = line.trim()
+        if (!text) {
+            this.reprompt()
+            return
+        }
+        if (text === "/quit" || text === "/exit") return this.handler?.({ type: "quit" })
+        if (text === "/runs") return this.handler?.({ type: "runs" })
+        if (text.startsWith("/status")) return this.handler?.({ type: "status", id: text.split(/\s+/)[1] ?? "" })
+        if (text.startsWith("/stop")) return this.handler?.({ type: "stop", id: text.split(/\s+/)[1] ?? "" })
+        this.busy = true
+        this.handler?.({ type: "user", text })
+    }
+
+    private clearPrompt(): void {
+        if (this.asking) return
+        clearLine(this.out, 0)
+        cursorTo(this.out, 0)
+    }
+
+    private endLine(): void {
+        if (this.lineOpen) {
+            this.out.write("\n")
+            this.lineOpen = false
+        }
+    }
+
+    private reprompt(): void {
+        if (!this.busy && !this.asking) this.rl.prompt(true)
+    }
+}

--- a/packages/baro-orchestrator/src/operator/ui.ts
+++ b/packages/baro-orchestrator/src/operator/ui.ts
@@ -1,0 +1,48 @@
+/* What the operator needs from a surface, and nothing about how it draws.
+   Two adapters exist: the plain terminal chat (terminal-ui.ts) and the JSON
+   line protocol the Rust TUI speaks (json-ui.ts). */
+
+export interface RunRow {
+    readonly id: string
+    readonly state: "queued" | "running" | "completed" | "error" | "max-tokens" | "aborted"
+    readonly phase: string
+    readonly completed: number
+    readonly total: number
+    readonly goal: string
+    readonly elapsed: string
+    readonly prUrl: string | undefined
+}
+
+export interface AskMeta {
+    readonly kind: "permission" | "quit"
+    readonly tool?: string
+    readonly summary?: string
+    readonly options: readonly string[]
+}
+
+export type UiCommand =
+    | { readonly type: "user"; readonly text: string }
+    | { readonly type: "runs" }
+    | { readonly type: "status"; readonly id: string }
+    | { readonly type: "stop"; readonly id: string }
+    | { readonly type: "quit"; readonly stopRuns?: boolean }
+
+export interface TurnResult {
+    readonly durationMs: number | null
+    readonly totalCostUsd: number | null
+}
+
+export interface OperatorUi {
+    /** A slice of the assistant's reply, in order. */
+    stream(text: string): void
+    /** One dim line: a milestone, a queue note, a refusal. */
+    note(text: string): void
+    toolCall(name: string, summary: string): void
+    /** Resolves with the person's answer; the operator asks one thing at a time. */
+    ask(prompt: string, meta: AskMeta): Promise<string>
+    turnDone(result: TurnResult): void
+    runsChanged(rows: readonly RunRow[]): void
+    banner(text: string): void
+    onCommand(handler: (command: UiCommand) => void): void
+    close(): void
+}

--- a/packages/baro-orchestrator/src/operator/ui.ts
+++ b/packages/baro-orchestrator/src/operator/ui.ts
@@ -10,6 +10,9 @@ export interface RunRow {
     readonly total: number
     readonly goal: string
     readonly elapsed: string
+    /** Epoch millis when the child started; absent while queued. */
+    readonly startedMs: number | undefined
+    readonly finishedMs: number | undefined
     readonly prUrl: string | undefined
 }
 

--- a/packages/baro-orchestrator/src/operator/ui.ts
+++ b/packages/baro-orchestrator/src/operator/ui.ts
@@ -38,6 +38,8 @@ export interface OperatorUi {
     /** One dim line: a milestone, a queue note, a refusal. */
     note(text: string): void
     toolCall(name: string, summary: string): void
+    /** What the last tool returned, reduced to one line. */
+    toolResult(summary: string): void
     /** Resolves with the person's answer; the operator asks one thing at a time. */
     ask(prompt: string, meta: AskMeta): Promise<string>
     turnDone(result: TurnResult): void

--- a/packages/baro-orchestrator/test/operator/host-tools-relay.test.ts
+++ b/packages/baro-orchestrator/test/operator/host-tools-relay.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict"
+import { createConnection } from "node:net"
+import { describe, it } from "node:test"
+
+import { HostToolsRelay, OPERATOR_MCP_MODE } from "../../src/operator/host-tools-relay.js"
+
+/* The relay is what the MCP child dials; this speaks its wire format directly. */
+
+async function call(port: number, request: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return await new Promise((resolve, reject) => {
+        const socket = createConnection({ host: "127.0.0.1", port })
+        socket.setEncoding("utf8")
+        let buffer = ""
+        socket.once("connect", () => socket.write(JSON.stringify(request) + "\n"))
+        socket.on("data", (chunk: string) => {
+            buffer += chunk
+            if (buffer.includes("\n")) {
+                socket.destroy()
+                resolve(JSON.parse(buffer.slice(0, buffer.indexOf("\n"))))
+            }
+        })
+        socket.once("error", reject)
+    })
+}
+
+describe("operator host tools relay", () => {
+    it("describes its tools and forwards calls, only with the token", async () => {
+        const calls: unknown[] = []
+        const relay = new HostToolsRelay(
+            [
+                {
+                    name: "echo",
+                    description: "returns its input",
+                    parameters: { type: "object", properties: { text: { type: "string" } } },
+                    invoke: async (args) => {
+                        calls.push(args)
+                        return `echo:${(args as { text: string }).text}`
+                    },
+                },
+            ],
+            "test instructions",
+        )
+        const connection = await relay.open()
+        try {
+            const token = Object.values(connection.env)[0]!
+            const port = Number(connection.args[connection.args.indexOf("--bridge-port") + 1])
+            assert.ok(connection.args.includes(OPERATOR_MCP_MODE))
+            assert.match(token, /^[a-f0-9]{64}$/)
+
+            const described = await call(port, { type: "describe", token })
+            assert.equal(described.ok, true)
+            const result = described.result as { instructions: string; tools: Array<{ name: string }> }
+            assert.equal(result.instructions, "test instructions")
+            assert.deepEqual(result.tools.map((t) => t.name), ["echo"])
+
+            const answered = await call(port, { type: "call", name: "echo", args: { text: "hi" }, token })
+            assert.deepEqual(answered, { ok: true, result: "echo:hi" })
+            assert.deepEqual(calls, [{ text: "hi" }])
+
+            const refused = await call(port, { type: "call", name: "echo", args: {}, token: "nope" })
+            assert.equal(refused.ok, false)
+            assert.match(String(refused.error), /authentication failed/)
+
+            const unknown = await call(port, { type: "call", name: "missing", args: {}, token })
+            assert.equal(unknown.ok, false)
+            assert.match(String(unknown.error), /unknown tool: missing/)
+        } finally {
+            await relay.close()
+        }
+    })
+})

--- a/packages/baro-orchestrator/test/operator/run-registry.test.ts
+++ b/packages/baro-orchestrator/test/operator/run-registry.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict"
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { after, before, describe, it } from "node:test"
+
+import { RunRegistry, type RunRecord } from "../../src/operator/run-registry.js"
+
+/* A fake `baro` that speaks protocol v3 on stdout: the registry only ever
+   reads the stream, so this covers spawning, folding and queuing without a
+   model or a repository. The goal text selects the script's behaviour. */
+
+let dir: string
+let fakeBaro: string
+
+before(() => {
+    dir = mkdtempSync(join(tmpdir(), "baro-operator-registry-"))
+    fakeBaro = join(dir, "fake-baro.js")
+    writeFileSync(
+        fakeBaro,
+        `#!/usr/bin/env node
+const goal = process.argv[2] ?? ""
+const say = (o) => process.stdout.write(JSON.stringify(o) + "\\n")
+const ms = goal.startsWith("slow") ? 400 : 20
+say({ type: "architect_start" })
+setTimeout(() => {
+  say({ type: "init", protocol: 3, project: "fake", stories: [{ id: "S1" }] })
+  say({ type: "story_merged", id: "S1", ts: "2026-09-10T10:00:00.000Z" })
+  if (goal.includes("fail")) {
+    process.stderr.write("boom\\n")
+    say({ type: "done", success: false, abort_code: "shell_timeout", abort_reason: "S1 timed out" })
+    process.exit(1)
+  }
+  say({ type: "done", success: true, stats: { stories_completed: 1, stories_skipped: 0 } })
+  process.exit(0)
+}, ms)
+`,
+    )
+    chmodSync(fakeBaro, 0o755)
+})
+
+after(() => {
+    rmSync(dir, { recursive: true, force: true })
+})
+
+function finished(registry: RunRegistry, id: string): Promise<RunRecord> {
+    return new Promise((resolve) => {
+        const tick = setInterval(() => {
+            const run = registry.get(id)
+            if (run?.finishedAt !== null) {
+                clearInterval(tick)
+                resolve(run!)
+            }
+        }, 10)
+    })
+}
+
+describe("operator run registry", () => {
+    it("spawns baro headless, folds milestones and reports the outcome", async () => {
+        const milestones: string[] = []
+        const outcomes: string[] = []
+        const registry = new RunRegistry({
+            baroBin: fakeBaro,
+            baroArgs: ["--local-only"],
+            onMilestone: (_run, line) => milestones.push(line),
+            onFinished: (_run, outcome) => outcomes.push(outcome),
+        })
+        const { run, behind } = registry.delegate("quick goal", dir)
+        assert.equal(behind, null)
+        assert.equal(registry.stateOf(run), "running")
+        const done = await finished(registry, run.id)
+        assert.equal(done.terminal, "completed")
+        assert.equal(done.exitCode, 0)
+        assert.ok(milestones.some((l) => /story_merged S1/.test(l)), milestones.join("|"))
+        assert.match(outcomes[0] ?? "", /^baro run succeeded\./)
+        assert.match(registry.status(run.id), /\[completed\]/)
+    })
+
+    it("keeps the stderr tail for a failed run's status", async () => {
+        const registry = new RunRegistry({ baroBin: fakeBaro })
+        const { run } = registry.delegate("fail goal", dir)
+        const done = await finished(registry, run.id)
+        assert.equal(done.terminal, "error")
+        const status = registry.status(run.id)
+        assert.match(status, /baro run failed \(shell_timeout\)/)
+        assert.match(status, /stderr tail:\nboom/)
+    })
+
+    it("queues a second goal for the same repository and starts it when the first exits", async () => {
+        const started: string[] = []
+        const registry = new RunRegistry({
+            baroBin: fakeBaro,
+            onStarted: (run) => started.push(run.id),
+        })
+        const first = registry.delegate("slow goal", dir)
+        const second = registry.delegate("quick goal", dir)
+        assert.equal(second.behind?.id, first.run.id)
+        assert.equal(registry.stateOf(second.run), "queued")
+        assert.match(registry.table(), /queued behind run-1/)
+        assert.match(registry.status(second.run.id), /queued: baro allows one run per repository/)
+
+        const other = registry.delegate("quick goal", join(dir, "other"))
+        assert.equal(other.behind, null, "a different repository is not queued")
+
+        await finished(registry, first.run.id)
+        await finished(registry, second.run.id)
+        assert.deepEqual(started, [second.run.id])
+        assert.equal(second.run.terminal, "completed")
+        assert.ok(second.run.startedAt! >= first.run.finishedAt!, "second started after first exited")
+    })
+
+    it("stops a queued run without ever spawning it", async () => {
+        const registry = new RunRegistry({ baroBin: fakeBaro })
+        const first = registry.delegate("slow goal", dir)
+        const second = registry.delegate("quick goal", dir)
+        assert.equal(registry.stop(second.run.id), true)
+        assert.equal(second.run.terminal, "aborted")
+        await finished(registry, first.run.id)
+        await new Promise((r) => setTimeout(r, 50))
+        assert.equal(second.run.startedAt, null, "never started")
+        assert.equal(registry.running().length, 0)
+    })
+})

--- a/packages/baro-orchestrator/test/operator/run-tracker.test.ts
+++ b/packages/baro-orchestrator/test/operator/run-tracker.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { isMilestone, parseLine } from "../../src/operator/protocol.js"
+import {
+    RunTracker,
+    classifyDone,
+    renderOutcome,
+    renderProgress,
+    resolveTerminal,
+} from "../../src/operator/run-tracker.js"
+
+describe("operator protocol", () => {
+    it("parses only JSON objects with a string type", () => {
+        assert.equal(parseLine("not json"), null)
+        assert.equal(parseLine('{"no":"type"}'), null)
+        assert.equal(parseLine("[1,2]"), null)
+        assert.deepEqual(parseLine(' {"type":"progress","completed":1,"total":3} '), {
+            type: "progress",
+            completed: 1,
+            total: 3,
+        })
+    })
+
+    it("splits milestone from live feed by type", () => {
+        assert.equal(isMilestone({ type: "critique" }), true)
+        assert.equal(isMilestone({ type: "activity" }), false)
+    })
+})
+
+describe("operator run tracker", () => {
+    it("classifies done by success first, then the one code it knows", () => {
+        assert.equal(classifyDone({ type: "done", success: true }), "completed")
+        assert.equal(classifyDone({ type: "done", success: false, abort_code: "token_ceiling" }), "max-tokens")
+        assert.equal(classifyDone({ type: "done", success: false, abort_code: "shell_timeout" }), "error")
+    })
+
+    it("treats a run whose stories all merged with verification passed as delivered", () => {
+        const done = {
+            type: "done",
+            success: false,
+            abort_reason: "global goal is not satisfied (G-A1): 1 open invariant(s)",
+            verification_status: "passed",
+            stats: { stories_completed: 3, stories_skipped: 0, total_commits: 6 },
+        }
+        assert.equal(classifyDone(done), "completed")
+        const tracker = new RunTracker()
+        tracker.accept(done)
+        const text = renderOutcome(tracker.summary(), "completed")
+        assert.match(text, /^baro run delivered: every story merged and verification passed/)
+        assert.match(text, /commits: 6/)
+        assert.equal(classifyDone({ ...done, stats: { ...done.stats, stories_skipped: 1 } }), "error")
+    })
+
+    it("resolves a terminal without a done line from the exit code", () => {
+        assert.equal(resolveTerminal(true, 0, undefined), "aborted")
+        assert.equal(resolveTerminal(false, 0, undefined), "completed")
+        assert.equal(resolveTerminal(false, 1, undefined), "error")
+    })
+
+    it("returns the milestone line it recorded and keeps the log bounded", () => {
+        const tracker = new RunTracker(3)
+        assert.equal(tracker.accept({ type: "activity", text: "noise" }), null)
+        assert.match(tracker.accept({ type: "init", project: "demo", stories: [{ id: "S1" }, { id: "S2" }] }) ?? "", /^init demo \(2 stories\)$/)
+        assert.match(tracker.accept({ type: "story_start", id: "S1", ts: "2026-09-09T10:00:01.000Z" }) ?? "", /^10:00:01 story_start S1$/)
+        tracker.accept({ type: "progress", completed: 1, total: 2 })
+        tracker.accept({ type: "push_status", pr_url: "https://example.test/pr/1" })
+        tracker.accept({ type: "done", success: true, stats: { stories_completed: 2, stories_skipped: 0 } })
+        const summary = tracker.summary()
+        assert.equal(summary.phase, "done")
+        assert.deepEqual([summary.completed, summary.total], [1, 2])
+        assert.equal(summary.prUrl, "https://example.test/pr/1")
+        assert.equal(summary.milestones.length, 3, "oldest milestone dropped past the limit")
+        assert.match(renderProgress(summary), /^phase: done\nactivity: noise\nproject: demo\nprogress: 1\/2\npr: https/)
+    })
+
+    it("follows the phases the stream announces before the first milestone", () => {
+        const tracker = new RunTracker()
+        assert.equal(tracker.summary().phase, "intake")
+        tracker.accept({ type: "architect_start" })
+        assert.equal(tracker.summary().phase, "architect")
+        tracker.accept({ type: "plan_fragment", stories: [{ id: "S1", title: "Title case" }] })
+        assert.equal(tracker.summary().phase, "planning")
+        assert.equal(tracker.summary().storiesTotal, 1)
+        // Progressive planning inits with an empty graph; the fragment count stays.
+        tracker.accept({ type: "init", project: "p", stories: [] })
+        assert.equal(tracker.summary().phase, "executing")
+        assert.equal(tracker.summary().storiesTotal, 1)
+        tracker.accept({ type: "activity", id: "S1", text: "npm test" })
+        assert.equal(tracker.summary().activity, "S1: npm test")
+        tracker.accept({ type: "finalize_start" })
+        assert.equal(tracker.summary().phase, "finalizing")
+    })
+})


### PR DESCRIPTION
The operator: one conversation that outlives its runs. Claude Code (Opus by default, on the user's own subscription through the CLI) answers, edits directly like a coding agent, or delegates a goal to baro, and says which. Delegated runs are headless baro children in the background; milestones, a runs strip and the outcome flow back into the same conversation.

## What ships

- `packages/baro-orchestrator/src/operator/`: session (altitudes, tools `delegate` / `runs` / `run_status` / `stop`, permission tool with a runaway-scope guard), run registry (per-repository queue behind baro's session lock), protocol reader and run tracker, a general host-tools relay (loopback + MCP stdio child served by the same bundle), and the surface as a port with two adapters: plain terminal chat and the JSON line protocol (`docs/operator-protocol.md`).
- `operator.mjs` bundle (tsup entry) staged with the others.
- Rust: `baro operator [--cwd] [--model] [--permission auto|ask] [--local-only]` handled before clap (no session lock, no run record). The session screen draws the operator: streamed replies, tool calls as `● Name(args)` with a one-line result under each, notes and milestones, `y / n / a` for a permission ask, and a live runs strip in the header.
- Permissions default to auto (Claude Code auto mode); `--permission ask` opts in.

## Measured while building it (playground repo)

- direct: a four-file CLI with tests in under a minute; three helpers in 163 s / $0.63; a docs generator in 87 s / $0.37.
- delegate: workspace conversion, 16 min, 4 stories merged, false verification failure → #129 / #130.
- baro's fixed cost (intake + architect) is 7–15 min regardless of goal size, so the operator offers the choice for goals it could finish itself and reserves baro for scope it cannot see to the end.

## Tests

- operator: 12 (tracker, relay wire format, registry with a fake baro: fold, stderr tail, queue, stop while queued)
- `cargo test -p baro-tui`: 262
- full baro-orchestrator suite green

## Not yet

Run drill-in in the TUI (`ctrl+o` per run), richer strip; those follow on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1bpAF6qY7wdqxL77pKxKE