### PR TITLE
verification: admit the 'cd <pkg> && <cmd>' declared-test form

### DIFF
--- a/packages/baro-orchestrator/src/verification/declared-verification.ts
+++ b/packages/baro-orchestrator/src/verification/declared-verification.ts
@@ -59,6 +59,10 @@ export function translateDeclaredTests(
         if (requirement.declarationError) {
             return incomplete(requirement, requirement.declarationError)
         }
+        const scoped = splitCdPrefix(requirement.command)
+        if (scoped) {
+            return translateCdScoped(cwd, requirement, scoped, packageManagers)
+        }
         const parsed = tokenize(requirement.command)
         if (typeof parsed === "string") return incomplete(requirement, parsed)
         return dispatchDeclared(
@@ -140,6 +144,95 @@ function dispatchDeclared(
         requirement,
         "unsupported declared test; allowed tools are npm/pnpm/yarn, exact npx rstest run paths, cargo, node, git diff --check, composer, vendor/bin/phpunit, and ddev exec",
     )
+}
+
+// The one compound form admitted, because agents naturally scope a command to
+// a package this way. The inner command still faces tokenize, so any further
+// shell syntax (a second '&&', ';', pipes) stays rejected.
+const CD_PREFIX = /^cd\s+([^\s&]+)\s*&&\s*([^]*)$/
+
+interface CdScoped {
+    readonly dir: string
+    readonly inner: string
+}
+
+function splitCdPrefix(command: unknown): CdScoped | null {
+    if (typeof command !== "string" || command.length > MAX_COMMAND_LENGTH) {
+        return null
+    }
+    const match = CD_PREFIX.exec(command.trim())
+    return match ? { dir: match[1]!, inner: match[2]! } : null
+}
+
+function translateCdScoped(
+    root: string,
+    requirement: DeclaredTestRequirement,
+    scoped: CdScoped,
+    packageManagers: readonly VerifyJavaScriptPackageManager[],
+): VerifyCommandSpec {
+    const dirTokens = tokenize(scoped.dir)
+    if (typeof dirTokens === "string") return incomplete(requirement, dirTokens)
+    const parsed = tokenize(scoped.inner)
+    if (typeof parsed === "string") return incomplete(requirement, parsed)
+    const dir = dirTokens.tokens[0]!
+    const contained = containedPath(root, dir, false)
+    let isDirectory = false
+    if (contained.path) {
+        try {
+            isDirectory = statSync(
+                realpathSync(resolve(root, contained.path)),
+            ).isDirectory()
+        } catch {
+            isDirectory = false
+        }
+    }
+    if (!contained.path || !isDirectory) {
+        return incomplete(
+            requirement,
+            `cd target '${dir}' must be an existing directory inside the repository`,
+        )
+    }
+    if (contained.path === ".") {
+        return dispatchDeclared(root, requirement, parsed, packageManagers, false)
+    }
+    const rel = contained.path
+    const scopeCwd = resolve(root, rel)
+    const scopedIncomplete = (reason: string): VerifyCommandSpec =>
+        incomplete(requirement, `cd ${rel}: ${reason}`)
+    const tool = parsed.tokens[0]
+    if (tool === "ddev" || tool === "npx") {
+        return scopedIncomplete(
+            `'${tool}' declarations cannot be scoped with cd; declare them from the repository root`,
+        )
+    }
+
+    // Package scripts go through the workspace selector so manager authority
+    // and script trust come from the package the command runs in, not root.
+    const alias = trustedScriptAlias(scopeCwd, parsed.tokens)
+    if (alias || /^(npm|pnpm|yarn)$/.test(tool ?? "")) {
+        const base = alias ? ["npm", "run", alias] : parsed.tokens
+        const [manager, operation, ...rest] = base
+        const tokens = operation === undefined
+            ? base
+            : [manager!, operation, `--workspace=${rel}`, ...rest]
+        const spec = translatePackage(
+            root,
+            requirement,
+            { normalized: tokens.join(" "), tokens },
+            packageManagers,
+        )
+        return spec.incompleteReason === undefined
+            ? spec
+            : scopedIncomplete(spec.incompleteReason)
+    }
+
+    const spec = tool === "node"
+        ? translateNode(scopeCwd, requirement, parsed, root)
+        : dispatchDeclared(scopeCwd, requirement, parsed, packageManagers, false)
+    if (spec.incompleteReason !== undefined) {
+        return scopedIncomplete(spec.incompleteReason)
+    }
+    return { ...spec, label: `cd ${rel} && ${spec.label}`, cwd: scopeCwd }
 }
 
 // Only a whole token wrapped in a matching quote pair is unwrapped, and the
@@ -889,6 +982,9 @@ function translateNode(
     cwd: string,
     requirement: DeclaredTestRequirement,
     parsed: DeclaredTokens,
+    // A cd-scoped node declaration must not dodge the root manifest check
+    // below by naming a subdirectory that happens to lack package.json.
+    manifestRoot: string = cwd,
 ): VerifyCommandSpec {
     // Only the literal two-token pair `--import tsx` is skipped over; any
     // other loader value, path or spelling falls through to the mode gate
@@ -908,7 +1004,8 @@ function translateNode(
         rest.length === 1 &&
         typeof mode === "string" &&
         !mode.startsWith("-") &&
-        !existsSync(join(cwd, "package.json"))
+        !existsSync(join(cwd, "package.json")) &&
+        !existsSync(join(manifestRoot, "package.json"))
     ) {
         const contained = containedPath(cwd, mode, true)
         if (!contained.path) {

--- a/packages/baro-orchestrator/test/verification/declared-verification.test.ts
+++ b/packages/baro-orchestrator/test/verification/declared-verification.test.ts
@@ -2132,6 +2132,152 @@ describe("declared verification policy", () => {
         })
     })
 
+    it("runs 'cd <dir> && <cmd>' as the allowlisted command with cwd=<dir>", async () => {
+        await withTempDir("baro-verify-declared-cd-", async (dir) => {
+            writeFileSync(
+                join(dir, "package.json"),
+                JSON.stringify({
+                    name: "root",
+                    private: true,
+                    workspaces: ["packages/*"],
+                }),
+            )
+            const workspace = join(dir, "packages", "app")
+            mkdirSync(join(workspace, "test"), { recursive: true })
+            writeFileSync(
+                join(workspace, "package.json"),
+                JSON.stringify({
+                    name: "@baro/app",
+                    scripts: { typecheck: "tsc --noEmit", test: "rstest run" },
+                }),
+            )
+            writeFileSync(join(workspace, "test", "a.test.ts"), "export {}\n")
+            const [node, script, focused, alias, dotRoot] = translateDeclaredTests(
+                dir,
+                [
+                    "cd packages/app && node --import tsx --test test/a.test.ts",
+                    "cd packages/app && npm run typecheck",
+                    "cd ./packages/app/ && npm test -- test/a.test.ts",
+                    "cd packages/app && tsc --noEmit",
+                    "cd . && git diff --check",
+                ].map((command) => ({ storyId: "S1", command })),
+                [{ manager: "npm" }, { manager: "npm", cwd: workspace }],
+            )
+
+            assert.equal(node?.incompleteReason, undefined)
+            assert.equal(node?.tool, "node")
+            assert.deepEqual(node?.args, [
+                "--import",
+                "tsx",
+                "--test",
+                "test/a.test.ts",
+            ])
+            assert.equal(node?.cwd, workspace)
+            assert.equal(
+                node?.label,
+                "cd packages/app && node --import tsx --test test/a.test.ts",
+            )
+            assert.deepEqual(node?.containedPaths, [
+                { path: "test/a.test.ts", requireFile: false },
+            ])
+
+            // A script alias resolves against the package's manifest and
+            // must run there, never at the root.
+            for (const spec of [script, alias]) {
+                assert.equal(spec?.incompleteReason, undefined)
+                assert.equal(spec?.tool, "npm")
+                assert.deepEqual(spec?.args, ["run", "typecheck"])
+                assert.equal(spec?.cwd, workspace)
+            }
+            assert.equal(focused?.incompleteReason, undefined)
+            assert.deepEqual(focused?.args, [
+                "run",
+                "test",
+                "--",
+                "test/a.test.ts",
+            ])
+            assert.equal(focused?.cwd, workspace)
+
+            assert.equal(dotRoot?.incompleteReason, undefined)
+            assert.equal(dotRoot?.label, "git diff --check")
+            assert.equal(dotRoot?.cwd, undefined)
+
+            const plan = createVerifyPlan(dir, {
+                declaredTests: [
+                    {
+                        storyId: "S1",
+                        command:
+                            "cd packages/app && node --import tsx --test test/a.test.ts",
+                    },
+                ],
+            })
+            const declared = plan.commands.filter(
+                (command) => command.origin === "declared",
+            )
+            assert.equal(declared.length, 1)
+            assert.equal(declared[0]?.incompleteReason, undefined)
+            assert.equal(declared[0]?.cwd, workspace)
+        })
+    })
+
+    it("keeps every other compound or escaping cd form fail-closed", async () => {
+        await withTempDir("baro-verify-declared-cd-reject-", async (base) => {
+            const dir = join(base, "repo")
+            const outside = join(base, "outside")
+            const workspace = join(dir, "packages", "app")
+            mkdirSync(workspace, { recursive: true })
+            mkdirSync(join(dir, "tools"), { recursive: true })
+            mkdirSync(outside, { recursive: true })
+            writeFileSync(
+                join(dir, "package.json"),
+                JSON.stringify({
+                    name: "root",
+                    private: true,
+                    workspaces: ["packages/*"],
+                }),
+            )
+            writeFileSync(
+                join(workspace, "package.json"),
+                JSON.stringify({
+                    name: "@baro/app",
+                    scripts: { test: "rstest run", release: "do-it" },
+                }),
+            )
+            writeFileSync(join(dir, "tools", "run.js"), "console.log('x')\n")
+            writeFileSync(join(outside, "run.js"), "console.log('x')\n")
+            symlinkSync(outside, join(dir, "packages", "link"))
+            const commands = [
+                "cd ../outside && npm test",
+                `cd ${outside} && node --check run.js`,
+                "cd packages/link && node --check run.js",
+                "cd missing && npm test",
+                "cd packages/app/package.json && npm test",
+                "cd -- && npm test",
+                "cd packages/app && cd . && npm test",
+                "cd packages/app; npm test",
+                "cd packages/app && npm test; touch x",
+                "cd packages/app a && npm test",
+                "cd packages/app &&",
+                "cd packages/app && npm run release",
+                "cd packages/app && npx rstest run a.test.ts",
+                "cd packages/app && ddev exec composer test",
+                "cd packages/app && node --test ../../tools/run.js",
+                "cd packages/app && bash -c true",
+                // The greenfield bare-node allowance is judged at the root.
+                "cd tools && node run.js",
+            ]
+            const specs = translateDeclaredTests(
+                dir,
+                commands.map((command) => ({ storyId: "S1", command })),
+                [{ manager: "npm" }, { manager: "npm", cwd: workspace }],
+            )
+            for (const [index, spec] of specs.entries()) {
+                assert.notEqual(spec.incompleteReason, undefined, commands[index])
+                assert.deepEqual(spec.args, [], commands[index])
+            }
+        })
+    })
+
     it("names the php-ecosystem routes in the catch-all message", async () => {
         await withTempDir("baro-verify-declared-catch-all-", async (dir) => {
             const [spec] = translateDeclaredTests(


### PR DESCRIPTION
Closes #109.

Exactly one `cd <dir> &&` prefix is admitted. The dir must be an existing directory inside the repository (symlinks resolved, no escaping via `..` or absolute paths). The inner command still faces `tokenize`, so a second `&&`, `;`, or a pipe is rejected as before.

- `npm` / `pnpm` / `yarn` and package scripts go through the workspace selector (`--workspace=<dir>`), so manager authority and script trust come from the scoped package, not the root.
- `node`, `cargo`, `composer`, `phpunit`, `git diff --check` run in that folder; the label keeps the `cd <dir> &&` prefix.
- `cd . && x` is treated as `x`.
- `npx` and `ddev` cannot be scoped.
- A scoped bare `node <file>` still faces the root manifest check, so `cd` into a folder without `package.json` does not dodge it.

Two tests added: the issue's example plus every admitted shape, and 17 shapes that must stay rejected. `declared-verification` + `verify` suites: 76/76.

Written by the baro operator in direct mode during the first self-hosting session (baro operating on its own repo); collected by hand because the same session's delegated run for #108 blocked on these files while they were uncommitted (that failure is being fixed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1bpAF6qY7wdqxL77pKxKE