### PR TITLE
integration: refuse a story merge the host checkout would block, and say so

### DIFF
--- a/packages/baro-orchestrator/src/integration/git-coordinator.ts
+++ b/packages/baro-orchestrator/src/integration/git-coordinator.ts
@@ -454,37 +454,45 @@ export class GitCoordinator extends SerializedObserver {
                 )
             } catch (e) {
                 const error = (e as Error)?.message ?? String(e)
+                const invariant =
+                    (e as { invariant?: IntegrationRefusalInvariant } | null)
+                        ?.invariant ?? "unknown"
                 let branch = worktrees.branchName(storyId)
                 let retryable = false
                 let preparationError: string | null = null
-                try {
-                    // Preserve the rejected attempt under a unique immutable
-                    // ref, then release the logical story ref. The Board may
-                    // now re-offer the story from the latest integrated HEAD.
-                    branch = await worktrees.prepareConflictRetry(storyId)
-                    retryable = true
-                } catch (prepareError) {
-                    preparationError =
-                        (prepareError as Error)?.message ?? String(prepareError)
-                    // A killed git process leaves the story's commit on its own
-                    // branch and the run branch untouched, so there is nothing
-                    // to preserve and nothing lost — the merge simply never
-                    // ran. Giving up here is what dropped an accepted story.
-                    retryable = isRepositoryCommandSignalDeath(e)
+                // A host checkout with uncommitted edits is the person's to
+                // clear; re-running the story would only meet the same wall,
+                // so the intact branch is kept and nothing is retried.
+                const blockedByHost = invariant === "host_checkout_dirty"
+                if (!blockedByHost) {
+                    try {
+                        // Preserve the rejected attempt under a unique immutable
+                        // ref, then release the logical story ref. The Board may
+                        // now re-offer the story from the latest integrated HEAD.
+                        branch = await worktrees.prepareConflictRetry(storyId)
+                        retryable = true
+                    } catch (prepareError) {
+                        preparationError =
+                            (prepareError as Error)?.message ?? String(prepareError)
+                        // A killed git process leaves the story's commit on its
+                        // own branch and the run branch untouched, so there is
+                        // nothing to preserve and nothing lost — the merge simply
+                        // never ran. Giving up here is what dropped an accepted
+                        // story.
+                        retryable = isRepositoryCommandSignalDeath(e)
+                    }
                 }
                 this.emitIntegrationRefused({
                     storyId,
                     runId: correlation?.runId ?? null,
                     leaseId: correlation?.leaseId ?? null,
-                    invariant:
-                        (e as { invariant?: IntegrationRefusalInvariant } | null)
-                            ?.invariant ?? "unknown",
+                    invariant,
                     detail: error,
                     branch,
                     retryable,
                     // Only a successful prepareConflictRetry mints an immutable
                     // recovery ref; otherwise `branch` is still the logical one.
-                    recoveryRef: preparationError ? null : branch,
+                    recoveryRef: preparationError || blockedByHost ? null : branch,
                 })
                 this.emitBus(
                     StoryMergeFailed.create({
@@ -500,7 +508,9 @@ export class GitCoordinator extends SerializedObserver {
                 log(
                     retryable
                         ? `[git] merge-back failed; attempt preserved at ${branch} and queued for recovery: ${error}`
-                        : `[git] merge-back failed; worktree preserved for manual recovery: ${error}`,
+                        : blockedByHost
+                          ? `[git] merge-back blocked by the host checkout; story kept on ${branch}: ${error}`
+                          : `[git] merge-back failed; worktree preserved for manual recovery: ${error}`,
                 )
                 if (emitTui) {
                     emit({ type: "push_status", id: storyId, success: false, error })

--- a/packages/baro-orchestrator/src/integration/worktree.ts
+++ b/packages/baro-orchestrator/src/integration/worktree.ts
@@ -22,6 +22,7 @@ import { join, resolve } from "path"
 
 import { GitGate } from "./git.js"
 import {
+    RepositoryCommandError,
     isRepositoryCommandTimeout,
     runRepositoryCommand as exec,
 } from "./repository-command.js"
@@ -76,6 +77,7 @@ export type IntegrationRefusalInvariant =
     | "sealed_merge_fingerprint"
     | "sealed_merge_dirty"
     | "merge_conflict"
+    | "host_checkout_dirty"
 
 export class WorktreeRefusalError extends Error {
     constructor(
@@ -779,6 +781,16 @@ export class WorktreeManager {
             const mergeTarget = candidateSeal
                 ? await this.sealedMergeTarget(storyId, path, candidateSeal)
                 : branch
+            const blocked = await this.hostCheckoutBlocks(mergeTarget)
+            if (blocked.length) {
+                this.markPreserved(storyId)
+                throw new WorktreeRefusalError(
+                    "host_checkout_dirty",
+                    `story ${storyId} cannot land: the host checkout has uncommitted changes on ` +
+                        `[${blocked.join(", ")}]; the story is intact on ${branch} — ` +
+                        `commit or stash those files, then merge it`,
+                )
+            }
             const msg = `baro: merge story ${storyId}`
             try {
                 await exec("git", ["merge", "--no-ff", "-m", msg, mergeTarget], {
@@ -804,9 +816,13 @@ export class WorktreeManager {
                 }
                 if (!this.resolveConflictsWithTheirs) {
                     this.markPreserved(storyId)
-                    throw new Error(
-                        `story ${storyId} conflicts with already-merged work` +
-                            (conflicts.length ? ` on [${conflicts.join(", ")}]` : ""),
+                    // No conflicted path means git refused for another reason;
+                    // calling that a conflict hides the reason git printed.
+                    throw new WorktreeRefusalError(
+                        "merge_conflict",
+                        conflicts.length
+                            ? `story ${storyId} conflicts with already-merged work on [${conflicts.join(", ")}]`
+                            : `story ${storyId} merge-back failed without a conflict: ${gitFailureDetail(error)}`,
                     )
                 }
                 this.log(
@@ -1402,6 +1418,27 @@ export class WorktreeManager {
         this.preserved.delete(storyId)
     }
 
+    /** Tracked paths dirty in the host checkout that the merge would also
+     * write. git refuses such a merge outright; reported as a conflict it
+     * sent two recoveries after the same wall on the first self-hosting run. */
+    private async hostCheckoutBlocks(mergeTarget: string): Promise<string[]> {
+        const [{ stdout: status }, { stdout: touched }] = await Promise.all([
+            exec("git", ["status", "--porcelain", "--untracked-files=no"], {
+                cwd: this.repoRoot,
+            }),
+            exec("git", ["diff", "--name-only", "HEAD", mergeTarget], {
+                cwd: this.repoRoot,
+            }),
+        ])
+        const dirty = new Set(
+            status.split("\n").filter(Boolean).map(porcelainPath),
+        )
+        return touched
+            .split("\n")
+            .map((line) => line.trim())
+            .filter((path) => path && dirty.has(path))
+    }
+
     private async conflictedPaths(): Promise<string[]> {
         try {
             const { stdout } = await exec(
@@ -1520,4 +1557,20 @@ function rmSyncQuiet(path: string): void {
 
 function errMsg(e: unknown): string {
     return (e as Error)?.message ?? String(e)
+}
+
+/** The first line git printed, when the failure came from git at all. */
+function gitFailureDetail(e: unknown): string {
+    if (e instanceof RepositoryCommandError) {
+        const line = e.stderr.split("\n").find((l) => l.trim())
+        if (line) return line.trim()
+    }
+    return errMsg(e)
+}
+
+/** `XY path` or `XY old -> new` from `git status --porcelain`. */
+function porcelainPath(line: string): string {
+    const entry = line.slice(3)
+    const renamed = entry.indexOf(" -> ")
+    return (renamed === -1 ? entry : entry.slice(renamed + 4)).trim()
 }

--- a/packages/baro-orchestrator/src/operator/operator-session.ts
+++ b/packages/baro-orchestrator/src/operator/operator-session.ts
@@ -1,3 +1,6 @@
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+
 import { AgenticEnvironment, BaseObserver } from "../runtime/mozaik.js"
 import type { FunctionCallOutputItem, Participant, SemanticEvent } from "../runtime/mozaik.js"
 import { AgentResult, ClaudeStreamChunk } from "../events/harness-stream.js"
@@ -24,11 +27,39 @@ export interface OperatorOptions {
 }
 
 const AGENT_ID = "operator"
+const execFileAsync = promisify(execFile)
 // Measured 9.9.2026: the operator built a four-file CLI with tests in under a
 // minute, while baro spent seven on intake and architect for three helpers.
 // Direct work is capped where it stops being one component; past that the
 // edit is refused with the remedy.
 const DIRECT_FILE_LIMIT = 10
+
+/** Tracked files with uncommitted changes; empty when `cwd` is not a git
+ * checkout, so a non-repository target is baro's to refuse, not ours. */
+async function uncommittedPaths(cwd: string): Promise<string[]> {
+    try {
+        const { stdout } = await execFileAsync(
+            "git",
+            ["status", "--porcelain", "--untracked-files=no"],
+            { cwd, encoding: "utf8" },
+        )
+        return stdout
+            .split("\n")
+            .filter(Boolean)
+            .map((line) => {
+                const entry = line.slice(3)
+                const renamed = entry.indexOf(" -> ")
+                return (renamed === -1 ? entry : entry.slice(renamed + 4)).trim()
+            })
+    } catch {
+        return []
+    }
+}
+
+function describePaths(paths: readonly string[]): string {
+    const shown = paths.slice(0, 5).join(", ")
+    return paths.length > 5 ? `${shown} and ${paths.length - 5} more` : shown
+}
 
 export async function runOperator(options: OperatorOptions, ui: OperatorUi): Promise<void> {
     let activitySnapshot: ReturnType<typeof setTimeout> | null = null
@@ -94,10 +125,19 @@ export async function runOperator(options: OperatorOptions, ui: OperatorUi): Pro
             invoke: async (args) => {
                 const { goal, cwd } = args as { goal?: unknown; cwd?: unknown }
                 if (typeof goal !== "string" || !goal.trim()) throw new Error("delegate requires a goal")
-                const { run, behind } = registry.delegate(
-                    goal.trim(),
-                    typeof cwd === "string" && cwd ? cwd : options.cwd,
-                )
+                const target = typeof cwd === "string" && cwd ? cwd : options.cwd
+                const dirty = await uncommittedPaths(target)
+                if (dirty.length) {
+                    ui.note(`delegate refused: ${dirty.length} uncommitted file(s) in ${target}`)
+                    return (
+                        `refused: ${target} has uncommitted changes to ${describePaths(dirty)}. ` +
+                        "baro merges each finished story into this checkout and cannot land one over uncommitted edits to the same files; " +
+                        "the first self-hosting run lost a story exactly this way. " +
+                        "Commit the changes (on a branch if they must not ride along with the run) or stash them, then delegate again. " +
+                        "Tell the user in one line what blocks and what you propose; do not commit or stash without their word."
+                    )
+                }
+                const { run, behind } = registry.delegate(goal.trim(), target)
                 ui.runsChanged(registry.rows())
                 if (behind) {
                     ui.note(`${run.id} · queued behind ${behind.id}: ${run.goal.slice(0, 80)}`)
@@ -436,7 +476,7 @@ function systemPrompt(cwd: string): string {
 Every request gets an altitude. Decide before you touch anything; reading a file or two to decide is fine. When the altitude is direct or delegate, say it in your FIRST line with a short reason, e.g. "direct — one component, eight files, tests exist." For an answer, never announce the altitude; just answer.
 - answer: questions, explanations, lookups. Reply directly, no preamble.
 - direct: one component you can finish in roughly ten minutes, clear intent, typically up to eight files. Do it yourself like a normal coding agent: edit, run the relevant tests, say what changed. Finish the whole thing in one turn; do not split a job to stay under a limit. Do not commit unless asked. Never push and never open a pull request yourself. The host refuses the eleventh file in one turn as a runaway-scope guard; if you hit it, delegate the rest.
-- delegate: work whose scope you cannot see to the end, changes across several modules or owned by different people, anything that needs independent review and a verified pull request, or anything the user asks to run through baro. baro has a fixed cost: intake, architect and goal contract take ten to fifteen minutes before the first story starts, whatever the size. So for a goal you could finish directly in a few minutes, say so and offer the choice in one line ("direct in ~3 min, or baro in ~15 with review and a PR?") instead of delegating by default. When you delegate, call \`delegate\` with a precise, self-contained goal (what, where, constraints, how to verify); baro's planner reads only that text. Warn first if the working tree has uncommitted changes the goal depends on: baro's agents work from the last commit. It returns at once with a run id and the run continues in the background. Do not poll in a loop. Tell the user the run id and one sentence on what to expect, then keep talking.
+- delegate: work whose scope you cannot see to the end, changes across several modules or owned by different people, anything that needs independent review and a verified pull request, or anything the user asks to run through baro. baro has a fixed cost: intake, architect and goal contract take ten to fifteen minutes before the first story starts, whatever the size. So for a goal you could finish directly in a few minutes, say so and offer the choice in one line ("direct in ~3 min, or baro in ~15 with review and a PR?") instead of delegating by default. When you delegate, call \`delegate\` with a precise, self-contained goal (what, where, constraints, how to verify); baro's planner reads only that text. \`delegate\` refuses while the working tree has uncommitted changes: baro's agents work from the last commit and baro merges finished stories into this very checkout, so uncommitted edits block a story from landing. Before delegating, get the tree clean with the user's word (commit, on a branch if the work must not ride along; or stash). While a run is active in this repository, do not edit files in the checkout; answer, plan, or delegate instead. It returns at once with a run id and the run continues in the background. Do not poll in a loop. Tell the user the run id and one sentence on what to expect, then keep talking.
 
 When asked what the agents are doing, call \`run_status\` (or \`runs\`) and summarize plainly: phase, stories done of total, last activity, recent milestones. When a run finishes you receive a message starting with [baro]; report the outcome and the pull request link if there is one. If the user overrides your altitude ("just do it yourself" / "send it to baro"), follow them.
 

--- a/packages/baro-orchestrator/test/integration/git-coordinator-integration-refused.test.ts
+++ b/packages/baro-orchestrator/test/integration/git-coordinator-integration-refused.test.ts
@@ -270,4 +270,45 @@ describe("GitCoordinator integration_refused", () => {
             )
         })
     })
+
+    it("does not queue a recovery when the host checkout blocked the merge", async () => {
+        await withTempDir("git-refused-host-dirty-", async (dir) => {
+            let prepared = 0
+            const worktrees = {
+                mergeBack: async () => {
+                    throw new WorktreeRefusalError(
+                        "host_checkout_dirty",
+                        "story S1 cannot land: the host checkout has uncommitted changes on [a.txt]",
+                    )
+                },
+                branchName: () => "baro-wt/run/S1",
+                prepareConflictRetry: async () => {
+                    prepared += 1
+                    return "baro-recovery/run/S1/1"
+                },
+                activePath: () => "/tmp/wt/S1",
+                recoveryRef: () => null,
+            } as unknown as WorktreeManager
+            const coordinator = coordinatorFor(dir, worktrees)
+            const env = joinWithCapture(coordinator)
+
+            requestIntegration(env)
+            await coordinator.idle()
+
+            assert.equal(prepared, 0, "the intact story branch is not released for a re-run")
+            const refused = env.events.filter(IntegrationRefused.is)
+            assert.equal(refused.length, 1)
+            assert.equal(refused[0]!.data.invariant, "host_checkout_dirty")
+            assert.equal(refused[0]!.data.retryable, false)
+            assert.equal(refused[0]!.data.branch, "baro-wt/run/S1")
+            assert.equal(refused[0]!.data.recoveryRef, null)
+            assert.equal(refused[0]!.data.worktreeRetained, true)
+
+            const failure = env.events.find(StoryMergeFailed.is)
+            assert.ok(failure)
+            assert.equal(failure.data.retryable, false)
+            assert.match(failure.data.error, /uncommitted changes on \[a\.txt\]/)
+            assert.doesNotMatch(failure.data.error, /recovery preparation failed/)
+        })
+    })
 })

--- a/packages/baro-orchestrator/test/integration/worktree.test.ts
+++ b/packages/baro-orchestrator/test/integration/worktree.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path"
 
 import { GitGate } from "../../src/integration/git.js"
 import { captureCriticRepositoryFingerprint } from "../../src/acceptance/critic-evidence.js"
-import { WorktreeManager } from "../../src/integration/worktree.js"
+import { WorktreeManager, WorktreeRefusalError } from "../../src/integration/worktree.js"
 import {
     removeWorktreeRun,
     uniqueRunId,
@@ -840,5 +840,38 @@ describe("WorktreeManager — fixture isolation", () => {
         for (const id of [first, second]) {
             assert.match(id, new RegExp(`^run-test-${process.pid}-[0-9a-f]{8}$`, "u"))
         }
+    })
+})
+
+describe("WorktreeManager — host checkout", () => {
+    it("refuses to land a story over uncommitted host edits to the same file, and names them", async () => {
+        const p1 = (await mgr.create("S1"))!
+        commitInWorktree(p1, "a.txt", "story\nline2\nline3\n")
+        // The person (or an operator in direct mode) edits the same file in
+        // the checkout without committing.
+        writeFileSync(join(repo, "a.txt"), "host\nline2\nline3\n")
+
+        await assert.rejects(
+            () => mgr.mergeBack("S1"),
+            (e: unknown) =>
+                e instanceof WorktreeRefusalError &&
+                e.invariant === "host_checkout_dirty" &&
+                /uncommitted changes on \[a\.txt\]/.test(e.message) &&
+                e.message.includes(`baro-wt/${runId}/S1`),
+        )
+
+        assert.equal(readFileSync(join(repo, "a.txt"), "utf8"), "host\nline2\nline3\n", "host edit untouched")
+        assert.equal(git(repo, "status", "--porcelain"), "M a.txt", "no merge left in progress")
+        assert.notEqual(git(repo, "branch", "--list", `baro-wt/${runId}/S1`), "", "story branch intact")
+    })
+
+    it("lands a story when the host's uncommitted edits are to other files", async () => {
+        const p1 = (await mgr.create("S1"))!
+        commitInWorktree(p1, "b.txt", "story\n")
+        writeFileSync(join(repo, "a.txt"), "host\nline2\nline3\n")
+
+        assert.equal(await mgr.mergeBack("S1"), true)
+        assert.equal(readFileSync(join(repo, "b.txt"), "utf8"), "story\n")
+        assert.equal(readFileSync(join(repo, "a.txt"), "utf8"), "host\nline2\nline3\n")
     })
 })


### PR DESCRIPTION
Found on the first self-hosting operator session (2026-09-11). The operator had uncommitted direct edits for #109 in the checkout and delegated #108; story S1 touched the same files. git refused the merge over the local changes, `mergeBack` called it `conflicts with already-merged work` (no paths), the coordinator queued a recovery that re-ran the whole story and hit the same wall. Two opus agents, one story lost, run closed 1/4. `git merge-tree` shows S1 merged cleanly onto the run branch: there never was a conflict.

Changes:
- `WorktreeManager.mergeBack`: before merging, intersect the host checkout's dirty tracked paths with the paths the story changes; if non-empty, throw `WorktreeRefusalError("host_checkout_dirty")` naming the files and the intact story branch. A merge that fails with no conflicted path now reports git's first stderr line instead of the conflict wording.
- `GitCoordinator`: for `host_checkout_dirty` no conflict retry is prepared; the story branch stays, `retryable: false`, `recoveryRef: null`, log line names the cause.
- Operator `delegate`: refuses while the target checkout has uncommitted tracked changes, tells the model to get the user's word on commit/stash first. System prompt: same rule, plus no editing the checkout while a run is active in it.

Tests: two new `WorktreeManager — host checkout` cases (blocked on the same file; lands when the dirty files differ), one new coordinator case (no `prepareConflictRetry`, non-retryable). Orchestrator suite 2268/2268.

The structural fix (a dedicated integration worktree so the run never shares a working tree with the person) is #137. The branch-naming bug seen on the same run is #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1bpAF6qY7wdqxL77pKxKE