### PR TITLE
operator: run drill-in in the TUI and a strip that shows what each run is doing

### DIFF
--- a/crates/baro-tui/src/app.rs
+++ b/crates/baro-tui/src/app.rs
@@ -614,6 +614,8 @@ pub struct OperatorState {
     /// The reply being streamed; becomes an assistant turn on turn_done.
     pub reply: String,
     pub gone: Option<String>,
+    /// Run shown in the drill-in pane (ctrl+o cycles, esc returns).
+    pub focus: Option<String>,
 }
 
 impl App {
@@ -781,6 +783,18 @@ impl App {
 
     pub fn operator_pending_ask(&self) -> Option<&OperatorAsk> {
         self.operator.as_ref().and_then(|state| state.pending_ask.as_ref())
+    }
+
+    pub fn operator_focused_run(&self) -> Option<&crate::operator_client::OperatorRun> {
+        let state = self.operator.as_ref()?;
+        let id = state.focus.as_deref()?;
+        state.runs.iter().find(|run| run.id == id)
+    }
+
+    /// A drill-in pane (an agent's activity or an operator run) owns the
+    /// transcript area, so scrolling keys go to it.
+    pub fn drill_in_active(&self) -> bool {
+        self.focused_story.is_some() || self.operator_focused_run().is_some()
     }
 
     // Screen transitions

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -1446,6 +1446,10 @@ async fn run_app(
         .checked_sub(Duration::from_millis(100))
         .unwrap_or_else(Instant::now);
     let mut dirty = true;
+    // A drill-in swaps the whole transcript area. Glyph-width disagreements
+    // between the terminal and the buffer diff leave stray cells behind on
+    // such swaps, so the switch itself repaints from scratch.
+    let mut last_drill_in: (Option<String>, Option<String>) = (None, None);
     // Scroll frames render from the session cache, so they can run at
     // ~120fps; content frames keep the 30fps flood throttle.
     let mut scroll_frame = false;
@@ -1458,6 +1462,14 @@ async fn run_app(
         };
         if let Some(t) = terminal.as_deref_mut() {
             if dirty && last_draw.elapsed() >= min_gap {
+                let drill_in = (
+                    app.focused_story.clone(),
+                    app.operator.as_ref().and_then(|state| state.focus.clone()),
+                );
+                if drill_in != last_drill_in {
+                    t.clear()?;
+                    last_drill_in = drill_in;
+                }
                 t.draw(|f| ui::render(f, &mut app))?;
                 last_draw = Instant::now();
                 dirty = false;

--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -1564,7 +1564,7 @@ async fn run_app(
             }
             Some(AppEvent::MouseScroll(delta)) => {
                 if app.screen == Screen::Conversation && !app.workbench_overlay {
-                    if app.focused_story.is_some() {
+                    if app.drill_in_active() {
                         if delta > 0 {
                             app.focus_scroll_back = app.focus_scroll_back.saturating_add(1);
                         } else {
@@ -2204,6 +2204,30 @@ async fn run_app(
                         KeyCode::Esc => {
                             app.quit_armed_tick = None;
                             app.focused_story = None;
+                            if let Some(state) = app.operator.as_mut() {
+                                state.focus = None;
+                            }
+                        }
+                        KeyCode::Char('o')
+                            if key.modifiers.contains(KeyModifiers::CONTROL)
+                                && app.operator.is_some() =>
+                        {
+                            // Same gesture as the agent drill-in: cycle the
+                            // runs, and past the last one return to the chat.
+                            if let Some(state) = app.operator.as_mut() {
+                                let ids: Vec<String> =
+                                    state.runs.iter().map(|run| run.id.clone()).collect();
+                                let next = match &state.focus {
+                                    Some(current) => ids
+                                        .iter()
+                                        .position(|id| id == current)
+                                        .map(|ix| ix + 1)
+                                        .unwrap_or(0),
+                                    None => 0,
+                                };
+                                state.focus = ids.get(next).cloned();
+                            }
+                            app.focus_scroll_back = 0;
                         }
                         KeyCode::Char('o')
                             if key.modifiers.contains(KeyModifiers::CONTROL) =>
@@ -2266,10 +2290,10 @@ async fn run_app(
                             app.mode_picker_index =
                                 (app.mode_picker_index + 1) % app::MODE_OPTIONS.len();
                         }
-                        KeyCode::PageUp if app.focused_story.is_some() => {
+                        KeyCode::PageUp if app.drill_in_active() => {
                             app.focus_scroll_back = app.focus_scroll_back.saturating_add(10);
                         }
-                        KeyCode::PageDown if app.focused_story.is_some() => {
+                        KeyCode::PageDown if app.drill_in_active() => {
                             app.focus_scroll_back = app.focus_scroll_back.saturating_sub(10);
                         }
                         KeyCode::PageUp => app.session_feed.scroll_up_by(10),

--- a/crates/baro-tui/src/operator_client.rs
+++ b/crates/baro-tui/src/operator_client.rs
@@ -38,6 +38,8 @@ pub struct OperatorRun {
     #[serde(default)]
     pub milestones: Vec<String>,
     #[serde(default)]
+    pub activity_tail: Vec<String>,
+    #[serde(default)]
     pub error: Option<String>,
 }
 

--- a/crates/baro-tui/src/operator_client.rs
+++ b/crates/baro-tui/src/operator_client.rs
@@ -21,8 +21,6 @@ pub struct OperatorRun {
     pub completed: u32,
     #[serde(default)]
     pub total: u32,
-    // Carried for the run drill-in that follows; the strip shows the rest.
-    #[allow(dead_code)]
     #[serde(default)]
     pub goal: String,
     #[serde(default)]
@@ -31,9 +29,25 @@ pub struct OperatorRun {
     pub started_ms: Option<u64>,
     #[serde(default)]
     pub finished_ms: Option<u64>,
-    #[allow(dead_code)]
     #[serde(default)]
     pub pr_url: Option<String>,
+    #[serde(default)]
+    pub activity: Option<String>,
+    #[serde(default)]
+    pub stories: Vec<OperatorStory>,
+    #[serde(default)]
+    pub milestones: Vec<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OperatorStory {
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub status: String,
 }
 
 impl OperatorRun {

--- a/crates/baro-tui/src/screens/session.rs
+++ b/crates/baro-tui/src/screens/session.rs
@@ -209,12 +209,19 @@ fn render_run_focus(
             Span::styled(pr.clone(), Style::default().fg(theme::ACCENT)),
         ]));
     }
-    if !run.milestones.is_empty() {
+    // The live feed: what the run said, oldest first, so the pane reads like
+    // the agent drill-in even before the first story exists.
+    if !run.activity_tail.is_empty() {
         lines.push(Line::from(""));
-        for milestone in &run.milestones {
+        for entry in &run.activity_tail {
+            let (clock, text) = entry.split_once(' ').unwrap_or(("", entry.as_str()));
+            let is_milestone = run.milestones.iter().any(|m| text == m);
             lines.push(Line::from(vec![
-                Span::styled("  · ", Style::default().fg(theme::MUTED)),
-                Span::styled(milestone.clone(), Style::default().fg(theme::TEXT_DIM)),
+                Span::styled(format!("  {clock} "), Style::default().fg(theme::MUTED)),
+                Span::styled(
+                    text.to_string(),
+                    Style::default().fg(if is_milestone { theme::TEXT } else { theme::TEXT_DIM }),
+                ),
             ]));
         }
     }

--- a/crates/baro-tui/src/screens/session.rs
+++ b/crates/baro-tui/src/screens/session.rs
@@ -63,7 +63,9 @@ pub fn render(frame: &mut Frame, app: &App) {
     let visible = chunks[1].height as usize;
     let max_back = total.saturating_sub(visible);
     let back = app.session_feed.scroll_back.min(max_back);
-    if let Some(id) = &app.focused_story {
+    if let Some(run) = app.operator_focused_run() {
+        render_run_focus(frame, app, run, chunks[1]);
+    } else if let Some(id) = &app.focused_story {
         render_focus(frame, app, id, chunks[1]);
     } else {
         let transcript = Paragraph::new(lines).wrap(Wrap { trim: false });
@@ -142,6 +144,89 @@ fn render_focus(frame: &mut Frame, app: &App, id: &str, area: ratatui::layout::R
     frame.render_widget(paragraph.scroll((offset as u16, 0)), body_area);
 }
 
+/// Operator drill-in: one delegated run over the transcript area — goal,
+/// stories with their state, the live activity line, recent milestones.
+fn render_run_focus(
+    frame: &mut Frame,
+    app: &App,
+    run: &crate::operator_client::OperatorRun,
+    area: ratatui::layout::Rect,
+) {
+    let mut lines: Vec<Line> = Vec::new();
+    let state = match run.state.as_str() {
+        "running" => format!("{} · {}", run.phase, run.elapsed_now()),
+        other => format!("{other} · {}", run.elapsed_now()),
+    };
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!("  ◉ {} ", run.id),
+            Style::default().fg(theme::ACCENT).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(state, Style::default().fg(theme::TEXT)),
+        Span::styled(
+            "   esc back · ctrl+o next run",
+            Style::default().fg(theme::MUTED),
+        ),
+    ]));
+    lines.push(Line::from(Span::styled(
+        format!("  {}", clip(&run.goal, area.width.saturating_sub(4) as usize)),
+        Style::default().fg(theme::TEXT_DIM),
+    )));
+    lines.push(Line::from(""));
+    if !run.stories.is_empty() {
+        for story in &run.stories {
+            let (glyph, color) = match story.status.as_str() {
+                "merged" => ("✔", theme::SUCCESS),
+                "done" => ("●", theme::SUCCESS),
+                "running" => ("◐", theme::ACCENT),
+                "suspended" => ("◌", theme::WARNING),
+                "failed" => ("✖", theme::ERROR),
+                _ => ("○", theme::MUTED),
+            };
+            lines.push(Line::from(vec![
+                Span::styled(format!("  {glyph} "), Style::default().fg(color)),
+                Span::styled(format!("{} ", story.id), Style::default().fg(theme::TEXT)),
+                Span::styled(story.title.clone(), Style::default().fg(theme::TEXT_DIM)),
+            ]));
+        }
+        lines.push(Line::from(""));
+    }
+    if let Some(activity) = &run.activity {
+        lines.push(Line::from(vec![
+            Span::styled("  now  ", Style::default().fg(theme::MUTED)),
+            Span::styled(activity.clone(), Style::default().fg(theme::TEXT)),
+        ]));
+    }
+    if let Some(error) = &run.error {
+        lines.push(Line::from(vec![
+            Span::styled("  error  ", Style::default().fg(theme::ERROR)),
+            Span::styled(error.clone(), Style::default().fg(theme::TEXT_DIM)),
+        ]));
+    }
+    if let Some(pr) = &run.pr_url {
+        lines.push(Line::from(vec![
+            Span::styled("  pr  ", Style::default().fg(theme::MUTED)),
+            Span::styled(pr.clone(), Style::default().fg(theme::ACCENT)),
+        ]));
+    }
+    if !run.milestones.is_empty() {
+        lines.push(Line::from(""));
+        for milestone in &run.milestones {
+            lines.push(Line::from(vec![
+                Span::styled("  · ", Style::default().fg(theme::MUTED)),
+                Span::styled(milestone.clone(), Style::default().fg(theme::TEXT_DIM)),
+            ]));
+        }
+    }
+    let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
+    let total = paragraph.line_count(area.width);
+    let visible = area.height as usize;
+    let max_back = total.saturating_sub(visible);
+    let back = app.focus_scroll_back.min(max_back);
+    let offset = max_back.saturating_sub(back);
+    frame.render_widget(paragraph.scroll((offset as u16, 0)), area);
+}
+
 fn header_line(app: &App) -> Paragraph<'static> {
     if let Some(operator) = &app.operator {
         let mut spans = vec![
@@ -165,7 +250,19 @@ fn header_line(app: &App) -> Paragraph<'static> {
             };
             let (label, color) = match run.state.as_str() {
                 "queued" => ("queued".to_string(), theme::MUTED),
-                "running" => (format!("{}{} · {}", run.phase, progress, run.elapsed_now()), theme::TEXT_DIM),
+                "running" => (
+                    match &run.activity {
+                        Some(activity) => format!(
+                            "{}{} · {} · {}",
+                            run.phase,
+                            progress,
+                            run.elapsed_now(),
+                            clip(activity, 40)
+                        ),
+                        None => format!("{}{} · {}", run.phase, progress, run.elapsed_now()),
+                    },
+                    theme::TEXT_DIM,
+                ),
                 "completed" => ("done".to_string(), theme::ACCENT),
                 other => (other.to_string(), theme::ERROR),
             };
@@ -1007,6 +1104,27 @@ fn footer_line(app: &App, scrolled_back: bool) -> Paragraph<'static> {
             Span::styled(" error: ", Style::default().fg(theme::ERROR)),
             Span::styled(clip(error, 120), Style::default().fg(theme::TEXT_DIM)),
         ]));
+    }
+    if let Some(operator) = &app.operator {
+        if !operator.runs.is_empty() && app.conversation_input.is_empty() {
+            let hint = |key: &str, what: &str| {
+                vec![
+                    Span::styled(format!(" {key}"), Style::default().fg(theme::ACCENT)),
+                    Span::styled(format!(" {what} "), Style::default().fg(theme::TEXT_DIM)),
+                ]
+            };
+            let mut spans = hint("enter", "send");
+            spans.extend(hint(
+                "ctrl+o",
+                if operator.focus.is_some() { "next run" } else { "run details" },
+            ));
+            if operator.focus.is_some() {
+                spans.extend(hint("esc", "back"));
+            }
+            spans.extend(hint("⇞⇟", "scroll"));
+            spans.extend(hint("ctrl+c ×2", "quit"));
+            return Paragraph::new(Line::from(spans));
+        }
     }
     if app.quit_armed_tick.is_some_and(|armed| app.tick_count.saturating_sub(armed) <= 20) {
         return Paragraph::new(Line::from(vec![

--- a/crates/baro-tui/src/screens/session.rs
+++ b/crates/baro-tui/src/screens/session.rs
@@ -393,7 +393,7 @@ fn turn_lines(
             // call line — bullet, bold name, dim arguments.
             if let Some(result) = turn.text.strip_prefix("⎿ ") {
                 lines.push(Line::from(vec![
-                    Span::styled("  ⎿  ".to_string(), Style::default().fg(theme::MUTED)),
+                    Span::styled("  └ ".to_string(), Style::default().fg(theme::MUTED)),
                     Span::styled(result.to_string(), Style::default().fg(theme::TEXT_DIM)),
                 ]));
                 return;
@@ -403,8 +403,11 @@ fn turn_lines(
                     Some(at) => (&call[..at], &call[at..]),
                     None => (call, ""),
                 };
+                // Narrow, unambiguous-width glyphs only: a bullet the terminal
+                // draws two cells wide shifts the line and leaves its tail
+                // behind on the next repaint.
                 lines.push(Line::from(vec![
-                    Span::styled("● ".to_string(), Style::default().fg(theme::SUCCESS)),
+                    Span::styled("• ".to_string(), Style::default().fg(theme::SUCCESS)),
                     Span::styled(
                         name.to_string(),
                         Style::default().fg(theme::TEXT).add_modifier(Modifier::BOLD),

--- a/docs/operator-protocol.md
+++ b/docs/operator-protocol.md
@@ -17,7 +17,7 @@ Every event carries `ts` (ISO 8601).
 | `tool_result` | `summary` | first meaningful line of what the last tool returned, with `(+N lines)` when there was more |
 | `ask` | `id`, `kind` (`permission` \| `quit`), `prompt`, `tool?`, `summary?`, `options` | a question only the person can answer; answer with `answer` |
 | `turn_done` | `duration_ms`, `cost_usd` (nullable) | the reply is complete |
-| `runs` | `runs[]`: `id`, `state`, `phase`, `completed`, `total`, `goal`, `elapsed`, `started_ms?`, `finished_ms?`, `pr_url?`, `activity?`, `stories[]` (`id`, `title`, `status`), `milestones[]` (last 20), `error?` | snapshot after anything about a run changed, at most once a second for activity; a surface with a clock derives elapsed from `started_ms` between snapshots |
+| `runs` | `runs[]`: `id`, `state`, `phase`, `completed`, `total`, `goal`, `elapsed`, `started_ms?`, `finished_ms?`, `pr_url?`, `activity?`, `stories[]` (`id`, `title`, `status`), `milestones[]` (last 20), `activity_tail[]` (last 40 live-feed lines with a clock, phase changes included), `error?` | snapshot after anything about a run changed, at most once a second for activity; a surface with a clock derives elapsed from `started_ms` between snapshots |
 | `exit` | | the operator is shutting down |
 
 `state` is `queued`, `running`, `completed`, `error`, `max-tokens` or `aborted`.

--- a/docs/operator-protocol.md
+++ b/docs/operator-protocol.md
@@ -17,7 +17,7 @@ Every event carries `ts` (ISO 8601).
 | `tool_result` | `summary` | first meaningful line of what the last tool returned, with `(+N lines)` when there was more |
 | `ask` | `id`, `kind` (`permission` \| `quit`), `prompt`, `tool?`, `summary?`, `options` | a question only the person can answer; answer with `answer` |
 | `turn_done` | `duration_ms`, `cost_usd` (nullable) | the reply is complete |
-| `runs` | `runs[]`: `id`, `state`, `phase`, `completed`, `total`, `goal`, `elapsed`, `started_ms?`, `finished_ms?`, `pr_url?` | snapshot after anything about a run changed; a surface with a clock derives elapsed from `started_ms` between snapshots |
+| `runs` | `runs[]`: `id`, `state`, `phase`, `completed`, `total`, `goal`, `elapsed`, `started_ms?`, `finished_ms?`, `pr_url?`, `activity?`, `stories[]` (`id`, `title`, `status`), `milestones[]` (last 20), `error?` | snapshot after anything about a run changed, at most once a second for activity; a surface with a clock derives elapsed from `started_ms` between snapshots |
 | `exit` | | the operator is shutting down |
 
 `state` is `queued`, `running`, `completed`, `error`, `max-tokens` or `aborted`.

--- a/packages/baro-orchestrator/src/operator/json-ui.ts
+++ b/packages/baro-orchestrator/src/operator/json-ui.ts
@@ -81,6 +81,7 @@ export class JsonUi implements OperatorUi {
                 ...(row.activity ? { activity: row.activity } : {}),
                 stories: row.stories,
                 milestones: row.milestones,
+                activity_tail: row.activityTail,
                 ...(row.error ? { error: row.error } : {}),
             })),
         })

--- a/packages/baro-orchestrator/src/operator/json-ui.ts
+++ b/packages/baro-orchestrator/src/operator/json-ui.ts
@@ -78,6 +78,10 @@ export class JsonUi implements OperatorUi {
                 ...(row.startedMs !== undefined ? { started_ms: row.startedMs } : {}),
                 ...(row.finishedMs !== undefined ? { finished_ms: row.finishedMs } : {}),
                 ...(row.prUrl ? { pr_url: row.prUrl } : {}),
+                ...(row.activity ? { activity: row.activity } : {}),
+                stories: row.stories,
+                milestones: row.milestones,
+                ...(row.error ? { error: row.error } : {}),
             })),
         })
     }

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -31,6 +31,7 @@ const AGENT_ID = "operator"
 const DIRECT_FILE_LIMIT = 10
 
 export async function runOperator(options: OperatorOptions, ui: OperatorUi): Promise<void> {
+    let activitySnapshot: ReturnType<typeof setTimeout> | null = null
     const registry = new RunRegistry({
         ...(options.baroArgs ? { baroArgs: options.baroArgs } : {}),
         onStarted: (run) => {
@@ -43,6 +44,15 @@ export async function runOperator(options: OperatorOptions, ui: OperatorUi): Pro
         onMilestone: (run, line) => {
             ui.note(`${run.id} · ${line}`)
             ui.runsChanged(registry.rows())
+        },
+        // Activity lines arrive many times a second; one snapshot a second is
+        // enough for a strip and a drill-in.
+        onActivity: () => {
+            if (activitySnapshot) return
+            activitySnapshot = setTimeout(() => {
+                activitySnapshot = null
+                ui.runsChanged(registry.rows())
+            }, 1_000)
         },
         onFinished: (run, outcome) => {
             ui.note(`${run.id} · finished (${run.terminal})`)

--- a/packages/baro-orchestrator/src/operator/run-registry.ts
+++ b/packages/baro-orchestrator/src/operator/run-registry.ts
@@ -44,6 +44,8 @@ export interface RunRegistryOptions {
     readonly baroBin?: string
     onStarted?(run: RunRecord, behind: RunRecord | null): void
     onMilestone?(run: RunRecord, line: string): void
+    /** The live feed moved (activity, story log); frequent, throttle it. */
+    onActivity?(run: RunRecord): void
     onFinished?(run: RunRecord, outcome: string): void
 }
 
@@ -142,6 +144,13 @@ export class RunRegistry {
                 startedMs: run.startedAt ?? undefined,
                 finishedMs: run.finishedAt ?? undefined,
                 prUrl: s.prUrl,
+                activity: s.activity,
+                stories: s.stories,
+                milestones: s.milestones.slice(-20),
+                error:
+                    run.terminal && run.terminal !== "completed"
+                        ? (s.abortReason ?? run.stderrTail.at(-1))
+                        : undefined,
             }
         })
     }
@@ -202,8 +211,10 @@ export class RunRegistry {
         createInterface({ input: child.stdout!, crlfDelay: Number.POSITIVE_INFINITY }).on("line", (line) => {
             const event = parseLine(line)
             if (!event) return
+            const before = record.tracker.summary().activity
             const milestone = record.tracker.accept(event)
             if (milestone) this.options.onMilestone?.(record, milestone)
+            else if (record.tracker.summary().activity !== before) this.options.onActivity?.(record)
         })
         createInterface({ input: child.stderr!, crlfDelay: Number.POSITIVE_INFINITY }).on("line", (line) => {
             record.stderrTail.push(line)

--- a/packages/baro-orchestrator/src/operator/run-registry.ts
+++ b/packages/baro-orchestrator/src/operator/run-registry.ts
@@ -147,6 +147,7 @@ export class RunRegistry {
                 activity: s.activity,
                 stories: s.stories,
                 milestones: s.milestones.slice(-20),
+                activityTail: s.activityTail,
                 error:
                     run.terminal && run.terminal !== "completed"
                         ? (s.abortReason ?? run.stderrTail.at(-1))

--- a/packages/baro-orchestrator/src/operator/run-tracker.ts
+++ b/packages/baro-orchestrator/src/operator/run-tracker.ts
@@ -48,6 +48,8 @@ export interface RunSummary {
     readonly activity: string | undefined
     readonly stories: readonly RunStory[]
     readonly abortReason: string | undefined
+    /** Recent live-feed lines with a clock, oldest first; phase changes included. */
+    readonly activityTail: readonly string[]
     readonly storiesTotal: number
     readonly completed: number
     readonly total: number
@@ -70,7 +72,14 @@ export class RunTracker {
     private done: BaroEvent | undefined
     private readonly milestones: string[] = []
     private readonly stories = new Map<string, RunStory>()
+    private readonly activityTail: string[] = []
     private revision = 0
+
+    private feed(text: string, ts?: unknown): void {
+        const clock = typeof ts === "string" ? ts.slice(11, 19) : new Date().toISOString().slice(11, 19)
+        this.activityTail.push(`${clock} ${text}`)
+        if (this.activityTail.length > 40) this.activityTail.shift()
+    }
 
     constructor(private readonly limit = 200) {}
 
@@ -95,6 +104,7 @@ export class RunTracker {
 
     /** Returns the milestone line when the event was one. */
     accept(event: BaroEvent): string | null {
+        const phaseBefore = this.phase
         switch (event.type) {
             case "architect_start":
                 this.setPhase("architect")
@@ -136,13 +146,13 @@ export class RunTracker {
             case "activity": {
                 const text = stringField(event, "text")
                 const id = stringField(event, "id")
-                if (text) this.setActivity(id && id !== "plan" ? `${id}: ${text}` : text)
+                if (text) this.setActivity(id && id !== "plan" ? `${id}: ${text}` : text, event.ts)
                 break
             }
             case "story_log": {
                 const line = stringField(event, "line")
                 const id = stringField(event, "id")
-                if (line) this.setActivity(id && id !== "plan" ? `${id}: ${line}` : line)
+                if (line) this.setActivity(id && id !== "plan" ? `${id}: ${line}` : line, event.ts)
                 break
             }
             case "progress": {
@@ -182,8 +192,10 @@ export class RunTracker {
                 this.setPhase("done")
                 break
         }
+        if (this.phase !== phaseBefore) this.feed(`phase: ${this.phase}`, event.ts)
         if (!isMilestone(event)) return null
         const line = describe(event)
+        this.feed(line, event.ts)
         this.milestones.push(line)
         if (this.milestones.length > this.limit) this.milestones.shift()
         this.revision += 1
@@ -197,6 +209,7 @@ export class RunTracker {
             activity: this.activity,
             stories: [...this.stories.values()],
             abortReason: this.done ? stringField(this.done, "abort_reason") : undefined,
+            activityTail: [...this.activityTail],
             storiesTotal: this.storiesTotal,
             completed: this.completed,
             total: this.total,
@@ -213,10 +226,11 @@ export class RunTracker {
         this.revision += 1
     }
 
-    private setActivity(text: string): void {
+    private setActivity(text: string, ts?: unknown): void {
         const next = text.length > ACTIVITY_LIMIT ? `${text.slice(0, ACTIVITY_LIMIT - 1)}…` : text
         if (this.activity === next) return
         this.activity = next
+        this.feed(next, ts)
         this.revision += 1
     }
 }

--- a/packages/baro-orchestrator/src/operator/run-tracker.ts
+++ b/packages/baro-orchestrator/src/operator/run-tracker.ts
@@ -34,10 +34,20 @@ export function resolveTerminal(
 
 export type Phase = "intake" | "architect" | "planning" | "executing" | "finalizing" | "done"
 
+export type StoryStatus = "pending" | "running" | "suspended" | "done" | "merged" | "failed"
+
+export interface RunStory {
+    readonly id: string
+    readonly title: string
+    readonly status: StoryStatus
+}
+
 export interface RunSummary {
     readonly project: string | undefined
     readonly phase: Phase
     readonly activity: string | undefined
+    readonly stories: readonly RunStory[]
+    readonly abortReason: string | undefined
     readonly storiesTotal: number
     readonly completed: number
     readonly total: number
@@ -59,9 +69,29 @@ export class RunTracker {
     private prUrl: string | undefined
     private done: BaroEvent | undefined
     private readonly milestones: string[] = []
+    private readonly stories = new Map<string, RunStory>()
     private revision = 0
 
     constructor(private readonly limit = 200) {}
+
+    private story(event: BaroEvent, status: StoryStatus): void {
+        const id = stringField(event, "id", "storyId", "story_id")
+        if (!id) return
+        const known = this.stories.get(id)
+        const title = stringField(event, "title") ?? known?.title ?? ""
+        this.stories.set(id, { id, title, status })
+        this.revision += 1
+    }
+
+    private rememberStories(list: unknown): void {
+        if (!Array.isArray(list)) return
+        for (const entry of list) {
+            if (typeof entry !== "object" || entry === null) continue
+            const id = stringField(entry as BaroEvent, "id")
+            if (!id || this.stories.has(id)) continue
+            this.stories.set(id, { id, title: stringField(entry as BaroEvent, "title") ?? "", status: "pending" })
+        }
+    }
 
     /** Returns the milestone line when the event was one. */
     accept(event: BaroEvent): string | null {
@@ -78,6 +108,7 @@ export class RunTracker {
                 break
             case "plan_fragment": {
                 this.setPhase("planning")
+                this.rememberStories(event.stories)
                 const stories = Array.isArray(event.stories) ? event.stories : []
                 this.storiesTotal += stories.length
                 const titles = stories
@@ -97,6 +128,7 @@ export class RunTracker {
                 break
             case "init":
                 this.project = stringField(event, "project")
+                this.rememberStories(event.stories)
                 this.storiesTotal =
                     (Array.isArray(event.stories) ? event.stories.length : 0) || this.storiesTotal
                 this.setPhase("executing")
@@ -120,6 +152,22 @@ export class RunTracker {
                 if (total !== undefined) this.total = total
                 break
             }
+            case "story_start":
+                this.story(event, "running")
+                break
+            case "story_suspended":
+                this.story(event, "suspended")
+                break
+            case "story_complete":
+                this.story(event, "done")
+                break
+            case "story_merged":
+                this.story(event, "merged")
+                break
+            case "merge_failed":
+            case "story_error":
+                this.story(event, "failed")
+                break
             case "finalize_start":
                 this.setPhase("finalizing")
                 break
@@ -147,6 +195,8 @@ export class RunTracker {
             project: this.project,
             phase: this.phase,
             activity: this.activity,
+            stories: [...this.stories.values()],
+            abortReason: this.done ? stringField(this.done, "abort_reason") : undefined,
             storiesTotal: this.storiesTotal,
             completed: this.completed,
             total: this.total,

--- a/packages/baro-orchestrator/src/operator/run-tracker.ts
+++ b/packages/baro-orchestrator/src/operator/run-tracker.ts
@@ -87,7 +87,10 @@ export class RunTracker {
         const id = stringField(event, "id", "storyId", "story_id")
         if (!id) return
         const known = this.stories.get(id)
-        const title = stringField(event, "title") ?? known?.title ?? ""
+        // story_start carries the id as its title (the lifecycle forwarder has
+        // no story text); the plan fragment already told us the real one.
+        const fromEvent = stringField(event, "title")
+        const title = fromEvent && fromEvent !== id ? fromEvent : (known?.title ?? "")
         this.stories.set(id, { id, title, status })
         this.revision += 1
     }
@@ -150,9 +153,10 @@ export class RunTracker {
                 break
             }
             case "story_log": {
+                // Raw lines: git output, relayed stdout fragments. Only the
+                // planner's own notes are prose worth a status line.
                 const line = stringField(event, "line")
-                const id = stringField(event, "id")
-                if (line) this.setActivity(id && id !== "plan" ? `${id}: ${line}` : line, event.ts)
+                if (line && stringField(event, "id") === "plan") this.setActivity(line, event.ts)
                 break
             }
             case "progress": {

--- a/packages/baro-orchestrator/src/operator/ui.ts
+++ b/packages/baro-orchestrator/src/operator/ui.ts
@@ -14,6 +14,11 @@ export interface RunRow {
     readonly startedMs: number | undefined
     readonly finishedMs: number | undefined
     readonly prUrl: string | undefined
+    readonly activity: string | undefined
+    readonly stories: readonly { id: string; title: string; status: string }[]
+    /** Last milestones, oldest first. */
+    readonly milestones: readonly string[]
+    readonly error: string | undefined
 }
 
 export interface AskMeta {

--- a/packages/baro-orchestrator/src/operator/ui.ts
+++ b/packages/baro-orchestrator/src/operator/ui.ts
@@ -18,6 +18,8 @@ export interface RunRow {
     readonly stories: readonly { id: string; title: string; status: string }[]
     /** Last milestones, oldest first. */
     readonly milestones: readonly string[]
+    /** Recent live-feed lines with a clock, oldest first. */
+    readonly activityTail: readonly string[]
     readonly error: string | undefined
 }
 

--- a/packages/baro-orchestrator/test/operator/run-tracker.test.ts
+++ b/packages/baro-orchestrator/test/operator/run-tracker.test.ts
@@ -91,4 +91,20 @@ describe("operator run tracker", () => {
         tracker.accept({ type: "finalize_start" })
         assert.equal(tracker.summary().phase, "finalizing")
     })
+
+    it("keeps each story's latest state for the drill-in", () => {
+        const tracker = new RunTracker()
+        tracker.accept({ type: "plan_fragment", stories: [{ id: "S1", title: "Core" }, { id: "S2", title: "CLI" }] })
+        tracker.accept({ type: "story_start", id: "S1", title: "Core" })
+        tracker.accept({ type: "story_start", id: "S2" })
+        tracker.accept({ type: "story_complete", id: "S1" })
+        tracker.accept({ type: "story_merged", id: "S1" })
+        tracker.accept({ type: "story_error", id: "S2", error: "boom" })
+        assert.deepEqual(
+            tracker.summary().stories.map((s) => [s.id, s.title, s.status]),
+            [["S1", "Core", "merged"], ["S2", "CLI", "failed"]],
+        )
+        tracker.accept({ type: "done", success: false, abort_reason: "verification failed: npm test" })
+        assert.equal(tracker.summary().abortReason, "verification failed: npm test")
+    })
 })

--- a/packages/baro-orchestrator/test/operator/run-tracker.test.ts
+++ b/packages/baro-orchestrator/test/operator/run-tracker.test.ts
@@ -95,8 +95,11 @@ describe("operator run tracker", () => {
     it("keeps each story's latest state for the drill-in", () => {
         const tracker = new RunTracker()
         tracker.accept({ type: "plan_fragment", stories: [{ id: "S1", title: "Core" }, { id: "S2", title: "CLI" }] })
-        tracker.accept({ type: "story_start", id: "S1", title: "Core" })
+        // The lifecycle forwarder sends the id as the title; the fragment's title wins.
+        tracker.accept({ type: "story_start", id: "S1", title: "S1" })
         tracker.accept({ type: "story_start", id: "S2" })
+        tracker.accept({ type: "story_log", id: "S2", line: "1I{" })
+        assert.notEqual(tracker.summary().activity, "S2: 1I{", "raw story_log lines are not status")
         tracker.accept({ type: "story_complete", id: "S1" })
         tracker.accept({ type: "story_merged", id: "S1" })
         tracker.accept({ type: "story_error", id: "S2", error: "boom" })


### PR DESCRIPTION
Follow-up to #131.

- `ctrl+o` in operator mode cycles the delegated runs; past the last one it returns to the chat, `esc` too. The pane over the transcript shows the goal, every story with its state (○ pending, ◐ running, ◌ suspended, ● done, ✔ merged, ✖ failed), the live activity line, the error or PR link when there is one, and the last twenty milestones. PageUp/PageDown and the wheel scroll it.
- The header strip carries each running run's last activity next to phase and elapsed.
- Protocol: the `runs` snapshot gains `activity`, `stories[]`, `milestones[]`, `error`, and is also sent on activity changes, throttled to once a second. The run tracker keeps each story's latest state from `plan_fragment` / `init` / `story_*` / `merge_failed`.

Tests: operator 13 (story states added), `cargo test -p baro-tui` 262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1bpAF6qY7wdqxL77pKxKE