### PR TITLE
tui: the operator never resumes a prd.json it finds in the checkout

### DIFF
--- a/crates/baro-tui/src/main.rs
+++ b/crates/baro-tui/src/main.rs
@@ -1248,7 +1248,9 @@ async fn run_app(
         std::env::set_var("BARO_CONTINUE", "1");
     }
     let mut entered_resume = false;
-    if prd_path.exists() {
+    // The operator has no run of its own to resume; a prd.json here belongs to
+    // a run it delegated (or one killed midway, whose branch may be gone).
+    if prd_path.exists() && !cli.operator {
         let initial = std::fs::read_to_string(&prd_path)
             .map_err(|error| error.to_string())
             .and_then(|contents| {


### PR DESCRIPTION
Seen right after 0.111.0: `baro operator --cwd ~/Desktop/baro-self` failed with `cannot establish resume branch: failed to checkout saved branch 'baro/goal-envelope-…'`. The delegated run killed earlier had left `prd.json` (gitignored) in the checkout with incomplete stories and a branch that had since been deleted; the operator entry shares `run_with_terminal` and hit the plain-run resume detection.

The operator has no run of its own to resume, so the detection is skipped when `cli.operator` is set. cargo test 262/262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1bpAF6qY7wdqxL77pKxKE